### PR TITLE
fix(i18n): format numbers and dates against the app language, not the host locale

### DIFF
--- a/packages/desktop/src/renderer/components/agent/ContextUsageIndicator.tsx
+++ b/packages/desktop/src/renderer/components/agent/ContextUsageIndicator.tsx
@@ -9,6 +9,7 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import type { TokenUsageCost, TokenUsageData } from '@/common/config/storage';
+import { formatCurrency, formatNumber } from '@/renderer/services/i18n/format';
 
 interface ContextUsageIndicatorProps {
   tokenUsage: TokenUsageData | null;
@@ -28,7 +29,8 @@ const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
   className = '',
   size = 20,
 }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language;
 
   const hasWindow = context_limit > 0;
 
@@ -47,7 +49,7 @@ const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
     if (!hasWindow) {
       return {
         percentage: 0,
-        displayTotal: formatTokenCount(total),
+        displayTotal: formatTokenCount(total, locale),
         displayLimit: '0',
         isWarning: false,
         isDanger: false,
@@ -58,12 +60,12 @@ const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
 
     return {
       percentage: pct,
-      displayTotal: formatTokenCount(total),
-      displayLimit: formatTokenCount(context_limit, true),
+      displayTotal: formatTokenCount(total, locale),
+      displayLimit: formatTokenCount(context_limit, locale, true),
       isWarning: pct > 70,
       isDanger: pct > 90,
     };
-  }, [tokenUsage, context_limit, hasWindow]);
+  }, [tokenUsage, context_limit, hasWindow, locale]);
 
   if (!tokenUsage) {
     return null;
@@ -92,27 +94,27 @@ const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
   if (breakdown) {
     if (typeof breakdown.input_tokens === 'number') {
       breakdownParts.push(
-        `${t('conversation.contextUsage.input', 'Input')} ${formatTokenCount(breakdown.input_tokens)}`
+        `${t('conversation.contextUsage.input', 'Input')} ${formatTokenCount(breakdown.input_tokens, locale)}`
       );
     }
     if (typeof breakdown.output_tokens === 'number') {
       breakdownParts.push(
-        `${t('conversation.contextUsage.output', 'Output')} ${formatTokenCount(breakdown.output_tokens)}`
+        `${t('conversation.contextUsage.output', 'Output')} ${formatTokenCount(breakdown.output_tokens, locale)}`
       );
     }
     if (breakdown.cached_read_tokens) {
       breakdownParts.push(
-        `${t('conversation.contextUsage.cachedRead', 'Cache read')} ${formatTokenCount(breakdown.cached_read_tokens)}`
+        `${t('conversation.contextUsage.cachedRead', 'Cache read')} ${formatTokenCount(breakdown.cached_read_tokens, locale)}`
       );
     }
     if (breakdown.cached_write_tokens) {
       breakdownParts.push(
-        `${t('conversation.contextUsage.cachedWrite', 'Cache write')} ${formatTokenCount(breakdown.cached_write_tokens)}`
+        `${t('conversation.contextUsage.cachedWrite', 'Cache write')} ${formatTokenCount(breakdown.cached_write_tokens, locale)}`
       );
     }
     if (breakdown.thought_tokens) {
       breakdownParts.push(
-        `${t('conversation.contextUsage.thought', 'Thinking')} ${formatTokenCount(breakdown.thought_tokens)}`
+        `${t('conversation.contextUsage.thought', 'Thinking')} ${formatTokenCount(breakdown.thought_tokens, locale)}`
       );
     }
   }
@@ -121,7 +123,7 @@ const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
     <>
       {tokenUsage.cost && (
         <div className='text-12px text-t-secondary mt-4px'>
-          {t('conversation.contextUsage.sessionCost', 'Session cost')} ≈ {formatCostAmount(tokenUsage.cost)}
+          {t('conversation.contextUsage.sessionCost', 'Session cost')} ≈ {formatCostAmount(tokenUsage.cost, locale)}
         </div>
       )}
       {breakdownParts.length > 0 && (
@@ -136,7 +138,7 @@ const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
   const popoverContent = hasWindow ? (
     <div className='p-8px min-w-160px'>
       <div className='text-14px font-medium text-t-primary'>
-        {percentage.toFixed(1)}% · {displayTotal} / {displayLimit}{' '}
+        {formatPercentage(percentage, locale)} · {displayTotal} / {displayLimit}{' '}
         {t('conversation.contextUsage.contextUsed', 'context used')}
       </div>
       {details}
@@ -191,39 +193,70 @@ const ContextUsageIndicator: React.FC<ContextUsageIndicatorProps> = ({
 };
 
 /**
- * Format an agent-reported cumulative session cost, e.g. "$0.42".
- * Falls back to "0.42 USD" when the currency code is not renderable.
+ * Smallest amount that four fraction digits can still render honestly. Below
+ * it, rounding to 4dp yields 0, and the currency's own minimum fraction digits
+ * (2 for USD) then print it as "$0.00".
  */
-export function formatCostAmount(cost: TokenUsageCost): string {
-  try {
-    return new Intl.NumberFormat(undefined, {
-      style: 'currency',
-      currency: cost.currency,
-      maximumFractionDigits: 4,
-    }).format(cost.amount);
-  } catch {
-    return `${cost.amount.toFixed(4)} ${cost.currency}`;
-  }
+const SUB_UNIT_PRECISION_FLOOR = 0.0001;
+
+/**
+ * Format an agent-reported cumulative session cost in the app language,
+ * e.g. "$0.42" (en-US) or "0,42 $" (de-DE).
+ *
+ * Four fraction digits suit an ordinary session cost, but a single cheap turn
+ * can bill fractions of a cent, and at that size `maximumFractionDigits: 4`
+ * rounds to zero and renders "$0.00" — indistinguishable from free. Amounts
+ * below the floor therefore switch to significant digits, which keeps the
+ * charge visible ("$0.00003") without turning "$1,234.5678" into "$1,200" the
+ * way significant digits would if applied across the whole range.
+ *
+ * Falls back to "0.4200 USD" when the currency code is not renderable.
+ */
+export function formatCostAmount(cost: TokenUsageCost, locale?: string): string {
+  const isVisibleAtFourDigits = cost.amount === 0 || Math.abs(cost.amount) >= SUB_UNIT_PRECISION_FLOOR;
+  const options: Intl.NumberFormatOptions = isVisibleAtFourDigits
+    ? { maximumFractionDigits: 4 }
+    : { maximumSignificantDigits: 2 };
+  return formatCurrency(cost.amount, cost.currency, locale, options);
 }
 
 /**
- * 格式化 token 数量显示
- * @param count token 数量
- * @param hideZeroDecimals 是否隐藏小数点为0的情况（如 1.0M 显示为 1M），默认为 false
- * @returns 格式化后的字符串，如 "37.0K" 或 "1.2M"，当 hideZeroDecimals 为 true 时 "1.0M" 显示为 "1M"
+ * Format the context-usage percentage in the app language, e.g. "4.8%" (en-US)
+ * or "4,8 %" (fr-FR).
  */
-export function formatTokenCount(count: number, hideZeroDecimals = false): string {
-  if (count >= 1_000_000) {
-    const value = count / 1_000_000;
-    const formatted = value.toFixed(1);
-    return hideZeroDecimals && formatted.endsWith('.0') ? `${Math.floor(value)}M` : `${formatted}M`;
-  }
-  if (count >= 1_000) {
-    const value = count / 1_000;
-    const formatted = value.toFixed(1);
-    return hideZeroDecimals && formatted.endsWith('.0') ? `${Math.floor(value)}K` : `${formatted}K`;
-  }
-  return count.toString();
+export function formatPercentage(value: number, locale?: string): string {
+  return formatNumber(value / 100, locale, {
+    style: 'percent',
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  });
+}
+
+/**
+ * Format a token count as a compact "12.6K" / "1.2M" string.
+ *
+ * The K/M suffixes stay as-is — `Intl` compact notation is unusable here
+ * (de-DE renders 12600 as "12.600", indistinguishable from a grouped integer) —
+ * but the decimal separator follows the app language, so the popover does not
+ * mix "0,42 $" with "12.6K".
+ *
+ * @param count token count
+ * @param locale app language (`i18n.language`)
+ * @param hideZeroDecimals drop a trailing zero decimal (1.0M → 1M), default false
+ */
+export function formatTokenCount(count: number, locale?: string, hideZeroDecimals = false): string {
+  const withSuffix = (value: number, suffix: string): string => {
+    // Keep the original rounding rule: a value that renders as "x.0" at one
+    // decimal collapses to the floored integer.
+    if (hideZeroDecimals && value.toFixed(1).endsWith('.0')) {
+      return `${formatNumber(Math.floor(value), locale, { maximumFractionDigits: 0 })}${suffix}`;
+    }
+    return `${formatNumber(value, locale, { minimumFractionDigits: 1, maximumFractionDigits: 1 })}${suffix}`;
+  };
+
+  if (count >= 1_000_000) return withSuffix(count / 1_000_000, 'M');
+  if (count >= 1_000) return withSuffix(count / 1_000, 'K');
+  return formatNumber(count, locale, { maximumFractionDigits: 0 });
 }
 
 export default ContextUsageIndicator;

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
@@ -21,6 +21,7 @@ import {
 } from '@icon-park/react';
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { formatDateTime } from '@/renderer/services/i18n/format';
 import AddModelModal from '@/renderer/pages/settings/components/AddModelModal';
 import AddPlatformModal from '@/renderer/pages/settings/components/AddPlatformModal';
 import { isNewApiPlatform, NEW_API_PROTOCOL_OPTIONS } from '@/renderer/utils/model/modelPlatforms';
@@ -106,7 +107,7 @@ const isModelEnabled = (platform: IProvider, model: string): boolean => {
 };
 
 const ModelModalContent: React.FC = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const viewMode = useSettingsViewMode();
   const isPageMode = viewMode === 'page';
   const [collapseKey, setCollapseKey] = useState<Record<string, boolean>>({});
@@ -544,7 +545,7 @@ const ModelModalContent: React.FC = () => {
                                       )}
                                       {model_health?.last_check && (
                                         <div className='text-12px mt-4px'>
-                                          {t('mcp.lastCheck')}: {new Date(model_health.last_check).toLocaleString()}
+                                          {t('mcp.lastCheck')}: {formatDateTime(model_health.last_check, i18n.language)}
                                         </div>
                                       )}
                                     </div>

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/WebuiModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/WebuiModalContent.tsx
@@ -23,6 +23,7 @@ import { Button, Form, Input, Message, Switch, Tabs, Tooltip } from '@arco-desig
 import { CheckOne, Communication, Copy, Earth, EditTwo, Refresh } from '@icon-park/react';
 import React, { Suspense, useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { formatTime } from '@/renderer/services/i18n/format';
 import { useSettingsViewMode } from '../settingsViewContext';
 
 /**
@@ -71,7 +72,7 @@ const DESKTOP_WEBUI_ALLOW_REMOTE_KEY = 'webui.desktop.allowRemote';
  * WebUI settings content component
  */
 const WebuiModalContent: React.FC = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const talkToButler = useTalkToButler();
   const viewMode = useSettingsViewMode();
   const isPageMode = viewMode === 'page';
@@ -536,8 +537,7 @@ const WebuiModalContent: React.FC = () => {
 
   // 格式化过期时间 / Format expiration time
   const formatExpiresAt = (timestamp: number) => {
-    const date = new Date(timestamp);
-    return date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+    return formatTime(timestamp, i18n.language, { hour: '2-digit', minute: '2-digit' });
   };
 
   // 获取实际密码 / Get actual password

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/DingTalkConfigForm.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/DingTalkConfigForm.tsx
@@ -10,6 +10,7 @@ import { isAionrsAssistant, type Assistant } from '@/common/types/agent/assistan
 import { resolveLocaleKey } from '@/common/utils';
 import { openExternalUrl } from '@/renderer/utils/platform';
 import { resolveAssistantName } from '@/renderer/utils/model/assistantDisplay';
+import { formatDateTime } from '@/renderer/services/i18n/format';
 import GoogleModelSelector from '@/renderer/pages/conversation/platforms/gemini/GoogleModelSelector';
 import type { GoogleModelSelection } from '@/renderer/pages/conversation/platforms/gemini/useGoogleModelSelection';
 import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
@@ -300,7 +301,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
 
   // Format timestamp
   const formatTime = (timestamp: number) => {
-    return new Date(timestamp).toLocaleString();
+    return formatDateTime(timestamp, i18n.language);
   };
 
   // Calculate remaining time

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/DiscordConfigForm.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/DiscordConfigForm.tsx
@@ -9,6 +9,7 @@ import { assistants, channel } from '@/common/adapter/ipcBridge';
 import { isAionrsAssistant, type Assistant } from '@/common/types/agent/assistantTypes';
 import { resolveLocaleKey } from '@/common/utils';
 import { resolveAssistantName } from '@/renderer/utils/model/assistantDisplay';
+import { formatDateTime } from '@/renderer/services/i18n/format';
 import GoogleModelSelector from '@/renderer/pages/conversation/platforms/gemini/GoogleModelSelector';
 import type { GoogleModelSelection } from '@/renderer/pages/conversation/platforms/gemini/useGoogleModelSelection';
 import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
@@ -297,7 +298,7 @@ const DiscordConfigForm: React.FC<DiscordConfigFormProps> = ({
 
   // Format timestamp
   const formatTime = (timestamp: number) => {
-    return new Date(timestamp).toLocaleString();
+    return formatDateTime(timestamp, i18n.language);
   };
 
   // Calculate remaining time

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/LarkConfigForm.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/LarkConfigForm.tsx
@@ -10,6 +10,7 @@ import { isAionrsAssistant, type Assistant } from '@/common/types/agent/assistan
 import { resolveLocaleKey } from '@/common/utils';
 import { openExternalUrl } from '@/renderer/utils/platform';
 import { resolveAssistantName } from '@/renderer/utils/model/assistantDisplay';
+import { formatDateTime } from '@/renderer/services/i18n/format';
 import GoogleModelSelector from '@/renderer/pages/conversation/platforms/gemini/GoogleModelSelector';
 import type { GoogleModelSelection } from '@/renderer/pages/conversation/platforms/gemini/useGoogleModelSelection';
 import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
@@ -311,7 +312,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
 
   // Format timestamp
   const formatTime = (timestamp: number) => {
-    return new Date(timestamp).toLocaleString();
+    return formatDateTime(timestamp, i18n.language);
   };
 
   // Calculate remaining time

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/SlackConfigForm.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/SlackConfigForm.tsx
@@ -9,6 +9,7 @@ import { assistants, channel } from '@/common/adapter/ipcBridge';
 import { isAionrsAssistant, type Assistant } from '@/common/types/agent/assistantTypes';
 import { resolveLocaleKey } from '@/common/utils';
 import { resolveAssistantName } from '@/renderer/utils/model/assistantDisplay';
+import { formatDateTime } from '@/renderer/services/i18n/format';
 import GoogleModelSelector from '@/renderer/pages/conversation/platforms/gemini/GoogleModelSelector';
 import type { GoogleModelSelection } from '@/renderer/pages/conversation/platforms/gemini/useGoogleModelSelection';
 import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
@@ -326,7 +327,7 @@ const SlackConfigForm: React.FC<SlackConfigFormProps> = ({
 
   // Format timestamp
   const formatTime = (timestamp: number) => {
-    return new Date(timestamp).toLocaleString();
+    return formatDateTime(timestamp, i18n.language);
   };
 
   // Calculate remaining time

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/TelegramConfigForm.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/TelegramConfigForm.tsx
@@ -9,6 +9,7 @@ import { assistants, channel } from '@/common/adapter/ipcBridge';
 import { isAionrsAssistant, type Assistant } from '@/common/types/agent/assistantTypes';
 import { resolveLocaleKey } from '@/common/utils';
 import { resolveAssistantName } from '@/renderer/utils/model/assistantDisplay';
+import { formatDateTime } from '@/renderer/services/i18n/format';
 import GoogleModelSelector from '@/renderer/pages/conversation/platforms/gemini/GoogleModelSelector';
 import type { GoogleModelSelection } from '@/renderer/pages/conversation/platforms/gemini/useGoogleModelSelection';
 import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
@@ -295,7 +296,7 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({
 
   // Format timestamp
   const formatTime = (timestamp: number) => {
-    return new Date(timestamp).toLocaleString();
+    return formatDateTime(timestamp, i18n.language);
   };
 
   // Calculate remaining time

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/WecomConfigForm.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/WecomConfigForm.tsx
@@ -10,6 +10,7 @@ import { isAionrsAssistant, type Assistant } from '@/common/types/agent/assistan
 import { resolveLocaleKey } from '@/common/utils';
 import { openExternalUrl } from '@/renderer/utils/platform';
 import { resolveAssistantName } from '@/renderer/utils/model/assistantDisplay';
+import { formatDateTime } from '@/renderer/services/i18n/format';
 import GoogleModelSelector from '@/renderer/pages/conversation/platforms/gemini/GoogleModelSelector';
 import type { GoogleModelSelection } from '@/renderer/pages/conversation/platforms/gemini/useGoogleModelSelection';
 import { Button, Dropdown, Empty, Input, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
@@ -274,7 +275,7 @@ const WecomConfigForm: React.FC<WecomConfigFormProps> = ({
 
   // Format timestamp
   const formatTime = (timestamp: number) => {
-    return new Date(timestamp).toLocaleString();
+    return formatDateTime(timestamp, i18n.language);
   };
 
   // Calculate remaining time

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/WeixinConfigForm.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/WeixinConfigForm.tsx
@@ -10,6 +10,7 @@ import { isAionrsAssistant, type Assistant } from '@/common/types/agent/assistan
 import { resolveLocaleKey } from '@/common/utils';
 import { getBaseUrl } from '@/common/adapter/httpBridge';
 import { resolveAssistantName } from '@/renderer/utils/model/assistantDisplay';
+import { formatDateTime } from '@/renderer/services/i18n/format';
 import GoogleModelSelector from '@/renderer/pages/conversation/platforms/gemini/GoogleModelSelector';
 import type { GoogleModelSelection } from '@/renderer/pages/conversation/platforms/gemini/useGoogleModelSelection';
 import { Button, Dropdown, Empty, Menu, Message, Spin, Tooltip } from '@arco-design/web-react';
@@ -59,8 +60,6 @@ const getRemainingTime = (expiresAt: number) => {
   const remaining = Math.max(0, Math.ceil((expiresAt - Date.now()) / 1000 / 60));
   return `${remaining} min`;
 };
-
-const formatTime = (timestamp: number) => new Date(timestamp).toLocaleString();
 
 const WeixinConfigForm: React.FC<WeixinConfigFormProps> = ({ pluginStatus, modelSelection, onStatusChange }) => {
   const { t, i18n } = useTranslation();
@@ -592,7 +591,8 @@ const WeixinConfigForm: React.FC<WeixinConfigFormProps> = ({ pluginStatus, model
                   <div className='flex-1'>
                     <div className='text-14px font-500 text-t-primary'>{user.display_name || 'Unknown User'}</div>
                     <div className='text-12px text-t-tertiary mt-4px'>
-                      {t('settings.assistant.authorizedAt', 'Authorized')}: {formatTime(user.authorizedAt)}
+                      {t('settings.assistant.authorizedAt', 'Authorized')}:{' '}
+                      {formatDateTime(user.authorizedAt, i18n.language)}
                     </div>
                   </div>
                   <Tooltip content={t('settings.assistant.revokeAccess', 'Revoke access')}>

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.tsx
@@ -8,6 +8,7 @@ import { ipcBridge } from '@/common';
 import type { IMessageSearchItem } from '@/common/types/team/database';
 import AionModal from '@/renderer/components/base/AionModal';
 import { AionSearchInput } from '@/renderer/components/base';
+import { formatDateTime } from '@/renderer/services/i18n/format';
 import { usePresetAssistantInfo } from '@/renderer/hooks/agent/usePresetAssistantInfo';
 import { useAgentLogos } from '@/renderer/utils/model/agentLogo';
 import { resolveConversationLeadingMark } from '@/renderer/pages/conversation/utils/conversationAssistantIdentity';
@@ -80,14 +81,14 @@ const renderHighlightedText = (text: string, keyword: string) => {
   });
 };
 
-const formatTime = (timestamp: number): string => {
+const formatTime = (timestamp: number, locale: string): string => {
   if (!timestamp) return '';
-  return new Intl.DateTimeFormat(undefined, {
+  return formatDateTime(timestamp, locale, {
     month: '2-digit',
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
-  }).format(timestamp);
+  });
 };
 
 interface ConversationSearchPopoverProps {
@@ -137,7 +138,7 @@ const ConversationSearchPopover: React.FC<ConversationSearchPopoverProps> = ({
   fullWidth = false,
   renderTrigger,
 }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const [visible, setVisible] = useState(false);
   const [keyword, setKeyword] = useState('');
@@ -402,7 +403,9 @@ const ConversationSearchPopover: React.FC<ConversationSearchPopoverProps> = ({
                       </div>
                     </div>
                   </div>
-                  <span className='shrink-0 text-11px text-t-secondary'>{formatTime(item.message_created_at)}</span>
+                  <span className='shrink-0 text-11px text-t-secondary'>
+                    {formatTime(item.message_created_at, i18n.language)}
+                  </span>
                 </div>
                 <div className='conversation-search-modal__snippet text-13px leading-22px text-t-primary/92 break-words'>
                   {renderHighlightedText(snippet, debouncedKeyword)}

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageCronBadge.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageCronBadge.tsx
@@ -5,6 +5,7 @@
  */
 
 import type { CronMessageMeta } from '@/common/chat/chatLib';
+import { formatDateTime } from '@/renderer/services/i18n/format';
 import { iconColors } from '@/renderer/styles/colors';
 import { AlarmClock } from '@icon-park/react';
 import React from 'react';
@@ -15,7 +16,7 @@ type MessageCronBadgeProps = {
 };
 
 const formatTime = (timestamp: number, locale: string): string => {
-  return new Date(timestamp).toLocaleString(locale, {
+  return formatDateTime(timestamp, locale, {
     month: 'short',
     day: 'numeric',
     hour: '2-digit',

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
@@ -35,7 +35,7 @@ const resolveTeamId = (conversation: TChatConversation): string | undefined => {
 };
 
 const TaskDetailPage: React.FC = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const { job_id } = useParams<{ job_id: string }>();
   const [job, setJob] = useState<ICronJob | null>(null);
@@ -389,7 +389,7 @@ const TaskDetailPage: React.FC = () => {
             )}
             {job.state.next_run_at_ms && (
               <span className='text-14px text-t-secondary'>
-                {t('cron.nextRun')} {formatNextRun(job.state.next_run_at_ms)}
+                {t('cron.nextRun')} {formatNextRun(job.state.next_run_at_ms, i18n.language)}
               </span>
             )}
           </div>
@@ -470,7 +470,7 @@ const TaskDetailPage: React.FC = () => {
                         )}
                         <span className='min-w-0 flex-1 truncate text-14px text-t-primary'>{conv.name || conv.id}</span>
                         <span className='shrink-0 text-13px text-t-secondary'>
-                          {formatNextRun(getActivityTime(conv))}
+                          {formatNextRun(getActivityTime(conv), i18n.language)}
                         </span>
                       </div>
                       {index < conversations.length - 1 && <div className='h-1px w-full bg-[var(--color-border-2)]' />}
@@ -482,7 +482,7 @@ const TaskDetailPage: React.FC = () => {
                   <span>{t('cron.detail.noHistory')}</span>
                   {job.enabled && job.state.next_run_at_ms && (
                     <span className='ml-4px'>
-                      · {t('cron.nextRun')} {formatNextRun(job.state.next_run_at_ms)}
+                      · {t('cron.nextRun')} {formatNextRun(job.state.next_run_at_ms, i18n.language)}
                     </span>
                   )}
                 </div>

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/index.tsx
@@ -27,7 +27,7 @@ import { Attention, Robot } from '@icon-park/react';
 const ScheduledTasksPage: React.FC = () => {
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const navigate = useNavigate();
   const { jobs, loading, pauseJob, resumeJob } = useAllCronJobs();
   const { presetAssistants } = useConversationAssistants();
@@ -206,7 +206,7 @@ const ScheduledTasksPage: React.FC = () => {
                   job.target.execution_mode === 'new_conversation'
                     ? t('cron.page.form.newConversation')
                     : t('cron.page.form.existingConversation');
-                const nextRun = job.state.next_run_at_ms ? formatNextRun(job.state.next_run_at_ms) : '-';
+                const nextRun = job.state.next_run_at_ms ? formatNextRun(job.state.next_run_at_ms, i18n.language) : '-';
                 const errorHint = job.state.last_error
                   ? `${t('cron.lastError')}：${job.state.last_error}`
                   : t('cron.status.error');

--- a/packages/desktop/src/renderer/pages/cron/cronUtils.ts
+++ b/packages/desktop/src/renderer/pages/cron/cronUtils.ts
@@ -6,6 +6,7 @@
 
 import type { ICronJob } from '@/common/adapter/ipcBridge';
 import type { TChatConversation } from '@/common/config/storage';
+import { formatDateTime } from '@/renderer/services/i18n/format';
 import type { TFunction } from 'i18next';
 
 const WEEKDAY_LABEL_KEY_BY_VALUE: Record<string, string> = {
@@ -96,12 +97,13 @@ export function createCronSchedule(expr: string, description: string): Extract<I
 }
 
 /**
- * Format next run time for display
+ * Format next run time for display, in the app language.
+ *
+ * @param locale app language (`i18n.language`)
  */
-export function formatNextRun(next_run_at_ms?: number): string {
+export function formatNextRun(next_run_at_ms: number | undefined, locale?: string): string {
   if (!next_run_at_ms) return '-';
-  const date = new Date(next_run_at_ms);
-  return date.toLocaleString();
+  return formatDateTime(next_run_at_ms, locale);
 }
 
 function formatTwoDigit(value: number): string {

--- a/packages/desktop/src/renderer/pages/settings/SkillsSettings/SkillsHubSettings.tsx
+++ b/packages/desktop/src/renderer/pages/settings/SkillsSettings/SkillsHubSettings.tsx
@@ -12,6 +12,7 @@ import SettingsPageWrapper from '../components/SettingsPageWrapper';
 import SettingsPageHeader from '../components/SettingsPageHeader';
 import TalkToButlerButton from '@/renderer/components/base/TalkToButlerButton';
 import { AionSearchInput } from '@/renderer/components/base';
+import { formatDateTime } from '@/renderer/services/i18n/format';
 import { buildSkillImportNotice, getSkillImportErrorMessage } from './skillImportMessages';
 
 // Skill 信息类型 / Skill info type
@@ -138,7 +139,7 @@ const getSkillsTabFromState = (state: unknown): SkillsTab => {
 };
 
 const SkillsHubSettings: React.FC<SkillsHubSettingsProps> = ({ withWrapper = true }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const layout = useLayoutContext();
   const isMobile = layout?.isMobile ?? false;
   const location = useLocation();
@@ -622,7 +623,7 @@ const SkillsHubSettings: React.FC<SkillsHubSettingsProps> = ({ withWrapper = tru
                           </span>
                         </div>
                         <div className='mt-5px flex flex-wrap gap-x-8px gap-y-2px text-12px text-t-tertiary'>
-                          <span>{new Date(group.createdAt).toLocaleString()}</span>
+                          <span>{formatDateTime(group.createdAt, i18n.language)}</span>
                           {importedNames && <span>{importedNames}</span>}
                         </div>
                       </div>

--- a/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpServerHeader.tsx
+++ b/packages/desktop/src/renderer/pages/settings/ToolsSettings/McpServerHeader.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import type { McpOAuthStatus } from '@/renderer/hooks/mcp/useMcpOAuth';
 import FeedbackButton from '@/renderer/components/base/FeedbackButton';
 import { iconColors } from '@/renderer/styles/colors';
+import { formatDateTime } from '@/renderer/services/i18n/format';
 
 interface McpServerHeaderProps {
   server: IMcpServer;
@@ -48,16 +49,17 @@ const getStatusIcon = (
   return <Info theme='outline' fill={iconColors.secondary} className='h-[24px]' />;
 };
 
-const formatStatusTimestamp = (timestamp?: number): string | null => {
+const formatStatusTimestamp = (timestamp: number | undefined, locale: string): string | null => {
   if (!timestamp) {
     return null;
   }
 
-  return new Date(timestamp).toLocaleString();
+  return formatDateTime(timestamp, locale);
 };
 
 const getStatusPopoverContent = (
   server: IMcpServer,
+  locale: string,
   t?: (key: string, options?: Record<string, unknown>) => string
 ) => {
   if (server.last_test_status !== 'error' && server.last_test_status !== 'connected') {
@@ -65,7 +67,7 @@ const getStatusPopoverContent = (
   }
 
   if (server.last_test_status === 'connected') {
-    const checkedAt = formatStatusTimestamp(server.last_connected || server.updated_at);
+    const checkedAt = formatStatusTimestamp(server.last_connected || server.updated_at, locale);
     return (
       <div className='max-w-300px space-y-2 text-13px leading-20px'>
         <div className='font-medium text-t-primary'>
@@ -82,7 +84,7 @@ const getStatusPopoverContent = (
     );
   }
 
-  const checkedAt = formatStatusTimestamp(server.updated_at);
+  const checkedAt = formatStatusTimestamp(server.updated_at, locale);
 
   const reasonText =
     server.builtin && server.name === 'chrome-devtools' && server.transport.type === 'stdio'
@@ -153,13 +155,13 @@ const McpServerHeader: React.FC<McpServerHeaderProps> = ({
   onDeleteServer,
   onOAuthLogin,
 }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const oauthCapable = supportsOAuth(server);
   const needsLogin = oauthCapable && oauthStatus?.needsLogin;
   const statusText = getStatusText(server, server.last_test_status, oauthStatus, isTestingConnection, t);
   const statusIcon = getStatusIcon(server.last_test_status, oauthStatus, isTestingConnection);
-  const statusPopoverContent = getStatusPopoverContent(server, t);
+  const statusPopoverContent = getStatusPopoverContent(server, i18n.language, t);
 
   const isError = server.last_test_status === 'error';
 

--- a/packages/desktop/src/renderer/services/i18n/format.ts
+++ b/packages/desktop/src/renderer/services/i18n/format.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Locale-aware display formatting for numbers, currencies and dates.
+ *
+ * `Intl.NumberFormat(undefined, …)`, `Intl.DateTimeFormat(undefined, …)` and the
+ * bare `toLocaleString()` / `toLocaleDateString()` / `toLocaleTimeString()` family
+ * all resolve to the *host OS* locale, which has nothing to do with the language
+ * the user picked inside AionUi. A German desktop running AionUi in English used
+ * to render `0,42 $` and `17.8.2025` next to English labels, and the same app on
+ * a `zh-HK` desktop rendered a locale AionUi does not even ship.
+ *
+ * Every user-visible number or date must therefore be formatted against the app
+ * language, passed in explicitly from `useTranslation().i18n.language`. Reading
+ * the i18next singleton in here instead would be invisible to React and would
+ * leave already-rendered numbers stale after a language switch.
+ *
+ * Import this module directly (`@/renderer/services/i18n/format`) rather than
+ * through `@/renderer/services/i18n`, whose index bootstraps i18next on load.
+ */
+
+import { DEFAULT_LANGUAGE, normalizeLanguageCode, type SupportedLanguage } from '@/common/config/i18n';
+
+/** Option set that reproduces `Date.prototype.toLocaleString()` defaults. */
+const DATE_TIME_DEFAULTS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+};
+
+/**
+ * Reduce any language hint to a locale AionUi actually ships, so formatting is
+ * deterministic and never depends on the host OS.
+ */
+export function resolveFormatLocale(language?: string | null): SupportedLanguage {
+  if (!language || !language.trim()) return DEFAULT_LANGUAGE;
+  return normalizeLanguageCode(language);
+}
+
+// `Intl.*Format` construction is expensive relative to `format()`, and these run
+// inside list renders. Cache one instance per (locale, options) pair.
+const numberFormatCache = new Map<string, Intl.NumberFormat>();
+const dateTimeFormatCache = new Map<string, Intl.DateTimeFormat>();
+
+function getNumberFormat(locale: SupportedLanguage, options?: Intl.NumberFormatOptions): Intl.NumberFormat {
+  const key = `${locale}|${JSON.stringify(options ?? {})}`;
+  let formatter = numberFormatCache.get(key);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale, options);
+    numberFormatCache.set(key, formatter);
+  }
+  return formatter;
+}
+
+function getDateTimeFormat(locale: SupportedLanguage, options?: Intl.DateTimeFormatOptions): Intl.DateTimeFormat {
+  const key = `${locale}|${JSON.stringify(options ?? {})}`;
+  let formatter = dateTimeFormatCache.get(key);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat(locale, options);
+    dateTimeFormatCache.set(key, formatter);
+  }
+  return formatter;
+}
+
+/**
+ * Format a plain number in the app language, e.g. `12.6` → `12,6` in de-DE.
+ */
+export function formatNumber(value: number, language?: string | null, options?: Intl.NumberFormatOptions): string {
+  return getNumberFormat(resolveFormatLocale(language), options).format(value);
+}
+
+/**
+ * Format a monetary amount in the app language.
+ *
+ * Falls back to `<number> <code>` when the currency code is not renderable —
+ * `Intl.NumberFormat` throws a RangeError on codes that are not well-formed.
+ */
+export function formatCurrency(
+  amount: number,
+  currency: string,
+  language?: string | null,
+  options?: Intl.NumberFormatOptions
+): string {
+  const locale = resolveFormatLocale(language);
+  try {
+    return getNumberFormat(locale, { style: 'currency', currency, ...options }).format(amount);
+  } catch {
+    // Mirror the requested precision: significant digits win over fraction
+    // digits in Intl, so a caller asking for them must not silently get the
+    // fraction-digit fallback, which would round a sub-cent amount to zero.
+    const digits = options?.maximumFractionDigits ?? 4;
+    const fallbackOptions: Intl.NumberFormatOptions =
+      options?.maximumSignificantDigits != null
+        ? { maximumSignificantDigits: options.maximumSignificantDigits }
+        : { minimumFractionDigits: digits, maximumFractionDigits: digits };
+    return `${getNumberFormat(locale, fallbackOptions).format(amount)} ${currency}`;
+  }
+}
+
+/**
+ * Format a timestamp (or `Date`) in the app language.
+ *
+ * With no `options` this reproduces `toLocaleString()`'s numeric date + time.
+ */
+export function formatDateTime(
+  value: number | Date,
+  language?: string | null,
+  options?: Intl.DateTimeFormatOptions
+): string {
+  return getDateTimeFormat(resolveFormatLocale(language), options ?? DATE_TIME_DEFAULTS).format(value);
+}
+
+/**
+ * Format the date part only — the `toLocaleDateString()` replacement.
+ */
+export function formatDate(
+  value: number | Date,
+  language?: string | null,
+  options?: Intl.DateTimeFormatOptions
+): string {
+  return formatDateTime(value, language, options ?? { year: 'numeric', month: 'numeric', day: 'numeric' });
+}
+
+/**
+ * Format the time part only — the `toLocaleTimeString()` replacement.
+ */
+export function formatTime(
+  value: number | Date,
+  language?: string | null,
+  options?: Intl.DateTimeFormatOptions
+): string {
+  return formatDateTime(value, language, options ?? { hour: 'numeric', minute: 'numeric', second: 'numeric' });
+}

--- a/tests/unit/renderer/ContextUsageIndicator.dom.test.tsx
+++ b/tests/unit/renderer/ContextUsageIndicator.dom.test.tsx
@@ -5,8 +5,13 @@
  */
 
 import { render } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import React from 'react';
+
+// The component formats numbers against the app language, so the tests drive
+// the locale from here — never from the host OS, which would make the decimal
+// separator depend on whichever machine runs the suite.
+let mockLanguage = 'en-US';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -15,6 +20,7 @@ vi.mock('react-i18next', () => ({
       if (!options) return text;
       return Object.entries(options).reduce((acc, [name, value]) => acc.replaceAll(`{{${name}}}`, String(value)), text);
     },
+    i18n: { language: mockLanguage },
   }),
 }));
 
@@ -27,9 +33,16 @@ vi.mock('@arco-design/web-react', () => ({
   ),
 }));
 
-import ContextUsageIndicator, { formatTokenCount } from '@/renderer/components/agent/ContextUsageIndicator';
+import ContextUsageIndicator, {
+  formatCostAmount,
+  formatTokenCount,
+} from '@/renderer/components/agent/ContextUsageIndicator';
 
 describe('ContextUsageIndicator', () => {
+  beforeEach(() => {
+    mockLanguage = 'en-US';
+  });
+
   it('renders a progress ring and a percentage popover when the window size is known', () => {
     const { container, getByTestId } = render(
       <ContextUsageIndicator tokenUsage={{ total_tokens: 12_600 }} context_limit={262_144} />
@@ -83,12 +96,37 @@ describe('ContextUsageIndicator', () => {
 
     const popover = getByTestId('popover-content').textContent ?? '';
     expect(popover).toContain('Session cost');
-    expect(popover).toContain('0.42');
+    expect(popover).toContain('$0.42');
     expect(popover).toContain('Input 14.1K');
     expect(popover).toContain('Output 30');
     expect(popover).toContain('Cache read 14.1K');
     // Zero-valued optional counters are noise, not information.
     expect(popover).not.toContain('Thinking');
+  });
+
+  it('formats cost, percentage and token counts in the app language, not the host locale', () => {
+    mockLanguage = 'de-DE';
+    const { getByTestId } = render(
+      <ContextUsageIndicator
+        tokenUsage={{
+          total_tokens: 14_118,
+          cost: { amount: 0.42, currency: 'USD' },
+          breakdown: { input_tokens: 14_088 },
+        }}
+        context_limit={1_000_000}
+      />
+    );
+
+    const popover = getByTestId('popover-content').textContent ?? '';
+    // German writes the decimal separator as a comma and puts the currency
+    // symbol last — for every number in the popover, not just the cost.
+    expect(popover).toContain('0,42\u00a0$');
+    expect(popover).toContain('1,4\u00a0%');
+    expect(popover).toContain('14,1K');
+    expect(popover).toContain('Input 14,1K');
+    // The separators must not be mixed within one popover.
+    expect(popover).not.toContain('14.1K');
+    expect(popover).not.toContain('$0.42');
   });
 
   it('omits cost and breakdown lines when the agent reported neither', () => {
@@ -104,8 +142,54 @@ describe('ContextUsageIndicator', () => {
 
 describe('formatTokenCount', () => {
   it('formats thousands and millions', () => {
-    expect(formatTokenCount(999)).toBe('999');
-    expect(formatTokenCount(12_600)).toBe('12.6K');
-    expect(formatTokenCount(1_000_000, true)).toBe('1M');
+    expect(formatTokenCount(999, 'en-US')).toBe('999');
+    expect(formatTokenCount(12_600, 'en-US')).toBe('12.6K');
+    expect(formatTokenCount(1_000_000, 'en-US', true)).toBe('1M');
+  });
+
+  it('keeps the K/M suffix but localises the decimal separator', () => {
+    // Intl compact notation is not usable here: de-DE renders 12600 as
+    // "12.600", which reads as a grouped integer rather than a compact one.
+    expect(formatTokenCount(12_600, 'de-DE')).toBe('12,6K');
+    expect(formatTokenCount(262_144, 'fr-FR')).toBe('262,1K');
+    expect(formatTokenCount(1_000_000, 'de-DE', true)).toBe('1M');
+  });
+
+  it('collapses a trailing zero decimal exactly as before', () => {
+    // 1.04M renders as "1.0M" at one decimal, so it collapses to "1M".
+    expect(formatTokenCount(1_040_000, 'en-US', true)).toBe('1M');
+    expect(formatTokenCount(1_040_000, 'en-US')).toBe('1.0M');
+  });
+});
+
+describe('formatCostAmount', () => {
+  it('formats in the given app language', () => {
+    expect(formatCostAmount({ amount: 0.42, currency: 'USD' }, 'en-US')).toBe('$0.42');
+    expect(formatCostAmount({ amount: 0.42, currency: 'USD' }, 'de-DE')).toBe('0,42\u00a0$');
+  });
+
+  it('keeps four fraction digits for ordinary amounts', () => {
+    expect(formatCostAmount({ amount: 0, currency: 'USD' }, 'en-US')).toBe('$0.00');
+    expect(formatCostAmount({ amount: 0.0001, currency: 'USD' }, 'en-US')).toBe('$0.0001');
+    expect(formatCostAmount({ amount: 1.2345, currency: 'USD' }, 'en-US')).toBe('$1.2345');
+    expect(formatCostAmount({ amount: 12.3, currency: 'USD' }, 'en-US')).toBe('$12.30');
+    // Significant digits applied across the whole range would render this as
+    // "$1,200"; large amounts must keep their fraction digits.
+    expect(formatCostAmount({ amount: 1234.5678, currency: 'USD' }, 'en-US')).toBe('$1,234.5678');
+  });
+
+  it('does not round a sub-cent charge down to "$0.00"', () => {
+    // A single cheap turn bills fractions of a cent. Four fraction digits round
+    // these to zero, which reads as free.
+    expect(formatCostAmount({ amount: 0.00003, currency: 'USD' }, 'en-US')).toBe('$0.00003');
+    expect(formatCostAmount({ amount: 0.000012, currency: 'USD' }, 'en-US')).toBe('$0.000012');
+    expect(formatCostAmount({ amount: 0.00003, currency: 'USD' }, 'de-DE')).toBe('0,00003\u00a0$');
+  });
+
+  it('falls back to "<amount> <code>" for a currency code Intl cannot render', () => {
+    expect(formatCostAmount({ amount: 0.42, currency: 'US' }, 'en-US')).toBe('0.4200 US');
+    // The fallback must honour significant digits too, or it reintroduces the
+    // "$0.00" rounding it was meant to avoid.
+    expect(formatCostAmount({ amount: 0.00003, currency: 'US' }, 'en-US')).toBe('0.00003 US');
   });
 });

--- a/tests/unit/renderer/cron/TaskDetailPage.dom.test.tsx
+++ b/tests/unit/renderer/cron/TaskDetailPage.dom.test.tsx
@@ -26,6 +26,9 @@ const { useCronJobConversationsMock } = vi.hoisted(() => ({
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
+    // The page formats next-run timestamps against the app language, so the
+    // mock has to expose `i18n` the way the real hook does.
+    i18n: { language: 'en-US' },
   }),
 }));
 

--- a/tests/unit/renderer/i18nFormat.test.ts
+++ b/tests/unit/renderer/i18nFormat.test.ts
@@ -1,0 +1,94 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatCurrency,
+  formatDate,
+  formatDateTime,
+  formatNumber,
+  formatTime,
+  resolveFormatLocale,
+} from '@/renderer/services/i18n/format';
+
+// A fixed instant so the assertions below are not clock-dependent:
+// 2025-08-17T11:06:40Z.
+const INSTANT = Date.UTC(2025, 7, 17, 11, 6, 40);
+
+describe('resolveFormatLocale', () => {
+  it('passes through a supported language tag', () => {
+    expect(resolveFormatLocale('de-DE')).toBe('de-DE');
+    expect(resolveFormatLocale('zh-CN')).toBe('zh-CN');
+  });
+
+  it('narrows an unsupported regional tag to the supported base language', () => {
+    // The host OS locale is routinely something AionUi does not ship.
+    expect(resolveFormatLocale('zh-HK')).toBe('zh-CN');
+    expect(resolveFormatLocale('de_AT')).toBe('de-DE');
+  });
+
+  it('falls back to the default language for unknown or empty input', () => {
+    expect(resolveFormatLocale('kl-GL')).toBe('en-US');
+    expect(resolveFormatLocale('')).toBe('en-US');
+    expect(resolveFormatLocale(undefined)).toBe('en-US');
+    expect(resolveFormatLocale(null)).toBe('en-US');
+  });
+});
+
+describe('formatNumber', () => {
+  it('uses the decimal separator of the app language, not the host locale', () => {
+    expect(formatNumber(12.6, 'en-US', { minimumFractionDigits: 1 })).toBe('12.6');
+    expect(formatNumber(12.6, 'de-DE', { minimumFractionDigits: 1 })).toBe('12,6');
+    expect(formatNumber(12.6, 'fr-FR', { minimumFractionDigits: 1 })).toBe('12,6');
+  });
+
+  it('groups thousands per language', () => {
+    expect(formatNumber(1234567, 'en-US')).toBe('1,234,567');
+    expect(formatNumber(1234567, 'de-DE')).toBe('1.234.567');
+  });
+});
+
+describe('formatCurrency', () => {
+  it('renders the amount in the app language', () => {
+    expect(formatCurrency(0.42, 'USD', 'en-US', { maximumFractionDigits: 4 })).toBe('$0.42');
+    // de-DE separates the amount from the symbol with a non-breaking space.
+    expect(formatCurrency(0.42, 'USD', 'de-DE', { maximumFractionDigits: 4 })).toBe('0,42\u00a0$');
+  });
+
+  it('keeps sub-cent precision up to four fraction digits', () => {
+    expect(formatCurrency(1.2345, 'USD', 'en-US', { maximumFractionDigits: 4 })).toBe('$1.2345');
+  });
+
+  it('falls back to "<amount> <code>" when the currency code is not renderable', () => {
+    // A two-letter code is not a well-formed ISO 4217 currency, so
+    // Intl.NumberFormat throws rather than rendering it.
+    expect(formatCurrency(0.42, 'US', 'en-US', { maximumFractionDigits: 4 })).toBe('0.4200 US');
+    expect(formatCurrency(0.42, 'US', 'de-DE', { maximumFractionDigits: 4 })).toBe('0,4200 US');
+  });
+});
+
+describe('formatDateTime / formatDate / formatTime', () => {
+  it('formats a timestamp in the app language', () => {
+    const en = formatDateTime(INSTANT, 'en-US', { year: 'numeric', month: 'numeric', day: 'numeric', timeZone: 'UTC' });
+    const de = formatDateTime(INSTANT, 'de-DE', { year: 'numeric', month: 'numeric', day: 'numeric', timeZone: 'UTC' });
+    expect(en).toBe('8/17/2025');
+    expect(de).toBe('17.8.2025');
+  });
+
+  it('reproduces toLocaleString() defaults when no options are given', () => {
+    const date = new Date(INSTANT);
+    expect(formatDateTime(INSTANT, 'de-DE')).toBe(date.toLocaleString('de-DE'));
+    expect(formatDate(INSTANT, 'de-DE')).toBe(date.toLocaleDateString('de-DE'));
+    expect(formatTime(INSTANT, 'de-DE')).toBe(date.toLocaleTimeString('de-DE'));
+  });
+
+  it('ignores the host locale entirely', () => {
+    // Whatever the runner's locale is, an explicit language wins.
+    const zh = formatDateTime(INSTANT, 'zh-CN', { year: 'numeric', month: 'numeric', day: 'numeric', timeZone: 'UTC' });
+    expect(zh).toBe('2025/8/17');
+  });
+});


### PR DESCRIPTION
## Description

`Intl.NumberFormat(undefined, …)`, `Intl.DateTimeFormat(undefined, …)` and the bare `toLocaleString()` / `toLocaleDateString()` / `toLocaleTimeString()` family all resolve to the **host OS locale**, which is unrelated to the language the user selected inside AionUi.

Consequences today:

- A German desktop running AionUi in English renders the session cost as `0,42 $` and timestamps as `17.8.2025`, next to English labels.
- A `zh-HK` desktop (verified: `Intl.NumberFormat().resolvedOptions().locale` → `zh-HK`) formats against a locale AionUi does not even ship.
- The same build renders differently on two machines with identical app settings, which also makes any assertion on those strings host-dependent.

This PR routes every user-visible number and date through a shared locale-aware module, with the locale passed explicitly from `i18n.language`. That is the pattern `MessageCronBadge` already used; this generalises it.

### Locale-aware formatting

- New `packages/desktop/src/renderer/services/i18n/format.ts` — `resolveFormatLocale`, `formatNumber`, `formatCurrency`, `formatDateTime`, `formatDate`, `formatTime`. Language hints are normalised through the app's own `normalizeLanguageCode`, so the set of supported locales stays owned by `i18n-config.json` rather than being duplicated here. `Intl` instances are cached per `(locale, options)` pair because several call sites run inside list renders.
- `ContextUsageIndicator` — session cost, context percentage and token counts now all follow the app language. Token counts keep their `K`/`M` suffixes: `Intl` compact notation is unusable here because de-DE renders `12600` as `"12.600"`, which reads as a grouped integer. Previously the popover mixed a hardcoded `.` from `toFixed(1)` with a host-localised currency.
- `ConversationSearchPopover`, `MessageCronBadge`, `McpServerHeader`, `SkillsHubSettings`, `ModelModalContent`, `WebuiModalContent`, cron `formatNextRun` (and its callers in `ScheduledTasksPage` / `TaskDetailPage`), and the seven channel config forms (Telegram, Slack, Discord, DingTalk, Lark, Wecom, Weixin) all thread `i18n.language` through.
- `ApiKeyManager` is deliberately left alone — it formats a log line, not UI. `getCurrentCronTimeZone` is also untouched: it reads the host time zone, which is correct.

### Sub-cent session costs no longer render as "$0.00"

`maximumFractionDigits: 4` rounds anything below `0.0001` to zero, and USD's own `minimumFractionDigits` of `2` then prints `$0.00` — indistinguishable from free, for a turn that really was billed:

| amount | before | after |
|---|---|---|
| `0.000012` | `$0.00` ❌ | `$0.000012` |
| `0.00003` | `$0.00` ❌ | `$0.00003` |
| `0.0004` | `$0.0004` | `$0.0004` |
| `0.42` | `$0.42` | `$0.42` |
| `12.3` | `$12.30` | `$12.30` |
| `1234.5678` | `$1,234.5678` | `$1,234.5678` |

Amounts below the floor switch to `maximumSignificantDigits: 2`. Applying significant digits across the whole range is not an option — it renders `$1,234.5678` as `$1,200` and `$12.30` as `$12` — hence the threshold. The unrenderable-currency fallback in `formatCurrency` honours significant digits too, so it cannot reintroduce the same rounding.

## Related Issues

Supersedes #4044, which identified the same symptom but pinned `formatCostAmount` to `'en-US'`. That makes output deterministic at the cost of being wrong for every non-English UI — a German user would see `$0.42` where German writes `0,42 $` — and it only covered the cost string, leaving the percentage and token counts on a hardcoded `.` separator. The determinism that PR wanted belongs in the test (drive the locale from a mocked `i18n.language`), not in production formatting.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (909 pre-existing warnings, 0 errors)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 455 files passed, 4105 tests passed, 1 file / 5 tests skipped
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — no new strings; only the formatting of existing values changed
- [x] `prek run --from-ref origin/main --to-ref HEAD` — all hooks pass

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

Not yet exercised in a running app — the behaviour is covered by unit tests that assert de-DE / fr-FR / zh-CN output directly, but a reviewer switching the app language and opening the context-usage popover would be a useful confirmation.

## Additional Context

Scope is the desktop renderer only. The `mobile/` package has the same bug class at three call sites and is intentionally out of scope here.
