### PR TITLE
feat(i18n): right-to-left layout for Persian (fa-IR)

### DIFF
--- a/packages/desktop/src/renderer/components/Markdown/CodeBlock.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/CodeBlock.tsx
@@ -123,6 +123,8 @@ function CodeBlock(props: CodeBlockProps) {
   return (
     <div
       ref={containerRef}
+      // Code is inherently left-to-right; keep it that way under an RTL document.
+      dir='ltr'
       style={{ width: '100%', minWidth: 0, maxWidth: '100%', ...props.codeStyle }}
       className='group'
     >

--- a/packages/desktop/src/renderer/components/agent/AgentModeSelector.tsx
+++ b/packages/desktop/src/renderer/components/agent/AgentModeSelector.tsx
@@ -360,12 +360,12 @@ const AgentModeSelector: React.FC<AgentModeSelectorProps> = ({
 
   // If mode switching is not supported, just render the content without dropdown
   if (!can_switchMode) {
-    return <div className='ml-16px'>{content}</div>;
+    return <div className='ms-16px'>{content}</div>;
   }
 
   // Render dropdown with mode selection menu
   return (
-    <div className='ml-16px'>
+    <div className='ms-16px'>
       <Dropdown
         trigger='click'
         popupVisible={dropdownVisible}

--- a/packages/desktop/src/renderer/components/agent/MarqueePillLabel.tsx
+++ b/packages/desktop/src/renderer/components/agent/MarqueePillLabel.tsx
@@ -110,8 +110,8 @@ const MarqueePillLabel: React.FC<{
         ref={marqueeRef}
         className={
           active
-            ? 'whitespace-nowrap leading-none absolute left-0 top-0'
-            : 'invisible whitespace-nowrap leading-none absolute left-0 top-0'
+            ? 'whitespace-nowrap leading-none absolute start-0 top-0'
+            : 'invisible whitespace-nowrap leading-none absolute start-0 top-0'
         }
       >
         {children}

--- a/packages/desktop/src/renderer/components/base/AionCollapse.tsx
+++ b/packages/desktop/src/renderer/components/base/AionCollapse.tsx
@@ -193,7 +193,7 @@ const AionCollapseComponent: React.FC<AionCollapseProps> & { Item: typeof AionCo
             <div
               onClick={() => handleToggle(name, disabled)}
               className={classNames(
-                'flex items-center gap-3 text-left transition-colors py-5px cursor-pointer',
+                'flex items-center gap-3 text-start transition-colors py-5px cursor-pointer',
                 headerClassName
               )}
             >

--- a/packages/desktop/src/renderer/components/base/FileChangesPanel.tsx
+++ b/packages/desktop/src/renderer/components/base/FileChangesPanel.tsx
@@ -184,7 +184,7 @@ const FileChangesPanel: React.FC<FileChangesPanelProps> = ({
                 )}
                 {/* 预览按钮 - 点击打开文件预览 / Preview button - click to open file preview */}
                 <span
-                  className='group-hover:opacity-100 transition-opacity shrink-0 ml-4px flex items-center gap-4px text-12px text-t-secondary cursor-pointer rd-4px px-4px py-2px hover:bg-4'
+                  className='group-hover:opacity-100 transition-opacity shrink-0 ms-4px flex items-center gap-4px text-12px text-t-secondary cursor-pointer rd-4px px-4px py-2px hover:bg-4'
                   onClick={(e) => {
                     e.stopPropagation();
                     onFileClick?.(file);

--- a/packages/desktop/src/renderer/components/chat/CollapsibleContent.tsx
+++ b/packages/desktop/src/renderer/components/chat/CollapsibleContent.tsx
@@ -199,7 +199,7 @@ export const CollapsibleContent: React.FC<CollapsibleContentProps> = ({
           - 100%: 完全不透明，融入背景色 Fully opaque, blends with background */}
       {!useMask && needsCollapse && isCollapsed && (
         <div
-          className='absolute bottom-0 left-0 right-0 pointer-events-none'
+          className='absolute bottom-0 start-0 end-0 pointer-events-none'
           style={{
             height: '80px',
             background: bgGradient,

--- a/packages/desktop/src/renderer/components/chat/CommandQueuePanel.tsx
+++ b/packages/desktop/src/renderer/components/chat/CommandQueuePanel.tsx
@@ -194,7 +194,7 @@ const QueueItemCard: React.FC<QueueItemCardProps> = ({
         touchAction: dragViaCard && !dragDisabled ? 'none' : undefined,
       }}
     >
-      <div className='flex items-center gap-6px min-w-0 flex-1 relative pl-8px'>
+      <div className='flex items-center gap-6px min-w-0 flex-1 relative ps-8px'>
         <div className='flex items-center gap-5px w-18px shrink-0 relative'>
           <button
             {...restDragHandleButtonProps}

--- a/packages/desktop/src/renderer/components/chat/MobileActionSheet/MobileActionSheet.module.css
+++ b/packages/desktop/src/renderer/components/chat/MobileActionSheet/MobileActionSheet.module.css
@@ -15,8 +15,8 @@
 
 .sheet {
   position: fixed;
-  left: 0;
-  right: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
   bottom: 0;
   max-height: min(72vh, 560px);
   background: var(--color-bg-1, #ffffff);
@@ -214,7 +214,7 @@
   text-align: center;
   font-size: 14px;
   font-weight: 600;
-  margin-right: 56px;
+  margin-inline-end: 56px;
 }
 
 .radio {
@@ -223,7 +223,7 @@
   border-radius: 50%;
   border: 1.5px solid var(--color-border-3, #c9cdd4);
   flex-shrink: 0;
-  margin-left: auto;
+  margin-inline-start: auto;
 }
 
 .radio.checked {
@@ -240,7 +240,7 @@
   border-radius: 4px;
   border: 1.5px solid var(--color-border-3, #c9cdd4);
   flex-shrink: 0;
-  margin-left: auto;
+  margin-inline-start: auto;
   position: relative;
 }
 
@@ -252,7 +252,7 @@
 .checkbox.checkboxChecked::after {
   content: '';
   position: absolute;
-  left: 5px;
+  inset-inline-start: 5px;
   top: 2px;
   width: 4px;
   height: 8px;

--- a/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
+++ b/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
@@ -1604,7 +1604,7 @@ const SendBox: React.FC<{
         // caller's z-index, e.g. z-10, which is how the box's surface covers
         // ThoughtDisplay's tucked band) — z-3 here only needs to beat the
         // panel's own untouched content, not re-fight that outer stacking.
-        <div className='absolute right-12px top--28px z-3 pointer-events-auto'>{topRightOverlay}</div>
+        <div className='absolute end-12px top--28px z-3 pointer-events-auto'>{topRightOverlay}</div>
       )}
       <div
         ref={containerRef}
@@ -1635,7 +1635,7 @@ const SendBox: React.FC<{
           question={btwCommand.question}
         />
         {isAtFileMenuOpen && (
-          <div className='absolute left-12px right-12px bottom-[calc(100%+8px)] z-70'>
+          <div className='absolute start-12px end-12px bottom-[calc(100%+8px)] z-70'>
             <AtFileMenu
               activeIndex={atFileMenuActiveIndex}
               emptyText={
@@ -1663,7 +1663,7 @@ const SendBox: React.FC<{
           </div>
         )}
         {isCommandMenuOpen && (
-          <div className='absolute left-12px right-12px bottom-[calc(100%+8px)] z-70'>
+          <div className='absolute start-12px end-12px bottom-[calc(100%+8px)] z-70'>
             {conversationExport.step === 'menu' ? (
               <SlashCommandMenu
                 title={t('messages.export.menuTitle')}
@@ -1821,7 +1821,7 @@ const SendBox: React.FC<{
                     : ((bottomHint as string | undefined) ??
                       t('conversation.sendbox.hint', { defaultValue: 'Type / for commands, @ to reference files' }))
               }
-              className={`${shouldUseHighlightOverlay ? 'sendbox-highlight-textarea ' : ''}pl-0 pr-0 !b-none focus:shadow-none m-0 !bg-transparent !focus:bg-transparent !hover:bg-transparent lh-[20px] !resize-none text-14px ${isMobile ? 'sendbox-input--mobile' : ''}`}
+              className={`${shouldUseHighlightOverlay ? 'sendbox-highlight-textarea ' : ''}ps-0 pe-0 !b-none focus:shadow-none m-0 !bg-transparent !focus:bg-transparent !hover:bg-transparent lh-[20px] !resize-none text-14px ${isMobile ? 'sendbox-input--mobile' : ''}`}
               data-testid='sendbox-input'
               style={{
                 width: '100%',

--- a/packages/desktop/src/renderer/components/chat/SendBox/sendbox.css
+++ b/packages/desktop/src/renderer/components/chat/SendBox/sendbox.css
@@ -255,9 +255,9 @@
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   color: var(--color-text-2);
-  text-align: right;
+  text-align: end;
   min-width: 34px;
-  padding-left: 2px;
+  padding-inline-start: 2px;
 }
 
 .speech-input-button {
@@ -555,8 +555,8 @@
      hit area) grows to the right edge instead of shrinking to placeholder width. */
   .sendbox-panel .arco-textarea-wrapper,
   .sendbox-panel .arco-textarea {
-    padding-left: 0 !important;
-    padding-right: 0 !important;
+    padding-inline-start: 0 !important;
+    padding-inline-end: 0 !important;
     width: 100% !important;
   }
 

--- a/packages/desktop/src/renderer/components/chat/SlashCommandMenu.tsx
+++ b/packages/desktop/src/renderer/components/chat/SlashCommandMenu.tsx
@@ -125,7 +125,7 @@ const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
                 itemRefs.current[index] = node;
               }}
               className={classNames(
-                'w-full text-left px-10px py-6px rounded-8px transition-all border border-solid outline-none cursor-pointer mb-2px last:mb-0',
+                'w-full text-start px-10px py-6px rounded-8px transition-all border border-solid outline-none cursor-pointer mb-2px last:mb-0',
                 {
                   'border-[var(--color-border-2)]': index === activeIndex,
                   'border-transparent hover:bg-[var(--color-fill-1)]': index !== activeIndex,

--- a/packages/desktop/src/renderer/components/chat/ThoughtDisplay.tsx
+++ b/packages/desktop/src/renderer/components/chat/ThoughtDisplay.tsx
@@ -150,7 +150,7 @@ const ThoughtDisplay: React.FC<ThoughtDisplayProps> = ({
             parallel-view column. */}
         <span className='text-t-secondary min-w-0 flex-1 truncate' title={statusText}>
           {statusText ?? t('conversation.chat.processing')}
-          {showElapsed && <span className='ml-8px opacity-60'>({formatElapsedTime(elapsedTime)})</span>}
+          {showElapsed && <span className='ms-8px opacity-60'>({formatElapsedTime(elapsedTime)})</span>}
         </span>
         {onRetryStart && (
           <Button className='flex-shrink-0' size='mini' type='text' onClick={onRetryStart}>

--- a/packages/desktop/src/renderer/components/layout/Layout.tsx
+++ b/packages/desktop/src/renderer/components/layout/Layout.tsx
@@ -420,7 +420,7 @@ const Layout: React.FC<{
             >
               <ArcoLayout.Header
                 className={classNames(
-                  'flex items-center justify-start pt-8px pb-8px pl-18px pr-16px gap-12px layout-sider-header',
+                  'flex items-center justify-start pt-8px pb-8px ps-18px pe-16px gap-12px layout-sider-header',
                   isMobile && 'layout-sider-header--mobile',
                   {
                     'cursor-pointer group ': collapsed,
@@ -578,7 +578,7 @@ const Layout: React.FC<{
                   widthPx={explorerWidthPx}
                   collapsed={explorerCollapsed}
                   dragHandle={createExplorerDragHandle({
-                    className: 'absolute left-0 top-0 bottom-0 z-20',
+                    className: 'absolute start-0 top-0 bottom-0 z-20',
                     reverse: true,
                   })}
                 />

--- a/packages/desktop/src/renderer/components/layout/Sider/Sider.module.css
+++ b/packages/desktop/src/renderer/components/layout/Sider/Sider.module.css
@@ -45,9 +45,9 @@
    hovered, the three-dot menu takes over that slot and the text reclaims
    the gap (18px), matching non-pinned rows. */
 .pinnedTextSlot {
-  padding-right: 28px;
+  padding-inline-end: 28px;
 }
 
 :global(.group):hover .pinnedTextSlot {
-  padding-right: 18px;
+  padding-inline-end: 18px;
 }

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderFooter.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderFooter.tsx
@@ -58,14 +58,14 @@ const SiderFooter: React.FC<SiderFooterProps> = ({
   const themeTooltip = theme === 'dark' ? t('settings.lightMode') : t('settings.darkMode');
 
   return (
-    <div className='shrink-0 sider-footer mt-auto pt-8px pb-8px border-t border-solid border-[var(--color-border-2)] border-l-0 border-r-0 border-b-0'>
+    <div className='shrink-0 sider-footer mt-auto pt-8px pb-8px border-t border-solid border-[var(--color-border-2)] border-s-0 border-e-0 border-b-0'>
       <div className={classNames('flex', collapsed ? 'flex-col gap-2px' : 'items-center gap-2px')}>
         <Tooltip {...siderTooltipProps} content={isSettings ? t('common.back') : t('common.settings')} position='right'>
           <div
             onClick={onSettingsClick}
             className={classNames(
               'group h-34px flex items-center rd-0.5rem cursor-pointer transition-colors',
-              collapsed ? 'w-full justify-center' : 'flex-1 min-w-0 justify-start gap-8px pl-10px pr-8px',
+              collapsed ? 'w-full justify-center' : 'flex-1 min-w-0 justify-start gap-8px ps-10px pe-8px',
               isMobile && 'sider-footer-btn-mobile',
               {
                 'bg-fill-3': isSettings,

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderItem.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderItem.tsx
@@ -56,7 +56,7 @@ const SiderItem: React.FC<SiderItemProps> = ({
     >
       <div
         className={classNames(
-          'h-34px rd-8px flex items-center gap-8px pl-10px pr-8px cursor-pointer relative overflow-hidden shrink-0 group min-w-0 transition-colors',
+          'h-34px rd-8px flex items-center gap-8px ps-10px pe-8px cursor-pointer relative overflow-hidden shrink-0 group min-w-0 transition-colors',
           {
             'hover:bg-fill-3': !selected,
             '!bg-fill-3': selected,
@@ -85,7 +85,7 @@ const SiderItem: React.FC<SiderItemProps> = ({
         </span>
 
         {/* Name with truncation — reserve room for the hover three-dot menu */}
-        <div className='h-24px min-w-0 flex-1 overflow-hidden pr-12px'>
+        <div className='h-24px min-w-0 flex-1 overflow-hidden pe-12px'>
           <div className='overflow-hidden text-ellipsis block w-full text-14px font-[500] lh-24px whitespace-nowrap min-w-0 text-t-primary'>
             <span className='block overflow-hidden text-ellipsis whitespace-nowrap'>{name}</span>
           </div>
@@ -94,7 +94,7 @@ const SiderItem: React.FC<SiderItemProps> = ({
         {/* Hover/active actions: three-dot menu */}
         {hasMenu && (
           <div
-            className={classNames('absolute right-8px top-1/2 -translate-y-1/2 items-center justify-end', {
+            className={classNames('absolute end-8px top-1/2 -translate-y-1/2 items-center justify-end', {
               flex: isMobile || menuVisible,
               'hidden group-hover:flex': !isMobile && !menuVisible,
             })}

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderNav/SiderAssistantEntry.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderNav/SiderAssistantEntry.tsx
@@ -54,7 +54,7 @@ const SiderAssistantEntry: React.FC<SiderAssistantEntryProps> = ({
     <Tooltip {...siderTooltipProps} content={t('settings.assistants')} position='right'>
       <div
         className={classNames(
-          'box-border group h-34px w-full flex items-center justify-start gap-8px pl-10px pr-8px rd-0.5rem cursor-pointer shrink-0 transition-all text-t-primary',
+          'box-border group h-34px w-full flex items-center justify-start gap-8px ps-10px pe-8px rd-0.5rem cursor-pointer shrink-0 transition-all text-t-primary',
           isMobile && 'sider-action-btn-mobile',
           isActive ? 'bg-fill-3' : 'hover:bg-fill-3 active:bg-fill-4'
         )}

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderNav/SiderScheduledEntry.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderNav/SiderScheduledEntry.tsx
@@ -54,7 +54,7 @@ const SiderScheduledEntry: React.FC<SiderScheduledEntryProps> = ({
     <Tooltip {...siderTooltipProps} content={t('cron.scheduledTasks')} position='right'>
       <div
         className={classNames(
-          'box-border group h-34px w-full flex items-center justify-start gap-8px pl-10px pr-8px rd-0.5rem cursor-pointer shrink-0 transition-all text-t-primary',
+          'box-border group h-34px w-full flex items-center justify-start gap-8px ps-10px pe-8px rd-0.5rem cursor-pointer shrink-0 transition-all text-t-primary',
           isMobile && 'sider-action-btn-mobile',
           isActive ? 'bg-fill-3' : 'hover:bg-fill-3 active:bg-fill-4'
         )}

--- a/packages/desktop/src/renderer/components/layout/Sider/SiderNav/SiderToolbar.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/SiderNav/SiderToolbar.tsx
@@ -61,7 +61,7 @@ const SiderToolbar: React.FC<SiderToolbarProps> = ({
         <div
           className={classNames(
             styles.newChatTrigger,
-            'h-34px flex-1 flex items-center justify-start gap-8px pl-10px pr-8px rd-0.5rem cursor-pointer group transition-all bg-transparent text-t-primary hover:bg-fill-3 active:bg-fill-4',
+            'h-34px flex-1 flex items-center justify-start gap-8px ps-10px pe-8px rd-0.5rem cursor-pointer group transition-all bg-transparent text-t-primary hover:bg-fill-3 active:bg-fill-4',
             isMobile && 'sider-action-btn-mobile'
           )}
           onClick={onNewChat}

--- a/packages/desktop/src/renderer/components/layout/Sider/TeamSiderSection.tsx
+++ b/packages/desktop/src/renderer/components/layout/Sider/TeamSiderSection.tsx
@@ -145,7 +145,7 @@ const TeamSiderSection: React.FC<TeamSiderSectionProps> = ({
                     )}
                     {(teamBadgeCounts.get(team.id) ?? 0) > 0 && (
                       <span
-                        className='absolute top-4px right-4px w-18px h-18px rounded-full text-10px font-bold flex items-center justify-center leading-none bg-danger-6 text-white'
+                        className='absolute top-4px end-4px w-18px h-18px rounded-full text-10px font-bold flex items-center justify-center leading-none bg-danger-6 text-white'
                         style={{ lineHeight: 1 }}
                       >
                         {(teamBadgeCounts.get(team.id) ?? 0) > 99 ? '99+' : teamBadgeCounts.get(team.id)}
@@ -167,7 +167,7 @@ const TeamSiderSection: React.FC<TeamSiderSectionProps> = ({
             <span className='text-14px text-t-tertiary sider-section-title group-hover/label:text-t-primary transition-colors font-[500] leading-none'>
               {t('team.sider.title')}
             </span>
-            <span className='ml-2px flex items-center justify-center opacity-0 group-hover/label:opacity-100 transition-opacity text-t-tertiary shrink-0'>
+            <span className='ms-2px flex items-center justify-center opacity-0 group-hover/label:opacity-100 transition-opacity text-t-tertiary shrink-0'>
               <Right
                 theme='outline'
                 size={12}
@@ -179,7 +179,7 @@ const TeamSiderSection: React.FC<TeamSiderSectionProps> = ({
             <Tooltip content={t('team.sider.createTeam')} position='top'>
               <div
                 data-testid='team-create-btn'
-                className='ml-auto -mr-4px size-20px rd-4px flex items-center justify-center hover:bg-fill-4 transition-all shrink-0 cursor-pointer text-t-secondary hover:text-t-primary'
+                className='ms-auto -me-4px size-20px rd-4px flex items-center justify-center hover:bg-fill-4 transition-all shrink-0 cursor-pointer text-t-secondary hover:text-t-primary'
                 onClick={(e) => {
                   e.stopPropagation();
                   setCreateTeamVisible(true);
@@ -273,7 +273,7 @@ const TeamSiderSection: React.FC<TeamSiderSectionProps> = ({
                   />
                   {teamBadge > 0 && (
                     <span
-                      className='absolute right-11px top-1/2 -translate-y-1/2 w-18px h-18px rounded-full text-10px font-bold flex items-center justify-center pointer-events-none z-10 group-hover:hidden bg-danger-6 text-white'
+                      className='absolute end-11px top-1/2 -translate-y-1/2 w-18px h-18px rounded-full text-10px font-bold flex items-center justify-center pointer-events-none z-10 group-hover:hidden bg-danger-6 text-white'
                       style={{ lineHeight: 1 }}
                     >
                       {teamBadge > 99 ? '99+' : teamBadge}

--- a/packages/desktop/src/renderer/components/media/Diff2Html.tsx
+++ b/packages/desktop/src/renderer/components/media/Diff2Html.tsx
@@ -149,10 +149,15 @@ const Diff2Html = ({
 
   return (
     <CollapsibleContent maxHeight={160} defaultCollapsed={true} className={className}>
-      <div className='relative w-full max-w-full overflow-x-auto' style={{ WebkitOverflowScrolling: 'touch' }}>
+      {/* Diffs are code; keep them left-to-right under an RTL document. */}
+      <div
+        dir='ltr'
+        className='relative w-full max-w-full overflow-x-auto'
+        style={{ WebkitOverflowScrolling: 'touch' }}
+      >
         <div
           className={classNames(
-            '![&_.line-num1]:hidden ![&_.line-num2]:w-30px [&_td:first-child]:w-40px ![&_td:nth-child(2)>div]:pl-45px min-w-0 max-w-full [&_div.d2f-file-wrapper]:rd-[0.3rem_0.3rem_0px_0px]  [&_div.d2h-file-header]:items-center [&_div.d2h-file-header]:bg-bg-3',
+            '![&_.line-num1]:hidden ![&_.line-num2]:w-30px [&_td:first-child]:w-40px ![&_td:nth-child(2)>div]:ps-45px min-w-0 max-w-full [&_div.d2f-file-wrapper]:rd-[0.3rem_0.3rem_0px_0px]  [&_div.d2h-file-header]:items-center [&_div.d2h-file-header]:bg-bg-3',
             {
               '[&_.d2h-file-diff]:hidden [&_.d2h-files-diff]:hidden': collapse,
               'd2h-dark-color-scheme': theme === 'dark',

--- a/packages/desktop/src/renderer/components/media/FilePreview.tsx
+++ b/packages/desktop/src/renderer/components/media/FilePreview.tsx
@@ -132,7 +132,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
         </div>
         {!readonly && (
           <div
-            className='absolute -top-4px -right-4px w-16px h-16px rd-50% bg-white dark:bg-gray-700 cursor-pointer flex items-center justify-center shadow-md hover:shadow-lg transition-all z-10 border-1 border-solid border-gray-200 dark:border-gray-600'
+            className='absolute -top-4px -end-4px w-16px h-16px rd-50% bg-white dark:bg-gray-700 cursor-pointer flex items-center justify-center shadow-md hover:shadow-lg transition-all z-10 border-1 border-solid border-gray-200 dark:border-gray-600'
             onClick={handleRemove}
           >
             <Close theme='filled' size='10' fill='#666' />
@@ -160,7 +160,7 @@ const FilePreview: React.FC<FilePreviewProps> = ({ path, onRemove, readonly = fa
       </div>
       {!readonly && (
         <div
-          className='absolute -top-4px -right-4px w-16px h-16px rd-50% bg-white dark:bg-gray-700 cursor-pointer flex items-center justify-center shadow-md hover:shadow-lg transition-all z-10 border-1 border-solid border-gray-200 dark:border-gray-600'
+          className='absolute -top-4px -end-4px w-16px h-16px rd-50% bg-white dark:bg-gray-700 cursor-pointer flex items-center justify-center shadow-md hover:shadow-lg transition-all z-10 border-1 border-solid border-gray-200 dark:border-gray-600'
           onClick={handleRemove}
         >
           <Close theme='filled' size='10' fill='#666' />

--- a/packages/desktop/src/renderer/components/media/HorizontalFileList.tsx
+++ b/packages/desktop/src/renderer/components/media/HorizontalFileList.tsx
@@ -128,7 +128,7 @@ const HorizontalFileList: React.FC<HorizontalFileListProps> = ({ children }) => 
       {/* 左侧滚动按钮 - 在非起始位置时显示 */}
       {showScrollButton && canScrollLeft && (
         <div
-          className='absolute left-0 top-0 h-full flex items-center cursor-pointer'
+          className='absolute start-0 top-0 h-full flex items-center cursor-pointer'
           style={{
             background: 'linear-gradient(to left, transparent, var(--dialog-fill-0) 30%)', // 左侧渐变遮罩
             width: '60px',
@@ -137,7 +137,7 @@ const HorizontalFileList: React.FC<HorizontalFileListProps> = ({ children }) => 
         >
           <button
             onClick={handleScrollLeft}
-            className='ml-0px w-28px h-28px rd-50% bg-1 flex items-center justify-center hover:bg-2 transition-colors border-1 border-solid b-color-border-2'
+            className='ms-0px w-28px h-28px rd-50% bg-1 flex items-center justify-center hover:bg-2 transition-colors border-1 border-solid b-color-border-2'
             style={{
               pointerEvents: 'auto', // 按钮响应点击
               boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
@@ -150,7 +150,7 @@ const HorizontalFileList: React.FC<HorizontalFileListProps> = ({ children }) => 
       {/* 右侧滚动按钮 - 在非结束位置时显示 */}
       {showScrollButton && canScrollRight && (
         <div
-          className='absolute right-0 top-0 h-full flex items-center cursor-pointer'
+          className='absolute end-0 top-0 h-full flex items-center cursor-pointer'
           style={{
             background: 'linear-gradient(to right, transparent, var(--dialog-fill-0) 30%)', // 右侧渐变遮罩
             width: '60px',
@@ -159,7 +159,7 @@ const HorizontalFileList: React.FC<HorizontalFileListProps> = ({ children }) => 
         >
           <button
             onClick={handleScrollRight}
-            className='ml-auto mr-0px w-28px h-28px rd-50% bg-1 flex items-center justify-center hover:bg-2 transition-colors border-1 border-solid b-color-border-2'
+            className='ms-auto me-0px w-28px h-28px rd-50% bg-1 flex items-center justify-center hover:bg-2 transition-colors border-1 border-solid b-color-border-2'
             style={{
               pointerEvents: 'auto', // 按钮响应点击
               boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',

--- a/packages/desktop/src/renderer/components/media/WebviewHost.tsx
+++ b/packages/desktop/src/renderer/components/media/WebviewHost.tsx
@@ -744,7 +744,7 @@ const WebviewHost: React.FC<WebviewHostProps> = ({
             )}
           </button>
           {isStarOffice && (
-            <div className='flex items-center gap-6px ml-2px'>
+            <div className='flex items-center gap-6px ms-2px'>
               <button onClick={handleZoomReset} className='toolbar-btn' title='Reset zoom'>
                 100%
               </button>
@@ -754,7 +754,7 @@ const WebviewHost: React.FC<WebviewHostProps> = ({
               <span className='toolbar-chip'>{Math.round(zoomFactor * 100)}%</span>
             </div>
           )}
-          <form onSubmit={handleUrlSubmit} className='flex-1 ml-2px'>
+          <form onSubmit={handleUrlSubmit} className='flex-1 ms-2px'>
             <input
               type='text'
               value={inputUrl}
@@ -785,7 +785,7 @@ const WebviewHost: React.FC<WebviewHostProps> = ({
         <webview
           ref={webviewRef as any}
           src={currentUrl}
-          className='border-0 absolute left-0 top-0'
+          className='border-0 absolute start-0 top-0'
           style={{
             opacity: !showNavBar && isLoading ? 0 : 1,
             transition: 'opacity 150ms ease-in',

--- a/packages/desktop/src/renderer/components/settings/FontSizeStepper.tsx
+++ b/packages/desktop/src/renderer/components/settings/FontSizeStepper.tsx
@@ -32,7 +32,7 @@ const FontSizeStepper: React.FC<FontSizeStepperProps> = ({
   // Defensive bound only; the parent already clamps via clampFontSize before persisting.
   const clamp = (n: number) => Math.min(max, Math.max(min, n));
   return (
-    <div className='flex items-center gap-10px ml-auto'>
+    <div className='flex items-center gap-10px ms-auto'>
       <Button
         size='mini'
         type='secondary'

--- a/packages/desktop/src/renderer/components/settings/ScaleControl.tsx
+++ b/packages/desktop/src/renderer/components/settings/ScaleControl.tsx
@@ -124,11 +124,8 @@ const ScaleControl: React.FC = () => {
             +
           </Button>
         </div>
-        <div className='flex items-center gap-10px ml-auto'>
-          <span
-            className='text-13px text-t-primary text-right min-w-56px'
-            style={{ fontVariantNumeric: 'tabular-nums' }}
-          >
+        <div className='flex items-center gap-10px ms-auto'>
+          <span className='text-13px text-t-primary text-end min-w-56px' style={{ fontVariantNumeric: 'tabular-nums' }}>
             {formattedValue}
           </span>
           <Button

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ModelModalContent.tsx
@@ -412,7 +412,7 @@ const ModelModalContent: React.FC = () => {
                 href='https://github.com/iOfficeAI/AionUi/wiki/LLM-Configuration'
                 target='_blank'
                 rel='noopener noreferrer'
-                className='text-[rgb(var(--primary-6))] hover:text-[rgb(var(--primary-5))] underline ml-4px'
+                className='text-[rgb(var(--primary-6))] hover:text-[rgb(var(--primary-5))] underline ms-4px'
               >
                 {t('settings.configGuide')}
               </a>
@@ -434,7 +434,7 @@ const ModelModalContent: React.FC = () => {
                   key={key}
                   bordered
                   expandIconPosition='left'
-                  className={`[&_.arco-collapse-item]:!border-0 [&_.arco-collapse-item]:!rounded-12px [&_.arco-collapse-item]:!overflow-hidden [&_.arco-collapse-item]:!bg-[var(--color-bg-2)] [&_.arco-collapse-item-header]:!bg-[var(--fill-0)] [&_.arco-collapse-item-header]:!pl-36px [&_.arco-collapse-item-header]:!pr-12px [&_.arco-collapse-item-header]:!py-8px [&_.arco-collapse-item-header]:transition-colors [&_.arco-collapse-item-header]:hover:!bg-[var(--color-bg-2)] [&_.arco-collapse-item-header]:!gap-8px [&_.arco-collapse-item-header-title]:!min-w-0 [&_.arco-collapse-item-header-icon]:!text-2 [&_.arco-collapse-item-header:hover_.arco-collapse-item-header-icon]:!text-1 [&_.arco-collapse-item-content]:!bg-fill-1 [&_.arco-collapse-item-content-box]:!px-10px [&_.arco-collapse-item-content-box]:!py-8px [&_.arco-collapse-item-content]:!border-t [&_.arco-collapse-item-content]:!border-[var(--color-border-2)] ${
+                  className={`[&_.arco-collapse-item]:!border-0 [&_.arco-collapse-item]:!rounded-12px [&_.arco-collapse-item]:!overflow-hidden [&_.arco-collapse-item]:!bg-[var(--color-bg-2)] [&_.arco-collapse-item-header]:!bg-[var(--fill-0)] [&_.arco-collapse-item-header]:!ps-36px [&_.arco-collapse-item-header]:!pe-12px [&_.arco-collapse-item-header]:!py-8px [&_.arco-collapse-item-header]:transition-colors [&_.arco-collapse-item-header]:hover:!bg-[var(--color-bg-2)] [&_.arco-collapse-item-header]:!gap-8px [&_.arco-collapse-item-header-title]:!min-w-0 [&_.arco-collapse-item-header-icon]:!text-2 [&_.arco-collapse-item-header:hover_.arco-collapse-item-header-icon]:!text-1 [&_.arco-collapse-item-content]:!bg-fill-1 [&_.arco-collapse-item-content-box]:!px-10px [&_.arco-collapse-item-content-box]:!py-8px [&_.arco-collapse-item-content]:!border-t [&_.arco-collapse-item-content]:!border-[var(--color-border-2)] ${
                     isExpanded
                       ? '[&_.arco-collapse-item-header]:!rounded-t-12px [&_.arco-collapse-item-header]:!rounded-b-0 [&_.arco-collapse-item-content]:!rounded-b-12px'
                       : '[&_.arco-collapse-item-header]:!rounded-12px'

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/BrowserNotificationGrant.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/BrowserNotificationGrant.tsx
@@ -25,16 +25,16 @@ const BrowserNotificationGrant: React.FC = () => {
   }, [supported]);
 
   if (!supported) {
-    return <div className='pl-12px text-12px text-3'>{t('settings.browserNotification.insecureContext')}</div>;
+    return <div className='ps-12px text-12px text-3'>{t('settings.browserNotification.insecureContext')}</div>;
   }
   if (permission === 'granted') {
-    return <div className='pl-12px text-12px text-3'>{t('settings.browserNotification.granted')}</div>;
+    return <div className='ps-12px text-12px text-3'>{t('settings.browserNotification.granted')}</div>;
   }
   if (permission === 'denied') {
-    return <div className='pl-12px text-12px text-3'>{t('settings.browserNotification.denied')}</div>;
+    return <div className='ps-12px text-12px text-3'>{t('settings.browserNotification.denied')}</div>;
   }
   return (
-    <div className='pl-12px'>
+    <div className='ps-12px'>
       <Button type='outline' size='small' onClick={handleRequest}>
         {t('settings.browserNotification.enable')}
       </Button>

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/DirInputItem.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/DirInputItem.tsx
@@ -50,7 +50,7 @@ const DirInputItem: React.FC<{
 
         return (
           <div
-            className='aion-dir-input h-[32px] flex items-center rounded-8px border border-solid border-transparent pl-14px bg-[var(--fill-0)] cursor-pointer'
+            className='aion-dir-input h-[32px] flex items-center rounded-8px border border-solid border-transparent ps-14px bg-[var(--fill-0)] cursor-pointer'
             tabIndex={0}
             onClick={handlePick}
             onKeyDown={handleKeyDown}

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/VoiceInputSection/index.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/VoiceInputSection/index.tsx
@@ -256,7 +256,7 @@ const VoiceInputSection: React.FC = () => {
                   return (
                     <AionSelect.Option key={model} value={model}>
                       {model}
-                      {badgeText !== null && <span className='text-12px text-t-tertiary ml-8px'>{badgeText}</span>}
+                      {badgeText !== null && <span className='text-12px text-t-tertiary ms-8px'>{badgeText}</span>}
                     </AionSelect.Option>
                   );
                 })}

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/index.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/index.tsx
@@ -500,7 +500,7 @@ const SystemModalContent: React.FC = () => {
                 showExpandIcon={false}
                 header={
                   <div className='flex flex-1 items-center justify-between w-full'>
-                    <span className='text-14px text-2 ml-12px'>{t('settings.notification')}</span>
+                    <span className='text-14px text-2 ms-12px'>{t('settings.notification')}</span>
                     <Switch
                       checked={notificationEnabled}
                       onClick={(e) => e.stopPropagation()}
@@ -510,7 +510,7 @@ const SystemModalContent: React.FC = () => {
                 }
               >
                 {isDesktop ? (
-                  <div className='pl-12px'>
+                  <div className='ps-12px'>
                     <PreferenceRow label={t('settings.cronNotificationEnabled')}>
                       <Switch
                         checked={cronNotificationEnabled}
@@ -534,7 +534,7 @@ const SystemModalContent: React.FC = () => {
                   content={
                     <span>
                       {typeof error === 'string' ? error : JSON.stringify(error)}
-                      <FeedbackButton module='system-settings' className='ml-6px' />
+                      <FeedbackButton module='system-settings' className='ms-6px' />
                     </span>
                   }
                 />

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/ToolsModalContent.tsx
@@ -533,7 +533,7 @@ const ToolsModalContent: React.FC = () => {
                 tooltip={
                   <div className='space-y-4px'>
                     <div>{t('settings.imageGenSupportedTooltipTitle')}</div>
-                    <ul className='list-disc pl-16px m-0'>
+                    <ul className='list-disc ps-16px m-0'>
                       <li>{t('settings.imageGenSupportedTooltipGemini')}</li>
                       <li>{t('settings.imageGenSupportedTooltipOpenRouter')}</li>
                       <li>{t('settings.imageGenSupportedTooltipAntigravity')}</li>
@@ -591,7 +591,7 @@ const ToolsModalContent: React.FC = () => {
                             href='https://github.com/iOfficeAI/AionUi/wiki/AionUi-Image-Generation-Tool-Model-Configuration-Guide'
                             target='_blank'
                             rel='noopener noreferrer'
-                            className='text-[rgb(var(--primary-6))] hover:text-[rgb(var(--primary-5))] underline ml-4px'
+                            className='text-[rgb(var(--primary-6))] hover:text-[rgb(var(--primary-5))] underline ms-4px'
                             onClick={(e) => e.stopPropagation()}
                           >
                             {t('settings.configGuide')}
@@ -603,7 +603,7 @@ const ToolsModalContent: React.FC = () => {
                         href='https://github.com/iOfficeAI/AionUi/wiki/AionUi-Image-Generation-Tool-Model-Configuration-Guide'
                         target='_blank'
                         rel='noopener noreferrer'
-                        className='ml-8px text-[rgb(var(--primary-6))] hover:text-[rgb(var(--primary-5))] cursor-pointer'
+                        className='ms-8px text-[rgb(var(--primary-6))] hover:text-[rgb(var(--primary-5))] cursor-pointer'
                         onClick={(e) => e.stopPropagation()}
                       >
                         <Help theme='outline' size='14' />

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/WebuiModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/WebuiModalContent.tsx
@@ -829,7 +829,7 @@ const WebuiModalContent: React.FC = () => {
             >
               <Communication theme='outline' size='15' />
               <span>Channels</span>
-              <span className='inline-flex items-center gap-4px ml-2px'>
+              <span className='inline-flex items-center gap-4px ms-2px'>
                 {CHANNEL_LOGOS.map((item) => (
                   <span
                     key={item.alt}

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/DingTalkConfigForm.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/DingTalkConfigForm.tsx
@@ -38,7 +38,7 @@ const PreferenceRow: React.FC<{
       <div className='flex items-center gap-8px'>
         <span className='text-14px text-t-primary'>
           {label}
-          {required && <span className='text-red-500 ml-2px'>*</span>}
+          {required && <span className='text-red-500 ms-2px'>*</span>}
         </span>
         {extra}
       </div>
@@ -441,7 +441,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
       {!hasExistingUsers && !pluginStatus?.connected && (
         <div className='flex justify-end'>
           {pluginStatus?.hasToken && !clientId.trim() && !clientSecret.trim() ? (
-            <span className='text-12px text-t-tertiary mr-12px self-center'>
+            <span className='text-12px text-t-tertiary me-12px self-center'>
               {t('settings.dingtalk.credentialsSaved', 'Credentials already configured. Enter new values to update.')}
             </span>
           ) : null}
@@ -593,7 +593,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
 
       {/* Pending Pairings */}
       {pluginStatus?.enabled && authorizedUsers.length === 0 && (
-        <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
+        <div className='bg-fill-1 rd-12px pt-16px pe-16px pb-16px ps-0'>
           <SectionHeader
             title={t('settings.assistant.pendingPairings', 'Pending Pairing Requests')}
             action={
@@ -668,7 +668,7 @@ const DingTalkConfigForm: React.FC<DingTalkConfigFormProps> = ({ pluginStatus, m
 
       {/* Authorized Users */}
       {authorizedUsers.length > 0 && (
-        <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
+        <div className='bg-fill-1 rd-12px pt-16px pe-16px pb-16px ps-0'>
           <SectionHeader
             title={t('settings.assistant.authorizedUsers', 'Authorized Users')}
             action={

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/DiscordConfigForm.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/DiscordConfigForm.tsx
@@ -469,7 +469,7 @@ const DiscordConfigForm: React.FC<DiscordConfigFormProps> = ({
                 'Open Discord and mention your bot in a server channel, or send it a DM'
               )}
               {pluginStatus.botUsername && (
-                <span className='ml-4px'>
+                <span className='ms-4px'>
                   <code className='bg-fill-2 px-6px py-2px rd-4px'>@{pluginStatus.botUsername}</code>
                 </span>
               )}
@@ -498,7 +498,7 @@ const DiscordConfigForm: React.FC<DiscordConfigFormProps> = ({
 
       {/* Pending Pairings - show when bot is enabled and no authorized users yet */}
       {pluginStatus?.enabled && authorizedUsers.length === 0 && (
-        <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
+        <div className='bg-fill-1 rd-12px pt-16px pe-16px pb-16px ps-0'>
           <SectionHeader
             title={t('settings.assistant.pendingPairings', 'Pending Pairing Requests')}
             action={
@@ -573,7 +573,7 @@ const DiscordConfigForm: React.FC<DiscordConfigFormProps> = ({
 
       {/* Authorized Users - show when there are authorized users */}
       {authorizedUsers.length > 0 && (
-        <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
+        <div className='bg-fill-1 rd-12px pt-16px pe-16px pb-16px ps-0'>
           <SectionHeader
             title={t('settings.assistant.authorizedUsers', 'Authorized Users')}
             action={

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/LarkConfigForm.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/LarkConfigForm.tsx
@@ -38,7 +38,7 @@ const PreferenceRow: React.FC<{
       <div className='flex items-center gap-8px'>
         <span className='text-14px text-t-primary'>
           {label}
-          {required && <span className='text-red-500 ml-2px'>*</span>}
+          {required && <span className='text-red-500 ms-2px'>*</span>}
         </span>
         {extra}
       </div>
@@ -562,7 +562,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
         <div className='flex justify-end'>
           {pluginStatus?.hasToken && !appId.trim() && !appSecret.trim() ? (
             // Credentials already saved but not entered in UI - show info message
-            <span className='text-12px text-t-tertiary mr-12px self-center'>
+            <span className='text-12px text-t-tertiary me-12px self-center'>
               {t('settings.lark.credentialsSaved', 'Credentials already configured. Enter new values to update.')}
             </span>
           ) : null}
@@ -713,7 +713,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
 
       {/* Pending Pairings */}
       {pluginStatus?.enabled && authorizedUsers.length === 0 && (
-        <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
+        <div className='bg-fill-1 rd-12px pt-16px pe-16px pb-16px ps-0'>
           <SectionHeader
             title={t('settings.assistant.pendingPairings', 'Pending Pairing Requests')}
             action={
@@ -788,7 +788,7 @@ const LarkConfigForm: React.FC<LarkConfigFormProps> = ({ pluginStatus, modelSele
 
       {/* Authorized Users */}
       {authorizedUsers.length > 0 && (
-        <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
+        <div className='bg-fill-1 rd-12px pt-16px pe-16px pb-16px ps-0'>
           <SectionHeader
             title={t('settings.assistant.authorizedUsers', 'Authorized Users')}
             action={

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/SlackConfigForm.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/SlackConfigForm.tsx
@@ -533,7 +533,7 @@ const SlackConfigForm: React.FC<SlackConfigFormProps> = ({
               <strong>1.</strong>{' '}
               {t('settings.assistant.slackStep1', 'Open Slack and mention your bot in a channel, or send it a DM')}
               {pluginStatus.botUsername && (
-                <span className='ml-4px'>
+                <span className='ms-4px'>
                   <code className='bg-fill-2 px-6px py-2px rd-4px'>@{pluginStatus.botUsername}</code>
                 </span>
               )}
@@ -559,7 +559,7 @@ const SlackConfigForm: React.FC<SlackConfigFormProps> = ({
 
       {/* Pending Pairings - show when bot is enabled and no authorized users yet */}
       {pluginStatus?.enabled && authorizedUsers.length === 0 && (
-        <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
+        <div className='bg-fill-1 rd-12px pt-16px pe-16px pb-16px ps-0'>
           <SectionHeader
             title={t('settings.assistant.pendingPairings', 'Pending Pairing Requests')}
             action={
@@ -634,7 +634,7 @@ const SlackConfigForm: React.FC<SlackConfigFormProps> = ({
 
       {/* Authorized Users - show when there are authorized users */}
       {authorizedUsers.length > 0 && (
-        <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
+        <div className='bg-fill-1 rd-12px pt-16px pe-16px pb-16px ps-0'>
           <SectionHeader
             title={t('settings.assistant.authorizedUsers', 'Authorized Users')}
             action={

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/TelegramConfigForm.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/TelegramConfigForm.tsx
@@ -476,7 +476,7 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({
             <p className='m-0'>
               <strong>1.</strong> {t('settings.assistant.step1', 'Open Telegram and search for your bot')}
               {pluginStatus.botUsername && (
-                <span className='ml-4px'>
+                <span className='ms-4px'>
                   <code className='bg-fill-2 px-6px py-2px rd-4px'>@{pluginStatus.botUsername}</code>
                 </span>
               )}
@@ -502,7 +502,7 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({
 
       {/* Pending Pairings - show when bot is enabled and no authorized users yet */}
       {pluginStatus?.enabled && authorizedUsers.length === 0 && (
-        <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
+        <div className='bg-fill-1 rd-12px pt-16px pe-16px pb-16px ps-0'>
           <SectionHeader
             title={t('settings.assistant.pendingPairings', 'Pending Pairing Requests')}
             action={
@@ -577,7 +577,7 @@ const TelegramConfigForm: React.FC<TelegramConfigFormProps> = ({
 
       {/* Authorized Users - show when there are authorized users */}
       {authorizedUsers.length > 0 && (
-        <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
+        <div className='bg-fill-1 rd-12px pt-16px pe-16px pb-16px ps-0'>
           <SectionHeader
             title={t('settings.assistant.authorizedUsers', 'Authorized Users')}
             action={

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/WecomConfigForm.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/WecomConfigForm.tsx
@@ -38,7 +38,7 @@ const PreferenceRow: React.FC<{
       <div className='flex items-center gap-8px'>
         <span className='text-14px text-t-primary'>
           {label}
-          {required && <span className='text-red-500 ml-2px'>*</span>}
+          {required && <span className='text-red-500 ms-2px'>*</span>}
         </span>
         {extra}
       </div>
@@ -408,7 +408,7 @@ const WecomConfigForm: React.FC<WecomConfigFormProps> = ({
       {!hasExistingUsers && (
         <div className='flex justify-end'>
           {pluginStatus?.hasToken && !botId.trim() && !secret.trim() ? (
-            <span className='text-12px text-t-tertiary mr-12px self-center'>
+            <span className='text-12px text-t-tertiary me-12px self-center'>
               {t('settings.wecom.credentialsSaved', 'Credentials already configured. Enter new values to update.')}
             </span>
           ) : null}
@@ -560,7 +560,7 @@ const WecomConfigForm: React.FC<WecomConfigFormProps> = ({
 
       {/* Pending Pairings */}
       {pluginStatus?.enabled && authorizedUsers.length === 0 && (
-        <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
+        <div className='bg-fill-1 rd-12px pt-16px pe-16px pb-16px ps-0'>
           <SectionHeader
             title={t('settings.assistant.pendingPairings', 'Pending Pairing Requests')}
             action={
@@ -635,7 +635,7 @@ const WecomConfigForm: React.FC<WecomConfigFormProps> = ({
 
       {/* Authorized Users */}
       {authorizedUsers.length > 0 && (
-        <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
+        <div className='bg-fill-1 rd-12px pt-16px pe-16px pb-16px ps-0'>
           <SectionHeader
             title={t('settings.assistant.authorizedUsers', 'Authorized Users')}
             action={

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/WeixinConfigForm.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/channels/WeixinConfigForm.tsx
@@ -491,7 +491,7 @@ const WeixinConfigForm: React.FC<WeixinConfigFormProps> = ({ pluginStatus, model
 
       {/* Pending Pairing Requests */}
       {pluginStatus?.connected && (
-        <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
+        <div className='bg-fill-1 rd-12px pt-16px pe-16px pb-16px ps-0'>
           <SectionHeader
             title={t('settings.assistant.pendingPairings', 'Pending Pairing Requests')}
             action={
@@ -565,7 +565,7 @@ const WeixinConfigForm: React.FC<WeixinConfigFormProps> = ({ pluginStatus, model
 
       {/* Authorized Users */}
       {authorizedUsers.length > 0 && (
-        <div className='bg-fill-1 rd-12px pt-16px pr-16px pb-16px pl-0'>
+        <div className='bg-fill-1 rd-12px pt-16px pe-16px pb-16px ps-0'>
           <SectionHeader
             title={t('settings.assistant.authorizedUsers', 'Authorized Users')}
             action={

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/index.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/index.tsx
@@ -374,7 +374,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ visible, onCancel, defaul
             )}
             onClick={() => setActiveTab(item.key)}
           >
-            <span className='mr-12px text-16px line-height-[10px]'>{item.icon}</span>
+            <span className='me-12px text-16px line-height-[10px]'>{item.icon}</span>
             <span className='text-14px font-500 flex-1 lh-22px'>{item.label}</span>
           </div>
         ))}
@@ -409,7 +409,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ visible, onCancel, defaul
             {isMobile ? mobileMenu : desktopMenu}
 
             <AionScrollArea
-              className={classNames('flex-1 min-h-0', isMobile ? 'overflow-y-auto' : 'flex flex-col pl-24px gap-16px')}
+              className={classNames('flex-1 min-h-0', isMobile ? 'overflow-y-auto' : 'flex flex-col ps-24px gap-16px')}
             >
               {renderBuiltinContent()}
               {renderExtensionTabs()}

--- a/packages/desktop/src/renderer/components/settings/UpdateMigrationDialog.tsx
+++ b/packages/desktop/src/renderer/components/settings/UpdateMigrationDialog.tsx
@@ -140,7 +140,7 @@ const UpdateMigrationDialog: React.FC = () => {
           <p className='mb-8px'>
             <strong>{t('update.migration.letter.whyTitle')}</strong> {t('update.migration.letter.whyLead')}
           </p>
-          <ul className='mb-8px pl-20px list-disc'>
+          <ul className='mb-8px ps-20px list-disc'>
             <li className='mb-4px'>{t('update.migration.letter.whyReason1')}</li>
             <li className='mb-4px'>{t('update.migration.letter.whyReason2')}</li>
             <li>{t('update.migration.letter.whyReason3')}</li>
@@ -153,7 +153,7 @@ const UpdateMigrationDialog: React.FC = () => {
           <p className='mb-8px'>
             <strong>{t('update.migration.letter.promisesTitle')}</strong>
           </p>
-          <ul className='mb-20px pl-20px list-disc'>
+          <ul className='mb-20px ps-20px list-disc'>
             <li className='mb-4px'>
               <strong>{t('update.migration.letter.promise1Bold')}</strong>
               {t('update.migration.letter.promise1Rest')}
@@ -165,7 +165,7 @@ const UpdateMigrationDialog: React.FC = () => {
           <p className='mb-8px'>
             <strong>{t('update.migration.letter.choicesTitle')}</strong>
           </p>
-          <ul className='mb-20px pl-20px list-disc'>
+          <ul className='mb-20px ps-20px list-disc'>
             <li className='mb-4px'>
               <strong>{t('update.migration.letter.choice1Bold')}</strong>
               {t('update.migration.letter.choice1Rest')}
@@ -176,7 +176,7 @@ const UpdateMigrationDialog: React.FC = () => {
           <p className='mb-24px'>{t('update.migration.letter.closing')}</p>
           {/* Signature block: right-aligned above a hairline, like a hand-signed letter */}
           <div className='flex justify-end'>
-            <div className='text-right pt-12px border-t border-[var(--border-base)] min-w-160px'>
+            <div className='text-end pt-12px border-t border-[var(--border-base)] min-w-160px'>
               <span className='text-15px' style={LETTER_SERIF}>
                 {t('update.migration.letter.signature')}
               </span>
@@ -187,7 +187,7 @@ const UpdateMigrationDialog: React.FC = () => {
             the fold, so users notice the letter scrolls even without hovering the
             scrollbar. Disappears once they reach the end. */}
         {hasMoreBelow && (
-          <div className='absolute bottom-0 left-0 right-0 h-56px pointer-events-none flex items-end justify-center bg-gradient-to-t from-[var(--dialog-fill-0)] to-transparent'>
+          <div className='absolute bottom-0 start-0 end-0 h-56px pointer-events-none flex items-end justify-center bg-gradient-to-t from-[var(--dialog-fill-0)] to-transparent'>
             <Down theme='outline' size={18} fill='currentColor' className='text-t-secondary animate-bounce mb-4px' />
           </div>
         )}

--- a/packages/desktop/src/renderer/components/settings/UpdateNotificationCard.tsx
+++ b/packages/desktop/src/renderer/components/settings/UpdateNotificationCard.tsx
@@ -53,7 +53,7 @@ const UpdateNotificationCard: React.FC = () => {
         data-mini-status={state.status}
         data-ring-stroke-width='8'
         aria-label={t('update.restoreUpdateNotification')}
-        className='fixed right-24px bottom-24px z-1000 w-52px h-52px rd-full bg-1 shadow-lg flex items-center justify-center cursor-pointer'
+        className='fixed end-24px bottom-24px z-1000 w-52px h-52px rd-full bg-1 shadow-lg flex items-center justify-center cursor-pointer'
         onClick={actions.restore}
       >
         <Progress
@@ -258,7 +258,7 @@ const UpdateNotificationCard: React.FC = () => {
     <>
       <section
         data-testid='update-notification-card'
-        className='fixed right-24px bottom-24px z-1000 w-max min-w-300px max-w-[calc(100vw-32px)] bg-1 border border-border-2 rd-8px shadow-[0_2px_16px_rgba(0,0,0,0.12)] overflow-hidden'
+        className='fixed end-24px bottom-24px z-1000 w-max min-w-300px max-w-[calc(100vw-32px)] bg-1 border border-border-2 rd-8px shadow-[0_2px_16px_rgba(0,0,0,0.12)] overflow-hidden'
       >
         <div className='flex items-center gap-10px px-16px pt-12px pb-6px min-w-0'>
           <Download

--- a/packages/desktop/src/renderer/components/workspace/webFsPicker.tsx
+++ b/packages/desktop/src/renderer/components/workspace/webFsPicker.tsx
@@ -167,7 +167,7 @@ export const WebFsPicker: React.FC<PickerProps> = ({ options, onDone }) => {
               : currentDir}
           </span>
           <span style={{ flexShrink: 0 }}>
-            <Button onClick={() => settle(undefined)} style={{ marginRight: 8 }}>
+            <Button onClick={() => settle(undefined)} style={{ marginInlineEnd: 8 }}>
               {t('common.cancel', { defaultValue: 'Cancel' })}
             </Button>
             <Button type='primary' disabled={confirmDisabled} onClick={handleConfirm}>

--- a/packages/desktop/src/renderer/hooks/ui/useResizableSplit.tsx
+++ b/packages/desktop/src/renderer/hooks/ui/useResizableSplit.tsx
@@ -273,7 +273,7 @@ export const useResizableSplit = (options: UseResizableSplitOptions = {}) => {
 
   return {
     splitRatio,
-    dragHandle: renderHandle({ className: 'right-0' }),
+    dragHandle: renderHandle({ className: 'end-0' }),
     setSplitRatio,
     createDragHandle: renderHandle,
   };

--- a/packages/desktop/src/renderer/main.tsx
+++ b/packages/desktop/src/renderer/main.tsx
@@ -83,6 +83,7 @@ configService.initialize().catch((err) => {
 
 // i18n
 import './services/i18n';
+import { isRtlLanguage } from './services/i18n/direction';
 import { registerPwa } from './services/registerPwa';
 
 import { ipcBridge } from '@/common';
@@ -303,7 +304,11 @@ const Config: React.FC<PropsWithChildren> = ({ children }) => {
   } = useTranslation();
   const arcoLocale = arcoLocales[language] ?? enUS;
 
-  return React.createElement(ConfigProvider, { theme: { primaryColor: '#4E5969' }, locale: arcoLocale }, children);
+  return React.createElement(
+    ConfigProvider,
+    { theme: { primaryColor: '#4E5969' }, locale: arcoLocale, rtl: isRtlLanguage(language) },
+    children
+  );
 };
 
 const Main = () => {

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
@@ -136,7 +136,7 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
     }
 
     return (
-      <span className='absolute right-8px top-1/2 -translate-y-1/2 flex items-center justify-center group-hover:hidden'>
+      <span className='absolute end-8px top-1/2 -translate-y-1/2 flex items-center justify-center group-hover:hidden'>
         <span className='h-8px w-8px rounded-full bg-#2C7FFF shadow-[0_0_0_2px_rgba(44,127,255,0.18)]' />
       </span>
     );
@@ -153,9 +153,9 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
         id={'c-' + conversation.id}
         className={classNames(
           'chat-history__item h-34px rd-8px flex items-center group cursor-pointer relative overflow-hidden shrink-0 conversation-item [&.conversation-item+&.conversation-item]:mt-2px min-w-0 transition-colors',
-          collapsed ? 'justify-center px-0' : 'justify-start gap-8px pr-16px',
+          collapsed ? 'justify-center px-0' : 'justify-start gap-8px pe-16px',
           // dimIcon means this row sits inside a project/cron parent — visually indent the row content while keeping the bg full-width
-          !collapsed && (dimIcon ? 'pl-34px' : 'pl-10px'),
+          !collapsed && (dimIcon ? 'ps-34px' : 'ps-10px'),
           {
             'hover:bg-fill-3': !batchMode && !selected,
             '!bg-fill-3': selected,
@@ -167,7 +167,7 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
       >
         {batchMode && (
           <span
-            className='mr-8px flex-center'
+            className='me-8px flex-center'
             onClick={(event) => {
               event.stopPropagation();
               onToggleChecked(conversation);
@@ -226,7 +226,7 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
         {!batchMode && (
           <div
             className={classNames(
-              'absolute right-8px top-1/2 -translate-y-1/2 items-center justify-end !collapsed-hidden',
+              'absolute end-8px top-1/2 -translate-y-1/2 items-center justify-end !collapsed-hidden',
               {
                 flex: isMobile || menuVisible,
                 'hidden group-hover:flex': !isMobile && !menuVisible,

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.tsx
@@ -371,7 +371,7 @@ const ConversationSearchPopover: React.FC<ConversationSearchPopoverProps> = ({
 
     return (
       <div
-        className='h-full min-h-0 overflow-y-auto overflow-x-hidden pr-4px'
+        className='h-full min-h-0 overflow-y-auto overflow-x-hidden pe-4px'
         onScroll={(event) => {
           const target = event.currentTarget;
           if (target.scrollHeight - target.scrollTop - target.clientHeight < 48) {
@@ -387,7 +387,7 @@ const ConversationSearchPopover: React.FC<ConversationSearchPopoverProps> = ({
                 key={`${item.message_id}-${item.message_created_at}`}
                 type='button'
                 className={classNames(
-                  'conversation-search-modal__result w-full text-left cursor-pointer transition-all duration-150',
+                  'conversation-search-modal__result w-full text-start cursor-pointer transition-all duration-150',
                   'focus:outline-none'
                 )}
                 onClick={() => {
@@ -428,7 +428,7 @@ const ConversationSearchPopover: React.FC<ConversationSearchPopoverProps> = ({
   const hasSearchResults = items.length > 0;
   const useCompactHeight = !debouncedKeyword || (!loading && !hasSearchResults);
   const triggerClassName = fullWidth
-    ? 'conversation-search-trigger-full h-34px w-full p-0 bg-transparent border-none outline-none flex items-center justify-start gap-8px pl-10px pr-8px rd-0.5rem cursor-pointer shrink-0 transition-all group text-t-primary focus:outline-none focus-visible:outline-none'
+    ? 'conversation-search-trigger-full h-34px w-full p-0 bg-transparent border-none outline-none flex items-center justify-start gap-8px ps-10px pe-8px rd-0.5rem cursor-pointer shrink-0 transition-all group text-t-primary focus:outline-none focus-visible:outline-none'
     : 'h-34px w-34px p-0 bg-transparent rd-0.5rem flex items-center justify-center cursor-pointer shrink-0 transition-all border border-solid border-transparent text-t-secondary hover:text-t-primary';
 
   return (

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/index.tsx
@@ -68,7 +68,7 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
           <span className='text-14px text-t-tertiary sider-section-title group-hover/label:text-t-primary transition-colors font-[500] leading-none'>
             {label}
           </span>
-          <span className='ml-2px flex items-center justify-center opacity-0 group-hover/label:opacity-100 transition-opacity text-t-tertiary shrink-0'>
+          <span className='ms-2px flex items-center justify-center opacity-0 group-hover/label:opacity-100 transition-opacity text-t-tertiary shrink-0'>
             <Right
               theme='outline'
               size={12}
@@ -76,7 +76,7 @@ const WorkspaceGroupedHistory: React.FC<WorkspaceGroupedHistoryProps> = ({
             />
           </span>
           {trailing && (
-            <div className='ml-auto' onClick={(e) => e.stopPropagation()}>
+            <div className='ms-auto' onClick={(e) => e.stopPropagation()}>
               {trailing}
             </div>
           )}

--- a/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -758,7 +758,7 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
       {showScrollButton && (
         <>
           {/* Gradient mask */}
-          <div className='absolute bottom-0 left-0 right-0 h-100px pointer-events-none' />
+          <div className='absolute bottom-0 start-0 end-0 h-100px pointer-events-none' />
           {/* Scroll button */}
           <div className='absolute bottom-20px left-50% transform -translate-x-50% z-100'>
             <div

--- a/packages/desktop/src/renderer/pages/conversation/Messages/acp/MessageAcpTerminalOutput.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/acp/MessageAcpTerminalOutput.tsx
@@ -68,7 +68,11 @@ const MessageAcpTerminalOutput: React.FC<{ message: IMessageAcpTerminalOutput }>
   return (
     <Card className='w-full mb-2' size='small' bordered>
       <div className='flex items-center gap-2 mb-2 min-w-0'>
-        <code className='text-13px font-mono text-t-primary truncate flex-1' data-testid='terminal-card-command'>
+        <code
+          dir='ltr'
+          className='text-13px font-mono text-t-primary truncate flex-1'
+          data-testid='terminal-card-command'
+        >
           $ {content.command}
         </code>
         {statusTag}
@@ -82,6 +86,7 @@ const MessageAcpTerminalOutput: React.FC<{ message: IMessageAcpTerminalOutput }>
         <pre
           ref={outputRef}
           data-testid='terminal-card-output'
+          dir='ltr'
           className='bg-1 p-2 rounded text-xs font-mono overflow-x-auto overflow-y-auto max-h-320px whitespace-pre-wrap m-0'
         >
           {content.truncated

--- a/packages/desktop/src/renderer/pages/conversation/Messages/acp/MessageAcpToolCall.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/acp/MessageAcpToolCall.tsx
@@ -165,7 +165,7 @@ const MessageAcpToolCall: React.FC<{ message: IMessageAcpToolCall }> = ({ messag
               <Tooltip content={t('acp.image.download')}>
                 <Button
                   aria-label={t('acp.image.download_aria')}
-                  className='!absolute right-10px top-10px !h-28px !w-28px !p-0 opacity-0 shadow-sm transition-opacity group-hover:opacity-90 focus:opacity-100'
+                  className='!absolute end-10px top-10px !h-28px !w-28px !p-0 opacity-0 shadow-sm transition-opacity group-hover:opacity-90 focus:opacity-100'
                   type='secondary'
                   size='mini'
                   shape='circle'

--- a/packages/desktop/src/renderer/pages/conversation/Messages/acp/MessageAvailableCommands.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/acp/MessageAvailableCommands.tsx
@@ -42,7 +42,7 @@ const MessageAvailableCommands: React.FC<MessageAvailableCommandsProps> = ({ mes
             >
               <div className='p-12px text-13px text-t-secondary'>
                 {command.description}
-                {command.hint && <span className='text-t-tertiary ml-4px'>({command.hint})</span>}
+                {command.hint && <span className='text-t-tertiary ms-4px'>({command.hint})</span>}
               </div>
             </AionCollapse.Item>
           ))}

--- a/packages/desktop/src/renderer/pages/conversation/Messages/anchorRail/MessageAnchorRail.module.css
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/anchorRail/MessageAnchorRail.module.css
@@ -32,8 +32,8 @@
    than compressing its ticks into an unreadable bar. */
 .viewport {
   position: absolute;
-  left: 0;
-  right: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
   pointer-events: auto;
   cursor: pointer;
   overflow: hidden;
@@ -67,7 +67,7 @@
      centre is x=5; the glyph is 11px inside a 16px box, so the box starts at
      5 - 16/2 = -3. Anything less pushes the magnifier right of the column and it
      visibly juts out of the stack. */
-  left: -3px;
+  inset-inline-start: -3px;
   width: 16px;
   height: 16px;
   padding: 0;
@@ -104,7 +104,7 @@
    height; its `height` is set inline from the tick count and the fixed gap. */
 .ticks {
   position: relative;
-  margin-left: 2px;
+  margin-inline-start: 2px;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -148,7 +148,7 @@
    chrome. Non-interactive — the wheel already scrolls. */
 .scrollHint {
   position: absolute;
-  left: 2px;
+  inset-inline-start: 2px;
   width: 6px;
   display: flex;
   flex-direction: column;
@@ -184,7 +184,7 @@
 
 .card {
   position: absolute;
-  left: 36px;
+  inset-inline-start: 36px;
   z-index: 30;
   display: flex;
   flex-direction: column;

--- a/packages/desktop/src/renderer/pages/conversation/Messages/anchorRail/MessageAnchorRail.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/anchorRail/MessageAnchorRail.tsx
@@ -221,7 +221,7 @@ const MessageAnchorRail: React.FC = () => {
   return (
     <div
       ref={setRailNode}
-      className={classNames(styles.rail, 'absolute left-0 top-0 bottom-0 z-20')}
+      className={classNames(styles.rail, 'absolute start-0 top-0 bottom-0 z-20')}
       data-testid='message-anchor-rail'
       aria-label={t('messages.anchorRail.label')}
       role='navigation'

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessagePermission/PermissionRequestPanel.module.css
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessagePermission/PermissionRequestPanel.module.css
@@ -137,7 +137,7 @@
   border: 0;
   border-radius: 0;
   background: transparent;
-  text-align: left;
+  text-align: start;
   transition: background-color 0.16s ease;
 }
 
@@ -158,7 +158,7 @@
 }
 
 .optionButton :global(.arco-btn-loading-icon) {
-  margin-right: 8px;
+  margin-inline-end: 8px;
 }
 
 .optionLabel {

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageThinking.module.css
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageThinking.module.css
@@ -50,7 +50,7 @@
   line-height: 1.7;
   padding: 10px 14px;
   margin-top: 6px;
-  margin-left: 20px;
+  margin-inline-start: 20px;
   background: color-mix(in srgb, var(--aou-1) 50%, #fff);
   border-radius: 8px;
   white-space: pre-wrap;

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageToolGroup.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageToolGroup.tsx
@@ -212,7 +212,7 @@ const ConfirmationDetails: React.FC<{
               );
             })}
           </Radio.Group>
-          <div className='flex justify-start pl-20px'>
+          <div className='flex justify-start ps-20px'>
             <Button type='primary' size='mini' disabled={!selected} onClick={() => onConfirm(selected)}>
               {t('messages.confirm')}
             </Button>
@@ -556,7 +556,7 @@ const MessageToolGroup: React.FC<IMessageToolGroupProps> = ({ message }) => {
               }
               content={
                 <div>
-                  <Tag className={'mr-4px'}>
+                  <Tag className={'me-4px'}>
                     {name}
                     {status === 'Canceled' ? `(${t('messages.canceledExecution')})` : ''}
                   </Tag>

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.css
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.css
@@ -67,7 +67,7 @@
   gap: 8px;
   padding: 10px 14px;
   margin-top: 6px;
-  margin-left: 20px;
+  margin-inline-start: 20px;
   background: color-mix(in srgb, var(--aou-1) 50%, #fff);
   border-radius: 8px;
 }
@@ -77,8 +77,8 @@
 }
 
 .tool-detail-panel {
-  border-left: 2px solid var(--color-border-2, #e5e6eb);
-  padding-left: 10px;
+  border-inline-start: 2px solid var(--color-border-2, #e5e6eb);
+  padding-inline-start: 10px;
   margin-bottom: 4px;
 }
 

--- a/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/components/MessageToolGroupSummary.tsx
@@ -126,7 +126,7 @@ const ToolItemDetail: React.FC<{ item: NormalizedToolCall }> = ({ item }) => {
           <Tooltip content={t('acp.image.download')}>
             <Button
               aria-label={t('acp.image.download_aria')}
-              className='!absolute right-10px top-10px !h-28px !w-28px !p-0 opacity-0 shadow-sm transition-opacity group-hover:opacity-90 focus:opacity-100'
+              className='!absolute end-10px top-10px !h-28px !w-28px !p-0 opacity-0 shadow-sm transition-opacity group-hover:opacity-90 focus:opacity-100'
               type='secondary'
               size='mini'
               shape='circle'

--- a/packages/desktop/src/renderer/pages/conversation/Messages/messages.css
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/messages.css
@@ -14,8 +14,8 @@
   .chat-surface-fluid {
     width: calc(100% - clamp(80px, 10cqw, 240px));
     max-width: none;
-    margin-left: auto;
-    margin-right: auto;
+    margin-inline-start: auto;
+    margin-inline-end: auto;
   }
 }
 

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewPanel.tsx
@@ -815,7 +815,7 @@ const PreviewPanel: React.FC = () => {
                 />
               </div>
               {/* 拖动分割线 / Drag handle */}
-              {createDragHandle({ className: 'absolute right-0 top-0 bottom-0' })}
+              {createDragHandle({ className: 'absolute end-0 top-0 bottom-0' })}
             </div>
 
             {/* 右侧：预览 / Right: Preview */}
@@ -892,7 +892,7 @@ const PreviewPanel: React.FC = () => {
                 />
               </div>
               {/* 拖动分割线 / Drag handle */}
-              {createDragHandle({ className: 'absolute right-0 top-0 bottom-0' })}
+              {createDragHandle({ className: 'absolute end-0 top-0 bottom-0' })}
             </div>
 
             {/* 右侧：预览 / Right: Preview */}

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewTabs.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/PreviewPanel/PreviewTabs.tsx
@@ -250,7 +250,7 @@ const PreviewTabs: React.FC<PreviewTabsProps> = ({
           {/* 新建浏览器 tab / New browser tab */}
           {onNewBrowserTab && (
             <div
-              className='flex items-center justify-center w-24px h-24px ml-4px rd-4px cursor-pointer flex-shrink-0 hover:bg-bg-3 transition-colors'
+              className='flex items-center justify-center w-24px h-24px ms-4px rd-4px cursor-pointer flex-shrink-0 hover:bg-bg-3 transition-colors'
               onClick={onNewBrowserTab}
               title={t('preview.browser.newTab')}
             >
@@ -261,7 +261,7 @@ const PreviewTabs: React.FC<PreviewTabsProps> = ({
 
         {/* 收起面板按钮 / Collapse panel button */}
         {onClosePanel && (
-          <div className='flex items-center h-full px-10px flex-shrink-0 rounded-tr-[16px]'>
+          <div className='flex items-center h-full px-10px flex-shrink-0 rounded-se-[16px]'>
             <div
               className='flex items-center justify-center w-20px h-20px rd-4px cursor-pointer hover:bg-bg-3 transition-colors'
               onClick={onClosePanel}
@@ -276,7 +276,7 @@ const PreviewTabs: React.FC<PreviewTabsProps> = ({
       {/* 左侧渐变指示器 / Left gradient indicator */}
       {showLeftFade && (
         <div
-          className='pointer-events-none absolute left-0 top-0 bottom-0 w-32px rounded-tl-[16px]'
+          className='pointer-events-none absolute start-0 top-0 bottom-0 w-32px rounded-ss-[16px]'
           style={{
             background: 'linear-gradient(90deg, var(--bg-2) 0%, transparent 100%)',
           }}
@@ -286,7 +286,7 @@ const PreviewTabs: React.FC<PreviewTabsProps> = ({
       {/* 右侧渐变指示器 / Right gradient indicator */}
       {showRightFade && (
         <div
-          className='pointer-events-none absolute right-0 top-0 bottom-0 w-32px rounded-tr-[16px]'
+          className='pointer-events-none absolute end-0 top-0 bottom-0 w-32px rounded-se-[16px]'
           style={{
             background: 'linear-gradient(270deg, var(--bg-2) 0%, transparent 100%)',
           }}

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/editors/CodeEditor.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/editors/CodeEditor.tsx
@@ -191,9 +191,9 @@ const CodeEditor: React.FC<CodeEditorProps> = ({
   const editorStyle = useMemo(() => ({ height: '100%', textAlign: 'left' as const }), []);
 
   return (
-    <div ref={containerRef} className='relative h-full w-full overflow-auto text-left'>
+    <div ref={containerRef} className='relative h-full w-full overflow-auto text-start'>
       {isStreaming && (
-        <div className='absolute right-12px top-8px z-2 flex items-center px-8px py-2px rd-4px bg-bg-3 text-11px text-t-secondary pointer-events-none'>
+        <div className='absolute end-12px top-8px z-2 flex items-center px-8px py-2px rd-4px bg-bg-3 text-11px text-t-secondary pointer-events-none'>
           {t('preview.aiWriting')}
         </div>
       )}

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/DiffViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/DiffViewer.tsx
@@ -189,7 +189,7 @@ const DiffPreview: React.FC<DiffPreviewProps> = ({
             className={classNames(
               'w-full max-w-full min-w-0',
               '![&_.line-num1]:hidden ![&_.line-num2]:w-30px',
-              '[&_td:first-child]:w-40px ![&_td:nth-child(2)>div]:pl-45px',
+              '[&_td:first-child]:w-40px ![&_td:nth-child(2)>div]:ps-45px',
               '[&_div.d2h-file-wrapper]:rd-[0.3rem_0.3rem_0px_0px]',
               '[&_div.d2h-file-header]:items-center [&_div.d2h-file-header]:bg-bg-3',
               {

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/HTMLViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/HTMLViewer.tsx
@@ -341,7 +341,7 @@ const HTMLPreview: React.FC<HTMLPreviewProps> = ({ content, file_path, hideToolb
 
             {/* 选中的元素路径 */}
             {selectedElement && (
-              <div className='text-12px text-t-secondary ml-8px'>
+              <div className='text-12px text-t-secondary ms-8px'>
                 {t('preview.html.selectedLabel')} <code className='bg-bg-3 px-4px rd-2px'>{selectedElement.path}</code>
               </div>
             )}
@@ -377,7 +377,7 @@ const HTMLPreview: React.FC<HTMLPreviewProps> = ({ content, file_path, hideToolb
       <div className='flex-1 flex overflow-hidden'>
         {/* 左侧：代码编辑器（编辑模式时显示） */}
         {editMode && (
-          <div className='flex-1 overflow-hidden border-r border-border-base'>
+          <div className='flex-1 overflow-hidden border-e border-border-base'>
             <MonacoEditor
               height='100%'
               language='html'

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/OfficeWatchViewer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/viewers/OfficeWatchViewer.tsx
@@ -274,7 +274,7 @@ const OfficeWatchViewer: React.FC<OfficeWatchViewerProps> = ({ docType, fileRef,
           <div className='text-16px text-danger mb-8px'>{error.message}</div>
           {!error.code && <div className='text-12px text-t-secondary mb-12px'>{t(keys.installHint)}</div>}
           {showServerInstallGuide && (
-            <div className='text-left mb-12px'>
+            <div className='text-start mb-12px'>
               <div className='text-12px text-t-secondary mb-8px'>{t('preview.office.serverInstall.hint')}</div>
               <code className='block select-all rounded-8px bg-2 px-10px py-8px text-12px text-t-primary'>
                 {OFFICECLI_SERVER_INSTALL_COMMAND}

--- a/packages/desktop/src/renderer/pages/conversation/SourceControl/ScmChangesView.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/SourceControl/ScmChangesView.tsx
@@ -140,7 +140,7 @@ const TreeNode: React.FC<{
       <div
         data-scm-tree-dir={node.key}
         className='flex items-center gap-4px px-8px py-3px rd-4px cursor-pointer hover:bg-2 min-w-0'
-        style={{ paddingLeft: 8 + depth * INDENT_STEP }}
+        style={{ paddingInlineStart: 8 + depth * INDENT_STEP }}
         onClick={() => onToggleDir(node.key)}
         role='button'
         aria-expanded={isOpen}

--- a/packages/desktop/src/renderer/pages/conversation/SourceControl/ScmPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/SourceControl/ScmPanel.tsx
@@ -284,7 +284,7 @@ const ScmSectionStack: React.FC<{
   );
 
   const changesBody = (
-    <div className='flex-1 min-h-0 overflow-auto pl-4px pr-4px pb-8px'>
+    <div className='flex-1 min-h-0 overflow-auto ps-4px pe-4px pb-8px'>
       <ScmChangesView
         repo={selectedRepo}
         status={view.statuses[selectedRepo.repo_id]}
@@ -543,19 +543,19 @@ const RepoRow: React.FC<{
     className={`flex items-center gap-6px px-8px py-3px rd-4px cursor-pointer hover:bg-2 min-w-0 ${
       isSelected ? 'bg-2' : ''
     }`}
-    style={indent ? { paddingLeft: 8 + indent } : undefined}
+    style={indent ? { paddingInlineStart: 8 + indent } : undefined}
   >
     {leading}
     <span className='flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-13px text-t-primary'>
       {repo.pe_name || repo.label}
     </span>
-    {/* Branch info is pinned to the right of the row (`ml-auto`), the branch
+    {/* Branch info is pinned to the right of the row (`ms-auto`), the branch
         name preceded by a branch glyph. `flex-1` on the repo name above
         claims the slack so the two never touch; both truncate under pressure.
         Rendered only when a head name is known — a detached/unknown head
         shows nothing rather than a lone icon. */}
     {repo.head?.name && (
-      <span className='ml-auto flex items-center gap-2px min-w-0 flex-shrink text-t-tertiary text-12px'>
+      <span className='ms-auto flex items-center gap-2px min-w-0 flex-shrink text-t-tertiary text-12px'>
         <BranchTwo theme='outline' size='12' className='flex-shrink-0' />
         <span className='overflow-hidden text-ellipsis whitespace-nowrap'>{repo.head.name}</span>
       </span>

--- a/packages/desktop/src/renderer/pages/conversation/SourceControl/ScmResourceRow.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/SourceControl/ScmResourceRow.tsx
@@ -236,7 +236,7 @@ export const ScmResourceRow: React.FC<ScmResourceRowProps> = ({
       className={`group flex items-center gap-6px px-8px py-3px rd-4px cursor-pointer hover:bg-2 min-w-0 ${
         selected ? 'bg-2' : ''
       }`}
-      style={indent ? { paddingLeft: 8 + indent } : undefined}
+      style={indent ? { paddingInlineStart: 8 + indent } : undefined}
       title={hint ?? resource.repo_relative_path}
     >
       <span
@@ -263,7 +263,7 @@ export const ScmResourceRow: React.FC<ScmResourceRowProps> = ({
         </span>
       )}
       {actionable && (
-        <span className='flex items-center flex-shrink-0 ml-auto'>
+        <span className='flex items-center flex-shrink-0 ms-auto'>
           {canDiscard && actionButton('discard', <Undo theme='outline' size='13' />)}
           {stagingActions &&
             (resource.staged === true

--- a/packages/desktop/src/renderer/pages/conversation/SourceControl/ScmSection.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/SourceControl/ScmSection.tsx
@@ -68,7 +68,7 @@ export const ScmSection: React.FC<ScmSectionProps> = ({
         <span className='text-13px font-600 uppercase tracking-wide text-t-secondary truncate'>{title}</span>
         {badge != null && <span className='text-12px text-t-tertiary flex-shrink-0'>{badge}</span>}
         {actions != null && (
-          <span className='ml-auto flex items-center gap-2px' onClick={(e) => e.stopPropagation()}>
+          <span className='ms-auto flex items-center gap-2px' onClick={(e) => e.stopPropagation()}>
             {actions}
           </span>
         )}
@@ -120,7 +120,7 @@ export const ScmSectionDivider: React.FC<{
       role='separator'
       aria-orientation='horizontal'
     >
-      <div className='absolute left-0 right-0 -top-3px h-7px' />
+      <div className='absolute start-0 end-0 -top-3px h-7px' />
     </div>
   );
 };

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatHistory.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatHistory.tsx
@@ -207,7 +207,7 @@ const ChatHistory: React.FC<{ onSessionClick?: () => void; collapsed?: boolean }
           onClick={handleSelect.bind(null, conversation)}
         >
           <MessageOne theme='outline' size='20' className='mt-2px flex' />
-          <FlexFullContainer className='h-24px collapsed-hidden ml-10px min-w-0'>
+          <FlexFullContainer className='h-24px collapsed-hidden ms-10px min-w-0'>
             {isEditing ? (
               <Input
                 className='chat-history__item-editor text-14px lh-24px h-24px w-full'
@@ -230,7 +230,7 @@ const ChatHistory: React.FC<{ onSessionClick?: () => void; collapsed?: boolean }
           {!isEditing && (
             <div
               className={classNames(
-                'absolute right-0px top-0px h-full w-70px items-center justify-end hidden group-hover:flex !collapsed-hidden pr-12px'
+                'absolute end-0px top-0px h-full w-70px items-center justify-end hidden group-hover:flex !collapsed-hidden pe-12px'
               )}
               style={{
                 backgroundImage: isSelected
@@ -243,7 +243,7 @@ const ChatHistory: React.FC<{ onSessionClick?: () => void; collapsed?: boolean }
             >
               {!isEditing && (
                 <span
-                  className='flex-center mr-8px'
+                  className='flex-center me-8px'
                   onClick={(event) => {
                     event.stopPropagation();
                     handleEditStart(conversation);

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/WorkspaceOpenButton.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/WorkspaceOpenButton.tsx
@@ -194,7 +194,7 @@ const WorkspaceOpenButton: React.FC<WorkspaceOpenButtonProps> = ({ workspacePath
           >
             <span className='flex items-center justify-center w-20px h-20px'>{option.icon}</span>
             <span className='text-14px'>{option.label}</span>
-            {currentTool === option.key && <span className='ml-auto text-12px text-[var(--color-text-3)]'>✓</span>}
+            {currentTool === option.key && <span className='ms-auto text-12px text-[var(--color-text-3)]'>✓</span>}
           </div>
         </React.Fragment>
       ))}
@@ -207,7 +207,7 @@ const WorkspaceOpenButton: React.FC<WorkspaceOpenButtonProps> = ({ workspacePath
         <Button
           type='text'
           size='small'
-          className='workspace-open-button__btn flex items-center gap-4px pl-8px pr-4px'
+          className='workspace-open-button__btn flex items-center gap-4px ps-8px pe-4px'
           onClick={() => handleOpenWith(currentTool)}
         >
           {currentIcon}
@@ -224,8 +224,8 @@ const WorkspaceOpenButton: React.FC<WorkspaceOpenButtonProps> = ({ workspacePath
         <Button
           type='text'
           size='small'
-          className='workspace-open-button__dropdown-btn pl-2px pr-4px'
-          style={{ marginLeft: '-4px' }}
+          className='workspace-open-button__dropdown-btn ps-2px pe-4px'
+          style={{ marginInlineStart: '-4px' }}
         >
           <Down size={12} className={`transition-transform duration-200 ${dropdownOpen ? 'rotate-180' : ''}`} />
         </Button>

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/WorkspacePanelHeader.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/WorkspacePanelHeader.tsx
@@ -35,7 +35,7 @@ const WorkspacePanelHeader: React.FC<WorkspaceHeaderProps> = ({
     {showToggle && togglePlacement === 'left' && (
       <button
         type='button'
-        className='workspace-header__toggle mr-4px'
+        className='workspace-header__toggle me-4px'
         aria-label='Toggle workspace'
         onClick={onToggle}
       >

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/chat-layout.css
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/chat-layout.css
@@ -19,8 +19,8 @@
 .chat-layout-header--glass::after {
   content: '';
   position: absolute;
-  left: 0;
-  right: 0;
+  inset-inline-start: 0;
+  inset-inline-end: 0;
   bottom: -12px;
   height: 12px;
   pointer-events: none;
@@ -88,6 +88,6 @@
   }
 
   .chat-header-cron-pill {
-    margin-right: 4px;
+    margin-inline-end: 4px;
   }
 }

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatLayout/index.tsx
@@ -325,7 +325,7 @@ const ChatLayout: React.FC<{
           >
             {isDesktop &&
               !rightSiderCollapsed &&
-              createWorkspaceDragHandle({ className: 'absolute left-0 top-0 bottom-0', style: {}, reverse: true })}
+              createWorkspaceDragHandle({ className: 'absolute start-0 top-0 bottom-0', style: {}, reverse: true })}
             <WorkspacePanelHeader
               collapsed={rightSiderCollapsed}
               onToggle={() => dispatchWorkspaceToggleEvent()}

--- a/packages/desktop/src/renderer/pages/conversation/components/ChatTitleEditor.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatTitleEditor.tsx
@@ -45,7 +45,7 @@ const ChatTitleEditor: React.FC<ChatTitleEditorProps> = ({
       )}
       style={{ width: '100%', maxWidth: `${titleAreaMaxWidth}px` }}
     >
-      {leading && <div className='shrink-0 flex items-center pl-8px'>{leading}</div>}
+      {leading && <div className='shrink-0 flex items-center ps-8px'>{leading}</div>}
       <div className='min-w-0 flex-1 px-8px py-5px'>
         {editingTitle && canRenameTitle ? (
           <Input
@@ -105,7 +105,7 @@ const ChatTitleEditor: React.FC<ChatTitleEditorProps> = ({
       {!editingTitle && (
         <div className='w-0 flex items-center overflow-hidden opacity-0 transition-all duration-180 group-hover:w-40px group-hover:opacity-100 group-focus-within:w-40px group-focus-within:opacity-100'>
           <span className='h-16px w-1px shrink-0 rounded-full bg-[color:color-mix(in_srgb,var(--color-text-4)_44%,transparent)]' />
-          <div className='ml-4px mr-4px flex items-center justify-center'>
+          <div className='ms-4px me-4px flex items-center justify-center'>
             <ConversationTitleMinimap conversation_id={conversation_id} />
           </div>
         </div>

--- a/packages/desktop/src/renderer/pages/conversation/components/ConversationTitleMinimap/ConversationTitleMinimap.module.css
+++ b/packages/desktop/src/renderer/pages/conversation/components/ConversationTitleMinimap/ConversationTitleMinimap.module.css
@@ -53,8 +53,8 @@
   border-radius: 0;
   background: transparent;
   box-shadow: none;
-  padding-left: 11px;
-  padding-right: 11px;
+  padding-inline-start: 11px;
+  padding-inline-end: 11px;
   overflow: hidden;
 }
 
@@ -79,7 +79,7 @@
   line-height: 1.4;
   background: transparent;
   box-shadow: none;
-  padding-right: 0;
+  padding-inline-end: 0;
 }
 
 .searchInput :global(.arco-input::placeholder) {

--- a/packages/desktop/src/renderer/pages/conversation/components/ConversationTitleMinimap/index.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ConversationTitleMinimap/index.tsx
@@ -157,7 +157,7 @@ const ConversationTitleMinimap: React.FC<ConversationTitleMinimapProps> = ({
         >
           <div
             className='conversation-minimap-body h-full overflow-y-auto overflow-x-hidden box-border'
-            style={{ paddingRight: '14px', scrollbarGutter: 'stable' }}
+            style={{ paddingInlineEnd: '14px', scrollbarGutter: 'stable' }}
           >
             <div className='conversation-minimap-list flex flex-col gap-6px'>
               {filteredItems.map((item, idx) => (
@@ -167,7 +167,7 @@ const ConversationTitleMinimap: React.FC<ConversationTitleMinimapProps> = ({
                   data-minimap-item-index={idx}
                   aria-selected={activeResultIndex === idx}
                   className={classNames(
-                    'conversation-minimap-item w-full text-left px-12px py-10px border-none rounded-10px hover:bg-fill-2 transition-colors cursor-pointer block',
+                    'conversation-minimap-item w-full text-start px-12px py-10px border-none rounded-10px hover:bg-fill-2 transition-colors cursor-pointer block',
                     isSearchMode && activeResultIndex === idx ? 'bg-fill-2' : 'bg-transparent'
                   )}
                   onMouseEnter={() => {

--- a/packages/desktop/src/renderer/pages/conversation/components/WorkspaceCollapse.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/WorkspaceCollapse.tsx
@@ -58,7 +58,7 @@ const WorkspaceCollapse: React.FC<WorkspaceCollapseProps> = ({
           style={stickyEnabled ? { top: stickyTop ?? 0 } : undefined}
         >
           <div
-            className='flex items-center gap-8px h-34px pl-10px pr-8px cursor-pointer hover:bg-fill-3 rd-8px transition-colors min-w-0 group'
+            className='flex items-center gap-8px h-34px ps-10px pe-8px cursor-pointer hover:bg-fill-3 rd-8px transition-colors min-w-0 group'
             onClick={onToggle}
           >
             <span className='size-22px flex items-center justify-center shrink-0 text-t-primary'>

--- a/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerContainer.tsx
@@ -402,7 +402,7 @@ export const ExplorerContainer: React.FC<ExplorerContainerProps> = ({ projectId 
           text / search icon / tree arrow) starts at 20px. 12px is not arbitrary —
           the sider's resize handle covers the leftmost 12px and sits above this
           content, so anything placed to its left cannot be clicked. */}
-      <div className='flex items-center gap-4px pl-12px pr-8px py-4px flex-shrink-0 border-b border-[var(--bg-3)]'>
+      <div className='flex items-center gap-4px ps-12px pe-8px py-4px flex-shrink-0 border-b border-[var(--bg-3)]'>
         <div className='flex items-center gap-2px overflow-x-auto flex-1 min-w-0'>
           {tabButton('files', t('conversation.explorer.tabs.files'))}
           {tabButton('changes', t('conversation.explorer.tabs.changes'))}

--- a/packages/desktop/src/renderer/pages/conversation/explorer/search/SearchPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/search/SearchPanel.tsx
@@ -87,22 +87,22 @@ export const SearchPanel: React.FC<SearchPanelProps> = ({ roots, peNames, onReve
   return (
     <div className='h-full flex flex-col min-h-0'>
       {/* pt-8px 让搜索框跟上方 tab 栏那条分割线拉开距离，不再贴着它。
-          pl-12px 把输入框外框对到面板基准线；输入框自带 12px 内边距会把里面的放大镜
-          推到 24px，用 !pl-8px 收成 8px，图标正好落在 20px —— 与 tab 文字、树箭头
+          ps-12px 把输入框外框对到面板基准线；输入框自带 12px 内边距会把里面的放大镜
+          推到 24px，用 !ps-8px 收成 8px，图标正好落在 20px —— 与 tab 文字、树箭头
           同一条线（见 ExplorerContainer.tsx 的基准线说明）。
 
           pt-8px lifts the box off the tab bar's bottom border instead of touching it.
-          pl-12px puts the input's outer border on the panel baseline; the input's own
-          12px inner padding would push the magnifier to 24px, so !pl-8px trims it to
+          ps-12px puts the input's outer border on the panel baseline; the input's own
+          12px inner padding would push the magnifier to 24px, so !ps-8px trims it to
           8px and lands the icon at 20px — the same line as the tab text and the tree
           arrow (see the baseline note in ExplorerContainer.tsx). */}
-      <div className='flex-shrink-0 pl-12px pr-8px pt-8px pb-4px'>
+      <div className='flex-shrink-0 ps-12px pe-8px pt-8px pb-4px'>
         <Input
           value={query}
           onChange={onQueryChange}
           allowClear
           size='small'
-          className='[&_.arco-input-inner-wrapper]:!pl-8px'
+          className='[&_.arco-input-inner-wrapper]:!ps-8px'
           prefix={<Search theme='outline' size='14' />}
           placeholder={t('conversation.explorer.search.placeholder')}
           aria-label={t('conversation.explorer.search.placeholder')}
@@ -114,22 +114,22 @@ export const SearchPanel: React.FC<SearchPanelProps> = ({ roots, peNames, onReve
           showing the tree (never a blank pane) even though our query is non-empty
           — the user re-owns by typing in the box again.
 
-          pl-12px 把树的行外框放到面板基准线上；行内箭头再由 arco-override.css 的
+          ps-12px 把树的行外框放到面板基准线上；行内箭头再由 arco-override.css 的
           .workspace-tree 规则补 8px，落到 20px。
-          pl-12px puts the tree's row boxes on the panel baseline; the arrow inside
+          ps-12px puts the tree's row boxes on the panel baseline; the arrow inside
           is then offset a further 8px by the .workspace-tree rules in
           arco-override.css, landing at 20px. */}
-      <div className='flex-1 min-h-0 overflow-auto pl-12px' style={active && owned ? { display: 'none' } : undefined}>
+      <div className='flex-1 min-h-0 overflow-auto ps-12px' style={active && owned ? { display: 'none' } : undefined}>
         {children}
       </div>
 
       {active && owned && (
-        // pl-4px + 行自身 px-8px = 12px，与树、搜索框外框同一条基准线，
+        // ps-4px + 行自身 px-8px = 12px，与树、搜索框外框同一条基准线，
         // 这样输入时结果列表顶掉树的一刻不会横向跳动。
-        // pl-4px plus each row's own px-8px lands on the same 12px baseline as the
+        // ps-4px plus each row's own px-8px lands on the same 12px baseline as the
         // tree and the search box, so the list replacing the tree as you type does
         // not shift sideways.
-        <div className='flex-1 min-h-0 overflow-auto pl-4px pr-4px'>
+        <div className='flex-1 min-h-0 overflow-auto ps-4px pe-4px'>
           {showSearching && (
             <div className='px-8px py-6px text-t-secondary text-13px'>
               {t('conversation.explorer.search.searching')}

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/CreateTaskDialog.tsx
@@ -711,7 +711,7 @@ const CreateTaskDialog: React.FC<CreateTaskDialogProps> = ({
                     value={option.value}
                     className={`m-0 min-w-0 text-14px text-t-secondary ${isExecutionModeLocked ? 'cursor-not-allowed' : 'cursor-pointer'}`}
                   >
-                    <span className='pl-4px text-14px font-medium text-t-primary'>{option.label}</span>
+                    <span className='ps-4px text-14px font-medium text-t-primary'>{option.label}</span>
                   </Radio>
                 );
               })}

--- a/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
+++ b/packages/desktop/src/renderer/pages/cron/ScheduledTasksPage/TaskDetailPage.tsx
@@ -481,7 +481,7 @@ const TaskDetailPage: React.FC = () => {
                 <div className='text-14px text-t-secondary'>
                   <span>{t('cron.detail.noHistory')}</span>
                   {job.enabled && job.state.next_run_at_ms && (
-                    <span className='ml-4px'>
+                    <span className='ms-4px'>
                       · {t('cron.nextRun')} {formatNextRun(job.state.next_run_at_ms, i18n.language)}
                     </span>
                   )}

--- a/packages/desktop/src/renderer/pages/cron/components/CronJobManager.tsx
+++ b/packages/desktop/src/renderer/pages/cron/components/CronJobManager.tsx
@@ -114,7 +114,7 @@ const CronJobManager: React.FC<CronJobManagerProps> = ({ conversation_id, cron_j
         >
           <AlarmClock theme='outline' size={16} fill={iconColors.primary} />
           <span
-            className={`ml-4px w-8px h-8px rounded-full ${hasError ? 'bg-[#f53f3f]' : isPaused ? 'bg-[#ff7d00]' : 'bg-[#00b42a]'}`}
+            className={`ms-4px w-8px h-8px rounded-full ${hasError ? 'bg-[#f53f3f]' : isPaused ? 'bg-[#ff7d00]' : 'bg-[#00b42a]'}`}
           />
         </span>
       </Button>

--- a/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
+++ b/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
@@ -702,8 +702,8 @@ const GuidPage: React.FC = () => {
           />
 
           {selectedAssistantPrompts.length > 0 ? (
-            <div className='mt-18px w-full animate-fade-in pl-20px'>
-              <div className={`${styles.assistantPromptHint} mb-10px text-left`}>
+            <div className='mt-18px w-full animate-fade-in ps-20px'>
+              <div className={`${styles.assistantPromptHint} mb-10px text-start`}>
                 {t('guid.promptExamplesHint', { defaultValue: 'Try these example prompts:' })}
               </div>
               <div className='flex flex-col gap-9px'>
@@ -711,7 +711,7 @@ const GuidPage: React.FC = () => {
                   <Button
                     key={`${index}-${prompt}`}
                     type='text'
-                    className='group !h-auto !w-full !border-none !bg-transparent !px-0 !py-6px !text-left !text-12.5px !text-t-secondary !whitespace-normal !break-words transition-colors hover:!bg-transparent hover:!text-t-primary'
+                    className='group !h-auto !w-full !border-none !bg-transparent !px-0 !py-6px !text-start !text-12.5px !text-t-secondary !whitespace-normal !break-words transition-colors hover:!bg-transparent hover:!text-t-primary'
                     onClick={() => {
                       guidInput.setInput(prompt);
                       guidInput.handleTextareaFocus();
@@ -721,7 +721,7 @@ const GuidPage: React.FC = () => {
                     <ArrowRightUp
                       theme='outline'
                       size='13'
-                      className='ml-6px inline-flex flex-shrink-0 align-[-1px] text-t-primary opacity-0 transition-opacity group-hover:opacity-100'
+                      className='ms-6px inline-flex flex-shrink-0 align-[-1px] text-t-primary opacity-0 transition-opacity group-hover:opacity-100'
                     />
                   </Button>
                 ))}

--- a/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/AssistantSelectionArea.tsx
@@ -266,7 +266,7 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
     <div
       data-testid='assistant-overflow-panel'
       data-overflow-columns={overflowColumns}
-      className={`absolute left-0 top-[calc(100%+8px)] z-100 w-full rounded-12px border border-border-2 p-8px shadow-lg ${styles.assistantOverflowPanel}`}
+      className={`absolute start-0 top-[calc(100%+8px)] z-100 w-full rounded-12px border border-border-2 p-8px shadow-lg ${styles.assistantOverflowPanel}`}
       style={{ background: 'var(--bg-base, #fff)' }}
     >
       {showOverflowSearch ? (
@@ -308,7 +308,7 @@ const AssistantSelectionArea: React.FC<AssistantSelectionAreaProps> = ({
               <Button
                 data-testid='assistant-more-btn'
                 type='text'
-                className={`!ml-6px !inline-flex !h-34px !shrink-0 !items-center !gap-4px !rounded-999px !border-none !px-12px !py-8px !text-13px !text-t-secondary opacity-75 transition-opacity hover:opacity-100 ${styles.assistantSelectorInactive}`}
+                className={`!ms-6px !inline-flex !h-34px !shrink-0 !items-center !gap-4px !rounded-999px !border-none !px-12px !py-8px !text-13px !text-t-secondary opacity-75 transition-opacity hover:opacity-100 ${styles.assistantSelectorInactive}`}
                 onClick={() => setMoreVisible((visible) => !visible)}
               >
                 <span>{t('common.more', { defaultValue: 'More' })}</span>

--- a/packages/desktop/src/renderer/pages/guid/components/GuidInputCard.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/GuidInputCard.tsx
@@ -128,7 +128,7 @@ const GuidInputCard: React.FC<GuidInputCardProps> = ({
           autoSize={textareaAutoSize}
           placeholder={placeholder}
           spellCheck={false}
-          className={`text-14px focus:b-none rounded-xl !bg-transparent !b-none !resize-none !py-0 !pr-0 !pl-7px ${styles.lightPlaceholder}`}
+          className={`text-14px focus:b-none rounded-xl !bg-transparent !b-none !resize-none !py-0 !pe-0 !ps-7px ${styles.lightPlaceholder}`}
           value={input}
           onChange={onInputChange}
           onPaste={onPaste}
@@ -148,9 +148,7 @@ const GuidInputCard: React.FC<GuidInputCardProps> = ({
         )}
         <UploadProgressBar source='sendbox' />
         {actionRow}
-        {slashCommandMenu && (
-          <div className='absolute left-0 right-0 top-[calc(100%+4px)] z-70'>{slashCommandMenu}</div>
-        )}
+        {slashCommandMenu && <div className='absolute start-0 end-0 top-[calc(100%+4px)] z-70'>{slashCommandMenu}</div>}
       </div>
       <GuidWorkspaceFootnote
         workspaceDir={workspaceDir}

--- a/packages/desktop/src/renderer/pages/guid/components/GuidWorkspaceFootnote.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/GuidWorkspaceFootnote.tsx
@@ -173,7 +173,7 @@ const GuidWorkspaceFootnote: React.FC<GuidWorkspaceFootnoteProps> = ({
                     stroke='currentColor'
                     strokeWidth='2.5'
                     viewBox='0 0 24 24'
-                    style={{ marginLeft: 'auto', flexShrink: 0 }}
+                    style={{ marginInlineStart: 'auto', flexShrink: 0 }}
                   >
                     <path d='M20 6L9 17l-5-5' />
                   </svg>

--- a/packages/desktop/src/renderer/pages/guid/components/SkillsMarketBanner.tsx
+++ b/packages/desktop/src/renderer/pages/guid/components/SkillsMarketBanner.tsx
@@ -68,7 +68,7 @@ const SkillsMarketBanner: React.FC = () => {
 
   return (
     <div
-      className='absolute right-12px z-10'
+      className='absolute end-12px z-10'
       style={{ top: 'calc(12px + env(safe-area-inset-top, 0px))' }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}

--- a/packages/desktop/src/renderer/pages/guid/index.module.css
+++ b/packages/desktop/src/renderer/pages/guid/index.module.css
@@ -63,7 +63,7 @@
   display: inline-flex;
   align-items: center;
   flex: 0 0 auto;
-  margin-right: 0;
+  margin-inline-end: 0;
 }
 
 /* 方案E：模型 + 权限各自独立 tb-btn，中间有竖线分隔 */
@@ -128,7 +128,7 @@
   align-items: center;
   gap: 6px;
   flex-shrink: 0;
-  margin-left: auto;
+  margin-inline-start: auto;
   min-width: 0;
 }
 
@@ -212,7 +212,7 @@
   justify-content: center;
   width: 18px;
   height: 18px;
-  margin-right: 2px;
+  margin-inline-end: 2px;
   border: none;
   background: transparent;
   cursor: pointer;
@@ -392,7 +392,7 @@
   }
 
   .actionEntry {
-    margin-right: 0;
+    margin-inline-end: 0;
   }
 
   .actionConfigGroup {
@@ -404,13 +404,13 @@
   }
 
   .actionConfigGroupWithDivider > :first-child::after {
-    right: -6px;
+    inset-inline-end: -6px;
     height: 16px;
   }
 
   .actionSubmit {
     flex-shrink: 0;
-    margin-left: 8px;
+    margin-inline-start: 8px;
   }
 }
 

--- a/packages/desktop/src/renderer/pages/login/LoginPage.css
+++ b/packages/desktop/src/renderer/pages/login/LoginPage.css
@@ -31,7 +31,7 @@ body.login-page-active {
   width: 500px;
   height: 500px;
   top: -250px;
-  left: -250px;
+  inset-inline-start: -250px;
   animation-delay: 0s;
 }
 
@@ -39,7 +39,7 @@ body.login-page-active {
   width: 350px;
   height: 350px;
   bottom: -175px;
-  right: -175px;
+  inset-inline-end: -175px;
   animation-delay: 5s;
 }
 
@@ -47,7 +47,7 @@ body.login-page-active {
   width: 250px;
   height: 250px;
   top: 50%;
-  right: 10%;
+  inset-inline-end: 10%;
   animation-delay: 10s;
 }
 
@@ -198,7 +198,7 @@ body.login-page-active {
 
 .login-page__input-icon {
   position: absolute;
-  left: 14px;
+  inset-inline-start: 14px;
   width: 16px;
   height: 16px;
   color: #999;
@@ -228,7 +228,7 @@ body.login-page-active {
 
 .login-page__toggle-password {
   position: absolute;
-  right: 14px;
+  inset-inline-end: 14px;
   width: 18px;
   height: 18px;
   padding: 0;

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentCard.tsx
@@ -159,7 +159,7 @@ const AgentCard: React.FC<AgentCardProps> = (props) => {
         </div>
       </div>
 
-      <div className='ml-12px flex flex-shrink-0 items-center gap-8px' onClick={stop}>
+      <div className='ms-12px flex flex-shrink-0 items-center gap-8px' onClick={stop}>
         <BoundAssistantStack assistants={boundAssistants} />
         <Button
           data-testid={`agent-row-test-${agent.id}`}

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentHubModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentHubModal.tsx
@@ -94,7 +94,7 @@ export const AgentHubModal: React.FC<AgentHubModalProps> = ({ visible, onCancel 
       style={{ width: 1000, maxWidth: '96vw' }}
     >
       <div>
-        <div className='mb-12px flex flex-wrap items-center justify-start gap-x-6px gap-y-2px text-left'>
+        <div className='mb-12px flex flex-wrap items-center justify-start gap-x-6px gap-y-2px text-start'>
           <Typography.Text type='secondary' className='text-12px leading-18px text-t-secondary'>
             {t('settings.agentManagement.marketContributionHint', {
               defaultValue: 'Want a new Agent listed here?',

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentRepairPage.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentRepairPage.tsx
@@ -141,7 +141,7 @@ const AgentRepairPage: React.FC = () => {
             <Typography.Text className='mb-8px block text-13px font-medium text-t-primary'>
               {t('settings.agentManagement.boundAssistantsTitle')}
               {boundAssistants.length > 0 ? (
-                <span className='ml-4px text-t-tertiary'>{`（${boundAssistants.length}）`}</span>
+                <span className='ms-4px text-t-tertiary'>{`（${boundAssistants.length}）`}</span>
               ) : null}
             </Typography.Text>
             <BoundAssistantList assistants={boundAssistants} onOpenAssistant={handleOpenAssistant} />

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentRepairPanel.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/AgentRepairPanel.tsx
@@ -229,7 +229,7 @@ const AgentRepairPanel: React.FC<AgentRepairPanelProps> = ({ agent, onSaved }) =
         <Typography.Text className='block text-11px font-medium text-t-secondary'>
           {t('settings.repair.envScenariosTitle')}
         </Typography.Text>
-        <ul className='my-4px pl-16px text-11px leading-18px text-t-tertiary'>
+        <ul className='my-4px ps-16px text-11px leading-18px text-t-tertiary'>
           <li>{t('settings.repair.envScenarioApiKey')}</li>
           <li>{t('settings.repair.envScenarioBaseUrl')}</li>
           <li>{t('settings.repair.envScenarioProxy')}</li>

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/BoundAssistants.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/BoundAssistants.tsx
@@ -60,7 +60,7 @@ export const BoundAssistantStack: React.FC<{ assistants: Assistant[]; max?: numb
           <div
             key={assistant.id}
             className='overflow-hidden rounded-full border-2 border-solid border-bg-2'
-            style={{ marginLeft: index === 0 ? 0 : -7, zIndex: shown.length - index }}
+            style={{ marginInlineStart: index === 0 ? 0 : -7, zIndex: shown.length - index }}
           >
             <AssistantAvatar assistant={assistant} size={22} />
           </div>
@@ -68,7 +68,7 @@ export const BoundAssistantStack: React.FC<{ assistants: Assistant[]; max?: numb
         {overflow > 0 && (
           <div
             className='flex items-center justify-center rounded-full border-2 border-solid border-bg-2 bg-fill-3 text-9px font-600 text-t-secondary'
-            style={{ width: 22, height: 22, marginLeft: -7 }}
+            style={{ width: 22, height: 22, marginInlineStart: -7 }}
           >
             +{overflow}
           </div>

--- a/packages/desktop/src/renderer/pages/settings/AppearanceSettings/CssThemeSettings.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AppearanceSettings/CssThemeSettings.tsx
@@ -149,7 +149,7 @@ const ThemeLayoutPreview: React.FC<{ palette: ThemePreviewPalette }> = ({ palett
     <div className='absolute inset-0 pointer-events-none'>
       <div className='absolute inset-0' style={{ background: palette.appBg }} />
       <div
-        className='absolute left-8px right-8px top-8px bottom-8px rounded-8px overflow-hidden border border-solid'
+        className='absolute start-8px end-8px top-8px bottom-8px rounded-8px overflow-hidden border border-solid'
         style={{ borderColor: palette.border, background: palette.mainBg }}
       >
         <div
@@ -162,13 +162,13 @@ const ThemeLayoutPreview: React.FC<{ palette: ThemePreviewPalette }> = ({ palett
             style={{ background: palette.border, opacity: 0.45 }}
           ></span>
           <span
-            className='block w-12px h-4px rounded-full ml-auto'
+            className='block w-12px h-4px rounded-full ms-auto'
             style={{ background: palette.border, opacity: 0.45 }}
           ></span>
         </div>
         <div style={{ height: 'calc(100% - 14px)', display: 'flex' }}>
           <div
-            className='border-r border-solid px-3px py-3px flex flex-col gap-3px'
+            className='border-e border-solid px-3px py-3px flex flex-col gap-3px'
             style={{ width: '23%', borderColor: palette.border, background: palette.sideBg }}
           >
             <span className='block h-3px rounded-full' style={{ background: palette.textMuted, opacity: 0.4 }}></span>
@@ -182,7 +182,7 @@ const ThemeLayoutPreview: React.FC<{ palette: ThemePreviewPalette }> = ({ palett
             ></span>
           </div>
           <div
-            className='border-r border-solid px-4px py-4px flex flex-col gap-4px'
+            className='border-e border-solid px-4px py-4px flex flex-col gap-4px'
             style={{ width: '54%', borderColor: palette.border, background: palette.mainBg }}
           >
             <span
@@ -482,12 +482,12 @@ const CssThemeSettings: React.FC = () => {
               )}
 
               {/* 底部渐变遮罩与名称、编辑按钮 / Bottom gradient overlay with name and edit button */}
-              <div className='absolute bottom-0 left-0 right-0 h-1/3 bg-gradient-to-t from-black/60 to-transparent flex items-end justify-between p-8px'>
+              <div className='absolute bottom-0 start-0 end-0 h-1/3 bg-gradient-to-t from-black/60 to-transparent flex items-end justify-between p-8px'>
                 <span className='text-13px text-white truncate flex-1'>{theme.name}</span>
                 {/* 编辑按钮（仅用户主题） / Edit button (user themes only) */}
                 {hoveredThemeId === theme.id && !theme.builtin && (
                   <div
-                    className='p-4px rounded-6px bg-white/20 cursor-pointer hover:bg-white/40 transition-colors ml-8px'
+                    className='p-4px rounded-6px bg-white/20 cursor-pointer hover:bg-white/40 transition-colors ms-8px'
                     onClick={(e) => handleEditTheme(theme, e)}
                   >
                     <EditTwo theme='outline' size='16' fill='#fff' />
@@ -497,7 +497,7 @@ const CssThemeSettings: React.FC = () => {
 
               {/* 选中标记 / Selected indicator */}
               {activeThemeId === theme.id && (
-                <div className='absolute top-8px right-8px'>
+                <div className='absolute top-8px end-8px'>
                   <CheckOne theme='filled' size='20' fill='var(--color-primary)' />
                 </div>
               )}

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantEditorPage.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantEditorPage.tsx
@@ -40,7 +40,7 @@ const AssistantEditorPage: React.FC<AssistantEditorPageProps> = ({ editor, activ
                 : t('settings.editAssistant', { defaultValue: 'Assistant Details' }))}
           </div>
         </div>
-        <div className='ml-auto flex items-center gap-8px'>
+        <div className='ms-auto flex items-center gap-8px'>
           {canDelete && (
             <Button
               status='danger'

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantListPanel.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantListPanel.tsx
@@ -182,7 +182,7 @@ const SortableAssistantCard: React.FC<SortableAssistantCardProps> = ({
         </div>
       </div>
       <div
-        className='ml-12px flex flex-shrink-0 items-center gap-8px text-t-secondary'
+        className='ms-12px flex flex-shrink-0 items-center gap-8px text-t-secondary'
         onClick={(e) => e.stopPropagation()}
       >
         <Switch

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/editor/DefaultsSection.module.css
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/editor/DefaultsSection.module.css
@@ -4,8 +4,8 @@
 
 .summarySelect :global(.arco-input-tag) {
   min-height: 32px;
-  padding-left: 11px !important;
-  padding-right: 11px !important;
+  padding-inline-start: 11px !important;
+  padding-inline-end: 11px !important;
   background: transparent;
   border: none;
 }
@@ -31,7 +31,7 @@
 
 .summarySelect :global(.arco-input-tag-has-placeholder input),
 .summarySelect :global(.arco-input-tag-has-placeholder .arco-input-tag-input-mirror) {
-  padding-left: 0 !important;
+  padding-inline-start: 0 !important;
 }
 
 .summarySelect :global(.arco-input-tag-input::placeholder) {
@@ -68,7 +68,7 @@
 
 .summarySelect :global(.arco-input-tag-tag) {
   width: 100%;
-  margin-right: 0;
+  margin-inline-end: 0;
   font-size: inherit;
 }
 

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/editor/PromptsSection.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/editor/PromptsSection.tsx
@@ -84,8 +84,8 @@ const PromptsSection: React.FC<PromptsSectionProps> = ({
                     <div
                       className={
                         isEditingPrompt
-                          ? 'w-24px pt-9px text-right text-12px font-500 leading-18px text-t-quaternary'
-                          : 'flex h-36px w-24px items-center justify-end text-right text-12px font-500 leading-18px text-t-quaternary'
+                          ? 'w-24px pt-9px text-end text-12px font-500 leading-18px text-t-quaternary'
+                          : 'flex h-36px w-24px items-center justify-end text-end text-12px font-500 leading-18px text-t-quaternary'
                       }
                     >
                       {index + 1}.

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/editor/editorSectionPrimitives.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/editor/editorSectionPrimitives.tsx
@@ -38,11 +38,11 @@ export const SectionCard: React.FC<SectionCardProps> = ({
           </span>
         ) : null}
         {readOnly && readOnlyLabel ? (
-          <span className='ml-auto rounded-8px bg-fill-1 px-8px py-3px text-10px font-500 text-t-tertiary'>
+          <span className='ms-auto rounded-8px bg-fill-1 px-8px py-3px text-10px font-500 text-t-tertiary'>
             {readOnlyLabel}
           </span>
         ) : null}
-        {extra ? <div className='ml-auto'>{extra}</div> : null}
+        {extra ? <div className='ms-auto'>{extra}</div> : null}
       </div>
       {children}
     </section>

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/home/EnabledAssistantsList.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/home/EnabledAssistantsList.tsx
@@ -116,7 +116,7 @@ const EnabledAssistantRow: React.FC<EnabledAssistantRowProps> = ({
           </Tag>
         </div>
       </div>
-      <div className='ml-10px flex flex-shrink-0 items-center gap-8px sm:gap-14px' onClick={(e) => e.stopPropagation()}>
+      <div className='ms-10px flex flex-shrink-0 items-center gap-8px sm:gap-14px' onClick={(e) => e.stopPropagation()}>
         {assistant.enabled !== false ? (
           <Button
             type='text'

--- a/packages/desktop/src/renderer/pages/settings/SkillsSettings/SkillUsedByStack.tsx
+++ b/packages/desktop/src/renderer/pages/settings/SkillsSettings/SkillUsedByStack.tsx
@@ -51,7 +51,7 @@ const SkillUsedByStack: React.FC<{ assistants: Assistant[]; max?: number }> = ({
           <div
             key={assistant.id}
             className='overflow-hidden rounded-full border-2 border-solid border-bg-2'
-            style={{ marginLeft: index === 0 ? 0 : -7, zIndex: shown.length - index }}
+            style={{ marginInlineStart: index === 0 ? 0 : -7, zIndex: shown.length - index }}
           >
             <AssistantAvatar assistant={assistant} size={22} />
           </div>
@@ -59,7 +59,7 @@ const SkillUsedByStack: React.FC<{ assistants: Assistant[]; max?: number }> = ({
         {overflow > 0 && (
           <div
             className='flex items-center justify-center rounded-full border-2 border-solid border-bg-2 bg-fill-3 text-9px font-600 text-t-secondary'
-            style={{ width: 22, height: 22, marginLeft: -7 }}
+            style={{ width: 22, height: 22, marginInlineStart: -7 }}
           >
             +{overflow}
           </div>

--- a/packages/desktop/src/renderer/pages/settings/SkillsSettings/SkillsHubSettings.tsx
+++ b/packages/desktop/src/renderer/pages/settings/SkillsSettings/SkillsHubSettings.tsx
@@ -684,7 +684,7 @@ const SkillsHubSettings: React.FC<SkillsHubSettingsProps> = ({ withWrapper = tru
             </p>
           )}
         </div>
-        <div className='shrink-0 sm:self-center flex items-center justify-end pl-4px'>
+        <div className='shrink-0 sm:self-center flex items-center justify-end ps-4px'>
           <SkillUsedByStack assistants={getAssistantsUsingSkill(skill.name, assistantCatalog ?? [])} />
         </div>
       </div>
@@ -870,7 +870,7 @@ const SkillsHubSettings: React.FC<SkillsHubSettingsProps> = ({ withWrapper = tru
               </div>
 
               {!batchMode && (
-                <div className='shrink-0 sm:self-center flex items-center justify-end gap-10px mt-12px sm:mt-0 pl-4px'>
+                <div className='shrink-0 sm:self-center flex items-center justify-end gap-10px mt-12px sm:mt-0 ps-4px'>
                   <SkillUsedByStack assistants={getAssistantsUsingSkill(skill.name, assistantCatalog ?? [])} />
                   <button
                     data-testid={`btn-delete-${normalizeTestId(skill.name)}`}

--- a/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/AddPlatformModal.tsx
@@ -149,7 +149,7 @@ const ProtocolDetectionStatus: React.FC<ProtocolDetectionStatusProps> = ({
 
         {/* Multi-key test result */}
         {multiKeyResult && multiKeyResult.total > 1 && (
-          <div className='flex items-center gap-6px text-11px text-t-tertiary pl-22px'>
+          <div className='flex items-center gap-6px text-11px text-t-tertiary ps-22px'>
             <span>
               {multiKeyResult.invalid === 0
                 ? t('settings.multiKeyAllValid', { total: String(multiKeyResult.total) })

--- a/packages/desktop/src/renderer/pages/settings/components/JsonImportModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/JsonImportModal.tsx
@@ -378,7 +378,7 @@ const JsonImportModal: React.FC<JsonImportModalProps> = ({ visible, server, onCa
               <Button
                 size='mini'
                 type='outline'
-                className='absolute top-2 right-2 z-10'
+                className='absolute top-2 end-2 z-10'
                 onClick={() => {
                   const copyToClipboard = async () => {
                     try {
@@ -428,7 +428,7 @@ const JsonImportModal: React.FC<JsonImportModalProps> = ({ visible, server, onCa
           content={
             <div>
               <div>{t('settings.mcpImportTips')}</div>
-              <ul className='list-disc pl-5 mt-2 space-y-1 text-sm'>
+              <ul className='list-disc ps-5 mt-2 space-y-1 text-sm'>
                 <li>{t('settings.mcpImportTip1')}</li>
                 <li>{t('settings.mcpImportTip2')}</li>
                 <li>{t('settings.mcpImportTip3')}</li>

--- a/packages/desktop/src/renderer/pages/settings/components/SettingsPageHeader.tsx
+++ b/packages/desktop/src/renderer/pages/settings/components/SettingsPageHeader.tsx
@@ -83,7 +83,7 @@ const SettingsPageHeader: React.FC<SettingsPageHeaderProps> = ({
                 {typeof tab.count === 'number' ? (
                   <span
                     className={classNames(
-                      'ml-6px inline-flex h-16px min-w-16px items-center justify-center rounded-999px px-5px text-10px font-500 leading-none',
+                      'ms-6px inline-flex h-16px min-w-16px items-center justify-center rounded-999px px-5px text-10px font-500 leading-none',
                       isActive ? 'bg-primary-1 text-primary-6' : 'bg-fill-2 text-t-quaternary'
                     )}
                   >

--- a/packages/desktop/src/renderer/pages/team/TeamPage.tsx
+++ b/packages/desktop/src/renderer/pages/team/TeamPage.tsx
@@ -556,7 +556,7 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({
               <>
                 {showLeftArrow && (
                   <div
-                    className='absolute left-0 top-0 bottom-0 w-48px z-20 flex items-center justify-center cursor-pointer opacity-80 hover:opacity-100 transition-opacity'
+                    className='absolute start-0 top-0 bottom-0 w-48px z-20 flex items-center justify-center cursor-pointer opacity-80 hover:opacity-100 transition-opacity'
                     style={{ background: 'linear-gradient(90deg, var(--color-bg-1) 40%, transparent)' }}
                     onClick={scrollToPrev}
                   >
@@ -586,7 +586,7 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({
                         data-slot-id={assistant.slot_id}
                         data-role={isLeaderSlot ? 'leader' : 'member'}
                         // 列间灰色隔离线：除最后一列外，右侧加一条分隔线，避免多列浅底粘连看不清边界。
-                        className={`relative h-full ${isLastColumn ? '' : 'border-r border-solid border-[color:var(--border-base)]'}`}
+                        className={`relative h-full ${isLastColumn ? '' : 'border-e border-solid border-[color:var(--border-base)]'}`}
                         style={{
                           // Always flex-grow to fill available space; each slot starts at 400px
                           // basis so the layout is stable, but spare room is distributed evenly
@@ -619,7 +619,7 @@ const TeamPageContent: React.FC<TeamPageContentProps> = ({
                 </div>
                 {showRightArrow && (
                   <div
-                    className='absolute right-0 top-0 bottom-0 w-48px z-20 flex items-center justify-center cursor-pointer opacity-80 hover:opacity-100 transition-opacity'
+                    className='absolute end-0 top-0 bottom-0 w-48px z-20 flex items-center justify-center cursor-pointer opacity-80 hover:opacity-100 transition-opacity'
                     style={{ background: 'linear-gradient(270deg, var(--color-bg-1) 40%, transparent)' }}
                     onClick={scrollToNext}
                   >

--- a/packages/desktop/src/renderer/pages/team/activity/ActivityBoardLayout.tsx
+++ b/packages/desktop/src/renderer/pages/team/activity/ActivityBoardLayout.tsx
@@ -82,7 +82,7 @@ const BoardColumn: React.FC<{
             />
           </div>
         )}
-        <span className='ml-auto text-11px text-[color:var(--color-text-3)]'>{laneItems.length}</span>
+        <span className='ms-auto text-11px text-[color:var(--color-text-3)]'>{laneItems.length}</span>
       </div>
       <div ref={scrollRef} className='flex-1 overflow-auto flex flex-col gap-8px p-8px'>
         {laneItems.length === 0 ? (

--- a/packages/desktop/src/renderer/pages/team/activity/MessageCard.tsx
+++ b/packages/desktop/src/renderer/pages/team/activity/MessageCard.tsx
@@ -69,7 +69,7 @@ const MessageCard: React.FC<Props> = ({ message, identity }) => {
         ) : (
           <MemberChip name={toName} color={identity.colorOf(message.to_agent_id)} />
         )}
-        <span className='ml-auto flex items-center gap-6px'>
+        <span className='ms-auto flex items-center gap-6px'>
           {isSystemMessageType(message.msg_type) && (
             <Tag size='small' color='gray'>
               {t(`team.activity.msgType.${message.msg_type}`, { defaultValue: message.msg_type })}
@@ -125,7 +125,7 @@ const MessageCard: React.FC<Props> = ({ message, identity }) => {
             </span>
           </Tooltip>
         )}
-        <span className='ml-auto shrink-0' title={time.full}>
+        <span className='ms-auto shrink-0' title={time.full}>
           {time.label}
         </span>
       </div>

--- a/packages/desktop/src/renderer/pages/team/activity/TaskCard.tsx
+++ b/packages/desktop/src/renderer/pages/team/activity/TaskCard.tsx
@@ -163,7 +163,7 @@ const TaskCard: React.FC<Props> = ({ task, identity }) => {
             </span>
           </Tooltip>
         )}
-        <span className='ml-auto shrink-0' title={time.full}>
+        <span className='ms-auto shrink-0' title={time.full}>
           {time.label}
         </span>
       </div>

--- a/packages/desktop/src/renderer/pages/team/components/AgentStatusBadge.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/AgentStatusBadge.tsx
@@ -24,7 +24,7 @@ const FALLBACK_COLOR = 'bg-gray-400';
 const AgentStatusBadge: React.FC<Props> = ({ status, testId, overlay = true }) => {
   const color = STATUS_CONFIG[status]?.color ?? FALLBACK_COLOR;
   const overlayClass = overlay
-    ? 'absolute -bottom-1px -right-1px w-8px h-8px border-2 border-solid border-[color:var(--color-bg-base)]'
+    ? 'absolute -bottom-1px -end-1px w-8px h-8px border-2 border-solid border-[color:var(--color-bg-base)]'
     : 'inline-block w-2 h-2';
   return (
     <span

--- a/packages/desktop/src/renderer/pages/team/components/TeamChatEmptyState.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamChatEmptyState.tsx
@@ -179,7 +179,7 @@ const TeamChatEmptyState: React.FC<Props> = ({
                 key={s.key}
                 data-testid={`team-chat-empty-state-suggestion-${s.key}`}
                 onClick={() => fillDraft(label)}
-                className='flex items-center gap-10px px-14px py-10px rd-10px bg-fill-2 hover:bg-fill-3 cursor-pointer transition-colors text-left border border-transparent hover:border-[var(--color-border-2)]'
+                className='flex items-center gap-10px px-14px py-10px rd-10px bg-fill-2 hover:bg-fill-3 cursor-pointer transition-colors text-start border border-transparent hover:border-[var(--color-border-2)]'
               >
                 <span className='text-15px shrink-0'>{s.icon}</span>
                 <span className='text-13px text-t-secondary'>{label}</span>

--- a/packages/desktop/src/renderer/pages/team/components/TeamCreateModal.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamCreateModal.tsx
@@ -164,7 +164,7 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
     <div className='grid grid-cols-[76px_minmax(0,1fr)] items-center gap-x-14px gap-y-10px'>
       <div className='text-14px font-600 leading-21px text-t-secondary'>
         {t('team.create.nameLabel', { defaultValue: 'Team name' })}
-        <span className='ml-4px text-danger-6'>*</span>
+        <span className='ms-4px text-danger-6'>*</span>
       </div>
       <div>
         <Input
@@ -204,7 +204,7 @@ const TeamCreateModal: React.FC<Props> = ({ visible, onClose, onCreated }) => {
       style={{ height: 'min(54vh, 470px)', minHeight: 390 }}
     >
       <section
-        className='flex min-h-0 flex-col border-r border-border-3 px-20px pb-18px pt-12px'
+        className='flex min-h-0 flex-col border-e border-border-3 px-20px pb-18px pt-12px'
         data-testid='team-create-assistant-pane'
       >
         <div className='mb-12px text-15px font-600 leading-22px text-t-secondary'>

--- a/packages/desktop/src/renderer/pages/team/components/TeamTabs.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamTabs.tsx
@@ -117,7 +117,7 @@ const TeamTabView: React.FC<TeamTabViewProps> = ({
       data-testid={`team-tab-${slot_id}`}
       data-team-tab-role={isLeader ? 'leader' : 'teammate'}
       data-active={isActive ? 'true' : 'false'}
-      className='relative flex items-center gap-6px pl-6px pr-10px h-34px max-w-220px cursor-pointer rounded-999px border border-solid transition-colors duration-150 shrink-0 bg-[color:var(--bg-2)]'
+      className='relative flex items-center gap-6px ps-6px pe-10px h-34px max-w-220px cursor-pointer rounded-999px border border-solid transition-colors duration-150 shrink-0 bg-[color:var(--bg-2)]'
       style={{
         ['--mc' as string]: color,
         borderColor: isActive ? color : 'transparent',
@@ -183,7 +183,7 @@ const TeamTabView: React.FC<TeamTabViewProps> = ({
               warmupFailed ? (
                 <span
                   data-testid={`team-tab-failed-${slot_id}`}
-                  className='absolute -right-2px -bottom-2px w-12px h-12px rounded-full flex items-center justify-center text-9px font-700 text-white'
+                  className='absolute -end-2px -bottom-2px w-12px h-12px rounded-full flex items-center justify-center text-9px font-700 text-white'
                   style={{ background: 'var(--danger)', border: '1.5px solid var(--bg-base)' }}
                 >
                   !
@@ -359,7 +359,7 @@ const TeamTabs: React.FC<TeamTabsProps> = ({ onTabClick, pendingCounts, warmingU
         {/* 两侧渐隐提示「还有更多」，只覆盖滚动区、不盖固定的添加入口 */}
         {showLeftFade && (
           <div
-            className='pointer-events-none absolute left-0 top-0 bottom-0 w-28px z-10'
+            className='pointer-events-none absolute start-0 top-0 bottom-0 w-28px z-10'
             style={{ background: 'linear-gradient(90deg, var(--color-bg-1), transparent)' }}
           />
         )}
@@ -374,7 +374,7 @@ const TeamTabs: React.FC<TeamTabsProps> = ({ onTabClick, pendingCounts, warmingU
         )}
         {/* 固定在最右、不随列表滚动的「添加成员」；左侧一根分隔线与成员列表隔开，按钮本身无边框。 */}
         {addAssistant ? (
-          <div className='flex items-center shrink-0 border-l border-solid border-[color:var(--border-base)] px-8px'>
+          <div className='flex items-center shrink-0 border-s border-solid border-[color:var(--border-base)] px-8px'>
             <TeamAddMemberPopover disabled={memberOpsDisabled}>
               <button
                 type='button'

--- a/packages/desktop/src/renderer/pages/team/components/TeamWarmupOverlay.tsx
+++ b/packages/desktop/src/renderer/pages/team/components/TeamWarmupOverlay.tsx
@@ -77,7 +77,7 @@ const TeamWarmupOverlay: React.FC<Props> = ({ phase, assistants, runtimeStatus, 
     <div
       data-testid='team-warmup-overlay'
       data-phase={phase}
-      className='absolute left-0 right-0 bottom-0 z-20 flex flex-col items-center justify-center'
+      className='absolute start-0 end-0 bottom-0 z-20 flex flex-col items-center justify-center'
       style={{
         top: COLUMN_HEADER_HEIGHT,
         background: 'color-mix(in srgb, var(--bg-1) 80%, transparent)',
@@ -122,7 +122,7 @@ const TeamWarmupOverlay: React.FC<Props> = ({ phase, assistants, runtimeStatus, 
                 />
                 {isFailed && (
                   <span
-                    className='absolute -right-2px -bottom-2px w-14px h-14px rounded-full flex items-center justify-center text-9px font-700 text-white'
+                    className='absolute -end-2px -bottom-2px w-14px h-14px rounded-full flex items-center justify-center text-9px font-700 text-white'
                     style={{ background: 'var(--danger)', border: '1.5px solid var(--bg-1)' }}
                   >
                     !
@@ -163,7 +163,7 @@ const TeamWarmupOverlay: React.FC<Props> = ({ phase, assistants, runtimeStatus, 
                 {failedMembers.map((m) => (
                   <div
                     key={m.assistant.slot_id}
-                    className='flex items-start gap-6px text-11px leading-relaxed text-left'
+                    className='flex items-start gap-6px text-11px leading-relaxed text-start'
                   >
                     <span className='shrink-0 font-600' style={{ color: 'var(--danger)' }}>
                       {m.assistant.assistant_name}
@@ -179,7 +179,7 @@ const TeamWarmupOverlay: React.FC<Props> = ({ phase, assistants, runtimeStatus, 
             ) : single?.error ? (
               <div
                 data-testid='team-warmup-error'
-                className='max-w-320px max-h-64px overflow-y-auto text-11px leading-relaxed text-left rounded-6px px-10px py-6px'
+                className='max-w-320px max-h-64px overflow-y-auto text-11px leading-relaxed text-start rounded-6px px-10px py-6px'
                 style={{ background: 'color-mix(in srgb, var(--danger) 8%, var(--bg-base))', color: 'var(--danger)' }}
               >
                 {simplifyWarmupError(single.error)}

--- a/packages/desktop/src/renderer/services/i18n/direction.ts
+++ b/packages/desktop/src/renderer/services/i18n/direction.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Layout direction for the app language.
+ *
+ * fa-IR is the only right-to-left language AionUi ships. Direction is derived
+ * from the app language (`i18n.language`), never from the host OS, for the same
+ * reason number and date formatting is: the two must not disagree.
+ *
+ * Content that is inherently left-to-right — code blocks, terminal output,
+ * file paths — must opt out locally with `dir="ltr"` on its container rather
+ * than fighting the document direction.
+ */
+
+import { normalizeLanguageCode } from '@/common/config/i18n';
+
+const RTL_LANGUAGES: ReadonlySet<string> = new Set(['fa-IR']);
+
+export type LayoutDirection = 'ltr' | 'rtl';
+
+/** Whether the given app language lays out right-to-left. */
+export function isRtlLanguage(language: string | undefined | null): boolean {
+  if (!language) return false;
+  return RTL_LANGUAGES.has(normalizeLanguageCode(language));
+}
+
+/** Resolve the document direction for the given app language. */
+export function directionForLanguage(language: string | undefined | null): LayoutDirection {
+  return isRtlLanguage(language) ? 'rtl' : 'ltr';
+}
+
+/**
+ * Apply the language's direction (and the language tag itself) to <html>.
+ *
+ * `dir` drives the CSS logical properties and flex/grid start/end used
+ * throughout the renderer; `lang` drives spell-check, CJK glyph selection and
+ * assistive technology.
+ */
+export function applyDocumentDirection(language: string | undefined | null): void {
+  if (typeof document === 'undefined') return;
+  document.documentElement.dir = directionForLanguage(language);
+  if (language) {
+    document.documentElement.lang = normalizeLanguageCode(language);
+  }
+}

--- a/packages/desktop/src/renderer/services/i18n/index.ts
+++ b/packages/desktop/src/renderer/services/i18n/index.ts
@@ -12,6 +12,7 @@ import {
   type LocaleData,
   type SupportedLanguage,
 } from '@/common/config/i18n';
+import { applyDocumentDirection } from './direction';
 
 // Static imports for all locales to ensure packaged app can always switch language.
 import enUS from './locales/en-US/index';
@@ -167,6 +168,13 @@ i18n.on('languageChanged', async (lang: string) => {
     console.error(`Failed to load language ${normalizedLang}:`, error);
   }
 });
+
+// Keep <html dir>/<html lang> in step with the app language (fa-IR is RTL).
+// Separate listener: the one above early-returns once the bundle is loaded.
+i18n.on('languageChanged', (lang: string) => {
+  applyDocumentDirection(lang);
+});
+applyDocumentDirection(initialLanguage);
 
 // Initialize on module load
 void initLanguage();

--- a/packages/desktop/src/renderer/styles/arco-override.css
+++ b/packages/desktop/src/renderer/styles/arco-override.css
@@ -436,7 +436,7 @@ body[arco-theme='dark'] .arco-message-error {
    and expresses nesting with in-row indent blocks, so these 8px are a single constant
    offset per level rather than something that accumulates with depth. */
 .workspace-tree .arco-tree-node {
-  padding-left: 8px;
+  padding-inline-start: 8px;
 }
 
 .workspace-tree .arco-tree-node:hover {
@@ -479,7 +479,7 @@ body[arco-theme='dark'] .arco-message-error {
   }
 
   .arco-tabs-nav-tab:first-child {
-    margin-left: 0;
+    margin-inline-start: 0;
   }
 
   .arco-tabs-nav-tab-active {
@@ -559,8 +559,8 @@ body[arco-theme='dark'] .arco-message-error {
  * ~12px each side, leaving a visible ~24px chasm even with gap:0. */
 [data-mobile='true'] [data-testid='guid-model-selector'].arco-btn-shape-round,
 [data-mobile='true'] [data-testid='mode-selector'] .arco-btn-shape-round {
-  padding-left: 4px !important;
-  padding-right: 4px !important;
+  padding-inline-start: 4px !important;
+  padding-inline-end: 4px !important;
 }
 
 /* Searchable dropdown lists (RuntimeSelectorModelList, DropdownSearchList) own

--- a/packages/desktop/src/renderer/styles/layout.css
+++ b/packages/desktop/src/renderer/styles/layout.css
@@ -35,7 +35,7 @@
 .layout-sider {
   overflow-x: hidden;
   box-shadow: none !important;
-  border-right: 1px solid var(--border-base);
+  border-inline-end: 1px solid var(--border-base);
 }
 
 /* Arco Layout inner container needs flex layout so Header + Content + Footer
@@ -151,11 +151,11 @@
 }
 
 /* Message component positioning - center in conversation area (exclude left sider) */
-/* Use padding-left offset while keeping inner message centered */
+/* Use padding-inline-start offset while keeping inner message centered */
 .arco-message-wrapper {
-  left: 0 !important;
+  inset-inline-start: 0 !important;
   width: 100% !important;
-  padding-left: 266px;
+  padding-inline-start: 266px;
   box-sizing: border-box;
   z-index: 10001 !important;
 }
@@ -247,7 +247,7 @@
 
   /* Mobile: remove left padding for message wrapper */
   .arco-message-wrapper {
-    padding-left: 0;
+    padding-inline-start: 0;
   }
 
   /* Sidebar conversation title + secondary timeline text */

--- a/packages/desktop/src/renderer/styles/markdown.css
+++ b/packages/desktop/src/renderer/styles/markdown.css
@@ -74,8 +74,8 @@
 }
 
 .aionui-markdown :where(blockquote) {
-  border-left: 3px solid var(--bg-3);
-  padding-left: 12px;
+  border-inline-start: 3px solid var(--bg-3);
+  padding-inline-start: 12px;
   color: var(--text-primary);
   margin: 16px 0;
 }
@@ -251,7 +251,7 @@
   border: none;
   background: transparent;
   color: var(--text-primary);
-  text-align: left;
+  text-align: start;
   white-space: nowrap;
   cursor: pointer;
 }

--- a/packages/desktop/src/renderer/styles/themes/base.css
+++ b/packages/desktop/src/renderer/styles/themes/base.css
@@ -82,15 +82,15 @@ body,
 @keyframes team-warmup-sweep {
   0% {
     width: 20%;
-    margin-left: 0;
+    margin-inline-start: 0;
   }
   50% {
     width: 60%;
-    margin-left: 40%;
+    margin-inline-start: 40%;
   }
   100% {
     width: 20%;
-    margin-left: 0;
+    margin-inline-start: 0;
   }
 }
 

--- a/tests/unit/renderer/i18nDirection.dom.test.ts
+++ b/tests/unit/renderer/i18nDirection.dom.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { applyDocumentDirection, directionForLanguage, isRtlLanguage } from '@/renderer/services/i18n/direction';
+
+describe('isRtlLanguage / directionForLanguage', () => {
+  it('marks fa-IR as RTL', () => {
+    expect(isRtlLanguage('fa-IR')).toBe(true);
+    expect(directionForLanguage('fa-IR')).toBe('rtl');
+  });
+
+  it('normalises regional and underscore variants before deciding', () => {
+    expect(isRtlLanguage('fa')).toBe(true);
+    expect(isRtlLanguage('fa_IR')).toBe(true);
+  });
+
+  it('treats every other shipped language as LTR', () => {
+    for (const lang of ['en-US', 'zh-CN', 'zh-TW', 'ja-JP', 'de-DE', 'ru-RU', 'tr-TR', 'uk-UA']) {
+      expect(isRtlLanguage(lang)).toBe(false);
+      expect(directionForLanguage(lang)).toBe('ltr');
+    }
+  });
+
+  it('defaults to LTR for missing input', () => {
+    expect(isRtlLanguage(undefined)).toBe(false);
+    expect(isRtlLanguage(null)).toBe(false);
+    expect(directionForLanguage(undefined)).toBe('ltr');
+  });
+});
+
+describe('applyDocumentDirection', () => {
+  it('sets dir and lang on <html> for an RTL language', () => {
+    applyDocumentDirection('fa-IR');
+    expect(document.documentElement.dir).toBe('rtl');
+    expect(document.documentElement.lang).toBe('fa-IR');
+  });
+
+  it('switches back to LTR when the language changes away', () => {
+    applyDocumentDirection('fa-IR');
+    applyDocumentDirection('de-DE');
+    expect(document.documentElement.dir).toBe('ltr');
+    expect(document.documentElement.lang).toBe('de-DE');
+  });
+});

--- a/tests/unit/settings/UpdateNotificationCard.dom.test.tsx
+++ b/tests/unit/settings/UpdateNotificationCard.dom.test.tsx
@@ -157,7 +157,8 @@ describe('UpdateNotificationCard', () => {
 
     const card = await screen.findByTestId('update-notification-card');
     expect(card).toHaveClass('fixed');
-    expect(card).toHaveClass('right-24px');
+    // Inline-end anchoring: bottom-right in LTR, bottom-left under RTL (fa-IR).
+    expect(card).toHaveClass('end-24px');
     expect(card).toHaveClass('bottom-24px');
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
 


### PR DESCRIPTION
## Description

fa-IR (Persian) has been a first-class option in the language switcher, but the app had no RTL support at all: no `<html dir>`, no Arco RTL mode, and physical left/right CSS throughout. Persian users got translated strings laid out backwards — text left-aligned, icons on the wrong side, panels on the wrong edge.

This PR delivers RTL in three phases, all verified against the running app.

### P1 — Direction plumbing

- New `renderer/services/i18n/direction.ts`: `isRtlLanguage`, `directionForLanguage`, `applyDocumentDirection`. Direction is derived from the app language, never the host OS — same principle as #4068.
- The renderer i18n service applies `<html dir>` / `<html lang>` at boot and on every `languageChanged`, so switching to/from فارسی retargets the entire layout live, no reload.
- Arco `ConfigProvider` gets `rtl={isRtlLanguage(language)}` — Arco 2.66 flips all its components (modals, selects, popover placement, pagination) natively (verified: `es/ConfigProvider/interface.d.ts:232`).
- **LTR islands**: markdown code blocks (`CodeBlock`), terminal command + output (`MessageAcpTerminalOutput`), and diffs (`Diff2Html`) pin `dir="ltr"` — code is inherently left-to-right.

### P2 — Physical → logical CSS (~120 files, mechanical)

- UnoCSS utilities: `ml/mr/pl/pr-*` → `ms/me/ps/pe-*`, `left/right-*` → `start/end-*`, `text-left/right` → `text-start/end`, `border-l/r` → `border-s/e`, `rounded-tl/tr` → `rounded-ss/se`. All logical rules verified to generate against this repo's exact UnoCSS preset config before converting.
- CSS files: `margin/padding/border-left|right` → `*-inline-start|end`, positional `left:/right:` → `inset-inline-start/end`, `text-align: left/right` → `start/end`.
- Inline styles: layout `marginLeft`/`paddingLeft`/…​ → `marginInlineStart` etc. (avatar stacks, tree indents, scrollbar gutter padding).

**This migration is a strict no-op for the 12 LTR languages**: `margin-inline-start` resolves to `margin-left` when `dir=ltr`, so existing users cannot regress.

Deliberately kept physical, with reasons in-code:
- `titlebar.css` + the Titlebar traffic-light margin — window chrome anchored to macOS controls, which stay top-left in every direction.
- `left: 50%` + `translateX(-50%)` centering pairs — centering is direction-independent; a logical offset with a physical transform would de-center under RTL.
- `CodeEditor` `textAlign: 'left'` (code island) and the SendBox highlight-layer padding copy (mirrors computed styles).

### P3 — Verified in the running app

Launched the webui build, drove it with Playwright, and confirmed with screenshots (attached below):

| Check | Result |
|---|---|
| Switch to فارسی on the login page | `<html dir>` → `rtl`, `<html lang>` → `fa-IR`, labels/icons/checkbox mirror |
| Home (guid) in fa-IR | Sidebar mirrors to the right edge, send button mirrors to the left, prompts right-aligned |
| Conversation in fa-IR | User bubbles mirror to the left, AI text right-aligned, error card RTL with technical details readable, file panel mirrors to the left |
| Settings in fa-IR | Nav on the right, agent rows fully mirrored, Arco tabs/selects flipped |
| Code/terminal in fa-IR | Stay LTR (islands) |
| Switch back to English | `dir` → `ltr` live; home/chat/settings pixel-match the pre-change layout |

Known cosmetic tail (not blocking, follow-up material): dotfile names like `.claude` in the file tree render with the leading dot on the visual right under RTL (bidi-neutral character) — file paths outside code blocks could use `dir="ltr"` spans; input placeholder prefix icons overlap slightly on the login page.

## Related Issues

Follow-up to #4068 (app-language-driven number/date formatting). Together they close the "fa-IR is offered but half-implemented" gap found in the i18n audit.

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — full suite green (4000+ tests); one assertion updated to follow the intentional `right-24px` → `end-24px` rename, still asserting inline-end anchoring
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys — no new user-facing strings
- [x] `prek run --from-ref origin/main --to-ref HEAD` — all hooks pass

## Runtime Verification

- [x] Verified on macOS (webui build driven by Playwright: fa-IR RTL across login/home/chat/settings, en-US regression pixel-checked)
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

Captured from the running app during verification (login fa-IR, home fa-IR, chat fa-IR, settings fa-IR, and the en-US regression set). Will attach to the PR conversation.
