### PR TITLE
fix(i18n): RTL polish pass — LTR paths and file names, shorthand paddings, mirrored chevrons

### DIFF
--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/AboutModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/AboutModalContent.tsx
@@ -113,27 +113,27 @@ const AboutModalContent: React.FC = () => {
     {
       title: t('settings.helpDocumentation'),
       url: 'https://github.com/iOfficeAI/AionUi/wiki',
-      icon: <Right theme='outline' size='16' />,
+      icon: <Right theme='outline' size='16' className='rtl-mirror' />,
     },
     {
       title: t('settings.updateLog'),
       url: 'https://github.com/iOfficeAI/AionUi/releases',
-      icon: <Right theme='outline' size='16' />,
+      icon: <Right theme='outline' size='16' className='rtl-mirror' />,
     },
     {
       title: t('settings.bugReport'),
       onClick: () => setShowFeedbackModal(true),
-      icon: <Right theme='outline' size='16' />,
+      icon: <Right theme='outline' size='16' className='rtl-mirror' />,
     },
     {
       title: t('settings.contactMe'),
       url: 'https://x.com/WailiVery',
-      icon: <Right theme='outline' size='16' />,
+      icon: <Right theme='outline' size='16' className='rtl-mirror' />,
     },
     {
       title: t('settings.officialWebsite'),
       url: 'https://www.aionui.com',
-      icon: <Right theme='outline' size='16' />,
+      icon: <Right theme='outline' size='16' className='rtl-mirror' />,
     },
   ];
 

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/DirInputItem.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/DirInputItem.tsx
@@ -56,7 +56,8 @@ const DirInputItem: React.FC<{
             onKeyDown={handleKeyDown}
           >
             <Tooltip content={current_value || t('settings.dirNotConfigured')} position='top'>
-              <div className='flex-1 min-w-0 text-13px text-t-primary truncate '>
+              {/* Paths are code-like; without dir=ltr the leading slash flips to the end under RTL. */}
+              <div dir='ltr' className='flex-1 min-w-0 text-13px text-t-primary truncate text-end'>
                 {current_value || t('settings.dirNotConfigured')}
               </div>
             </Tooltip>
@@ -64,7 +65,13 @@ const DirInputItem: React.FC<{
               <Button
                 type='text'
                 aria-label={actionTooltip}
-                style={{ borderLeft: '1px solid var(--color-border-2)', borderRadius: '0 8px 8px 0' }}
+                style={{
+                  borderInlineStart: '1px solid var(--color-border-2)',
+                  borderStartStartRadius: 0,
+                  borderStartEndRadius: 8,
+                  borderEndEndRadius: 8,
+                  borderEndStartRadius: 0,
+                }}
                 icon={<FolderOpen theme='outline' size='18' fill={iconColors.primary} />}
                 onClick={(e) => {
                   e.stopPropagation();

--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/WebuiModalContent.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/WebuiModalContent.tsx
@@ -560,7 +560,7 @@ const WebuiModalContent: React.FC = () => {
       <div className='flex flex-col h-full w-full'>
         <AionScrollArea className='flex-1 min-h-0 pb-16px' disableOverflow={isPageMode}>
           <div className='space-y-16px'>
-            <h2 className='text-20px font-500 text-t-primary m-0'>Channels</h2>
+            <h2 className='text-20px font-500 text-t-primary m-0'>{t('settings.channels', 'Channels')}</h2>
             <Suspense fallback={<div className='text-13px text-t-secondary'>{t('common.loading')}</div>}>
               <ChannelModalContentLazy />
             </Suspense>
@@ -828,7 +828,7 @@ const WebuiModalContent: React.FC = () => {
               className={`inline-flex items-center gap-6px transition-colors ${activeTab === 'channels' ? 'text-t-primary font-600' : 'text-t-secondary'}`}
             >
               <Communication theme='outline' size='15' />
-              <span>Channels</span>
+              <span>{t('settings.channels', 'Channels')}</span>
               <span className='inline-flex items-center gap-4px ms-2px'>
                 {CHANNEL_LOGOS.map((item) => (
                   <span

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.css
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationSearchPopover.css
@@ -171,7 +171,9 @@ body[arco-theme='dark'] .conversation-search-modal {
   border: 1px solid var(--conversation-search-input-border) !important;
   box-shadow: none !important;
   border-radius: 10px;
-  padding: 0 10px 0 12px;
+  padding-block: 0;
+  padding-inline-start: 12px;
+  padding-inline-end: 10px;
 }
 
 .conversation-search-modal__searchbar:focus-within {

--- a/packages/desktop/src/renderer/pages/conversation/SourceControl/ScmResourceRow.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/SourceControl/ScmResourceRow.tsx
@@ -251,6 +251,7 @@ export const ScmResourceRow: React.FC<ScmResourceRowProps> = ({
           browser check: inherited stayed rgb(0,0,0) under dark, while text-t-primary
           resolves to #fff). conflicted/failed keep danger; everything else is primary. */}
       <span
+        dir='ltr'
         className={`overflow-hidden text-ellipsis whitespace-nowrap text-13px ${
           kind === 'conflicted' || failed ? 'text-danger' : 'text-t-primary'
         } ${resource.state === 'deleted' ? 'line-through' : ''}`}

--- a/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/ExplorerPanel.tsx
@@ -209,7 +209,10 @@ export const ExplorerPanel: React.FC<ExplorerPanelProps> = ({
           {...dropProps}
         >
           <FileTypeIcon node={{ name, relativePath: keyToRef(key).relative_path, isFile }} expanded={isExpanded} />
-          <span className='overflow-hidden text-ellipsis whitespace-nowrap'>{name}</span>
+          {/* File names are code-like; bidi-neutral leading dots (.claude) must not flip under RTL. */}
+          <span dir='ltr' className='overflow-hidden text-ellipsis whitespace-nowrap'>
+            {name}
+          </span>
           {degraded && <Caution theme='outline' size='14' className='flex-shrink-0' />}
         </span>
       );

--- a/packages/desktop/src/renderer/pages/conversation/explorer/search/SearchPanel.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/explorer/search/SearchPanel.tsx
@@ -154,10 +154,14 @@ export const SearchPanel: React.FC<SearchPanelProps> = ({ roots, peNames, onReve
               title={hit.relative_path}
             >
               <FileTypeIcon node={{ name: hit.name, relativePath: hit.relative_path, isFile: true }} />
-              <span className='overflow-hidden text-ellipsis whitespace-nowrap flex-shrink-0 max-w-[45%]'>
+              {/* File names/paths are code-like: keep LTR under an RTL document. */}
+              <span dir='ltr' className='overflow-hidden text-ellipsis whitespace-nowrap flex-shrink-0 max-w-[45%]'>
                 {hit.name}
               </span>
-              <span className='overflow-hidden text-ellipsis whitespace-nowrap text-t-tertiary text-12px flex-1 min-w-0'>
+              <span
+                dir='ltr'
+                className='overflow-hidden text-ellipsis whitespace-nowrap text-t-tertiary text-12px flex-1 min-w-0'
+              >
                 {peLabeledPath(hit.pe_id, hit.relative_path, peNames)}
               </span>
               {onAddHit && (

--- a/packages/desktop/src/renderer/pages/guid/index.module.css
+++ b/packages/desktop/src/renderer/pages/guid/index.module.css
@@ -136,7 +136,9 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 6px 6px 10px 14px;
+  padding-block: 6px 10px;
+  padding-inline-start: 14px;
+  padding-inline-end: 6px;
   background: transparent;
 }
 
@@ -184,7 +186,9 @@
   color: var(--color-text-2);
   background: transparent;
   border: none;
-  padding: 4px 4px 4px 6px;
+  padding-block: 4px;
+  padding-inline-start: 6px;
+  padding-inline-end: 4px;
   cursor: pointer;
   font-family: inherit;
   transition:
@@ -511,7 +515,9 @@
   position: relative;
   max-height: 200px;
   overflow-y: auto;
-  padding: 4px 6px 4px 4px;
+  padding-block: 4px;
+  padding-inline-start: 4px;
+  padding-inline-end: 6px;
   scrollbar-width: thin;
 }
 

--- a/packages/desktop/src/renderer/pages/login/LoginPage.css
+++ b/packages/desktop/src/renderer/pages/login/LoginPage.css
@@ -208,7 +208,9 @@ body.login-page-active {
 .login-page__input {
   width: 100%;
   height: 44px;
-  padding: 10px 14px 10px 44px;
+  padding-block: 10px;
+  padding-inline-start: 44px;
+  padding-inline-end: 14px;
   border: 1px solid #ddd;
   border-radius: 12px;
   font-size: 15px;

--- a/packages/desktop/src/renderer/styles/layout.css
+++ b/packages/desktop/src/renderer/styles/layout.css
@@ -261,3 +261,8 @@
     line-height: 20px !important;
   }
 }
+
+/* Direction-implying icons (chevrons meaning "enter/forward") must mirror under RTL. */
+[dir='rtl'] .rtl-mirror {
+  transform: scaleX(-1);
+}


### PR DESCRIPTION
## Description

Full-page polish pass of the fa-IR (RTL) build following #4069: launched the webui build, walked **every page** in Persian (login, home, conversation + changes panel, scheduled tasks, assistants, and each settings section — agents, model, skills, tools, appearance, remote/channels, system, about), screenshotted each, and fixed everything found. Two root causes covered most of it.

### Bidi-neutral text rendered through the RTL algorithm

- `.claude` displayed as `claude.` in the explorer file tree (a leading dot is bidi-neutral, so it flips to the visual end). Explorer tree names, search-panel hit name/path, and SCM resource rows now pin `dir="ltr"` — the same treatment #4069 gave code blocks.
- The system-settings directory paths lost their leading slash: `/Users/zhoukai/.aionui-web-dev` rendered as `Users/zhoukai/.aionui-web-dev/`. `DirInputItem` pins `dir="ltr"` on the path text.

### Physical CSS the #4069 codemod could not see

- **Asymmetric 4-value shorthands**: the login input's `padding: 10px 14px 10px 44px` kept its 44px on the physical left while the field icon moved to inline-start — so the Persian placeholder rendered on top of the icon. All five asymmetric shorthands in the repo (login input, two guid card paddings, conversation-search input) are now logical `padding-block` / `padding-inline-start/end`. Grep confirms zero asymmetric physical shorthands remain.
- `DirInputItem`'s inline `borderLeft` + physical corner radii → `borderInlineStart` + logical corner radii.

### Direction-implying icons

- New global `[dir='rtl'] .rtl-mirror` utility (`transform: scaleX(-1)`), applied to the About page's five "enter" chevrons, which kept pointing right under RTL.

### Hardcoded strings found on the way

- `WebuiModalContent` rendered a literal `Channels` heading and tab label; both now use the existing `settings.channels` key (translated in all 13 locales).

## Verification

Verified in the running fa-IR webui build after a rebuild, page by page:

| Check | Before | After |
|---|---|---|
| Explorer tree dotfile | `claude.` | `.claude` |
| System settings paths | `Users/zhoukai/…-dev/` | `/Users/zhoukai/…-dev` |
| Login placeholder | starts under the field icon | starts clear of it |
| About chevrons | point right | point left (mirrored) |
| Channels heading | English literal | کانال‌ها |

LTR rendering is unchanged — logical properties resolve identically, and the `rtl-mirror` rule only matches under `[dir='rtl']`.

## Related Issues

Follow-up to #4069; same audit thread as #4068 / #4071 / #4072 / #4074 / #4075.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring
- [ ] Breaking change
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix — the RTL polish pass
- [x] The PR title follows Conventional Commit format

## Local Checks (Rule 3)

- [x] `bun run format` — passes
- [x] `bun run lint` — no errors
- [x] `bunx tsc --noEmit` — no errors
- [x] `bunx vitest run` — full suite green via `just push` gate
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys — the Channels fix is exactly this

## Runtime Verification

- [x] Verified on macOS (fa-IR webui build, every page screenshotted before/after)
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code
