### PR TITLE
fix(web-host): stop leaking PREBUILDS_ONLY into aioncore agent subprocesses

### DIFF
--- a/packages/web-host/src/backend-launcher.test.ts
+++ b/packages/web-host/src/backend-launcher.test.ts
@@ -240,6 +240,46 @@ describe('buildSpawnEnv', () => {
     expect(env.AIONUI_LOG_DIR).toBe('/l');
     expect(env.PATH).toBe(process.env.PATH); // inherits
   });
+
+  it('strips PREBUILDS_ONLY so agent CLIs spawned under aioncore can load their build/Release natives (#4070)', () => {
+    const prev = process.env.PREBUILDS_ONLY;
+    process.env.PREBUILDS_ONLY = '1';
+    try {
+      const env = buildSpawnEnv({
+        cacheDir: '/c',
+        workDir: '/w',
+        logDir: '/l',
+      });
+      expect(env).not.toHaveProperty('PREBUILDS_ONLY');
+    } finally {
+      if (prev === undefined) delete process.env.PREBUILDS_ONLY;
+      else process.env.PREBUILDS_ONLY = prev;
+    }
+  });
+
+  it('strips PREBUILDS_ONLY and injects no dir vars when no dir config is provided', () => {
+    const keys = ['PREBUILDS_ONLY', 'AIONUI_CACHE_DIR', 'AIONUI_WORK_DIR', 'AIONUI_LOG_DIR'] as const;
+    const saved = Object.fromEntries(keys.map((k) => [k, process.env[k]]));
+    process.env.PREBUILDS_ONLY = '1';
+    // Dir vars may be inherited from a dev shell; clear them so the assertion
+    // below observes injection behavior, not passthrough.
+    delete process.env.AIONUI_CACHE_DIR;
+    delete process.env.AIONUI_WORK_DIR;
+    delete process.env.AIONUI_LOG_DIR;
+    try {
+      const env = buildSpawnEnv();
+      expect(env).not.toHaveProperty('PREBUILDS_ONLY');
+      expect(env).not.toHaveProperty('AIONUI_CACHE_DIR');
+      expect(env).not.toHaveProperty('AIONUI_WORK_DIR');
+      expect(env).not.toHaveProperty('AIONUI_LOG_DIR');
+      expect(env.PATH).toBe(process.env.PATH); // inherits
+    } finally {
+      for (const k of keys) {
+        if (saved[k] === undefined) delete process.env[k];
+        else process.env[k] = saved[k];
+      }
+    }
+  });
 });
 
 describe('findAvailablePort', () => {

--- a/packages/web-host/src/backend-launcher.ts
+++ b/packages/web-host/src/backend-launcher.ts
@@ -221,9 +221,16 @@ export function buildSpawnArgs(config: SpawnConfig): string[] {
  * backend's `/api/system/info` matches what Electron main persists in
  * ProcessEnv('aionui.dir').
  */
-export function buildSpawnEnv(dirs: BackendDirConfig): NodeJS.ProcessEnv {
+export function buildSpawnEnv(dirs?: BackendDirConfig): NodeJS.ProcessEnv {
+  // PREBUILDS_ONLY protects the packaged Electron process's own node-gyp-build
+  // natives (see desktop process/index.ts) and must stay scoped to it. Agent
+  // CLIs spawned under aioncore (e.g. cursor-agent) ship natives under
+  // build/Release only, and node-gyp-build skips that directory for any
+  // non-empty value, aborting the agent before the ACP handshake (#4070).
+  const { PREBUILDS_ONLY: _prebuildsOnly, ...parentEnv } = process.env;
+  if (!dirs) return parentEnv;
   return {
-    ...process.env,
+    ...parentEnv,
     AIONUI_CACHE_DIR: dirs.cacheDir,
     AIONUI_WORK_DIR: dirs.workDir,
     AIONUI_LOG_DIR: dirs.logDir,
@@ -682,7 +689,7 @@ export class BackendLifecycleManager {
     try {
       this.childProcess = spawn(binaryPath, args, {
         stdio: ['pipe', 'pipe', 'pipe'],
-        env: dirs ? buildSpawnEnv(dirs) : process.env,
+        env: buildSpawnEnv(dirs),
         cwd: dirs?.workDir ?? dbPath,
         detached: process.platform !== 'win32',
       });


### PR DESCRIPTION
## Description

Packaged AionUi sets `PREBUILDS_ONLY=1` (`packages/desktop/src/process/index.ts`) to force its own node-gyp-build natives onto `prebuilds/`. `buildSpawnEnv` copied the full `process.env` into aioncore, so every agent CLI spawned under it inherited the flag. Third-party CLIs such as cursor-agent bundle natives under `build/Release` only (no `prebuilds/`), and node-gyp-build treats **any non-empty value** as enabled, so the agent crashed with `No native build was found` before completing the ACP initialize handshake — surfacing as "CLI started, but ACP initialization failed."

This PR strips `PREBUILDS_ONLY` in `buildSpawnEnv` and routes the previously-raw `env: process.env` spawn fallback (no dir config) through `buildSpawnEnv` as well, so the flag stays scoped to the Electron process where it is still needed.

**Verification of the root cause** (macOS arm64, cursor-agent `2026.08.11-e8db854`, the exact version from the report):

- `PREBUILDS_ONLY=1 cursor-agent worker-server` → `Error: No native build was found for platform=darwin arch=arm64 ... abi=137 node=24.5.0`, byte-identical to the issue report
- `PREBUILDS_ONLY= cursor-agent worker-server` → `running worker server` (tree-sitter loads fine)
- `node_modules/tree-sitter/` in that build ships `build/Release/tree_sitter_runtime_binding.node` and no `prebuilds/` directory, confirming the layout described in the issue

## Related Issues

- Closes #4070

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — targeted suites pass: `packages/web-host/` (4 files, 72 tests) and `tests/unit/bootstrap/backendLauncherParentPid.test.ts`; full suite left to CI
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — N/A, no user-facing text changed

## Runtime Verification

- [x] Verified on macOS — reproduced the failure and validated the env-scoping fix against the real cursor-agent `2026.08.11-e8db854` binary (A/B with `PREBUILDS_ONLY` set vs stripped)
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

Two regression tests added to `backend-launcher.test.ts`: the spawned aioncore env must not contain `PREBUILDS_ONLY` even when the parent has it set, both with and without a dir config. Setting the override to `0`/`false` would not have helped users — node-gyp-build uses a truthiness check (`!!process.env.PREBUILDS_ONLY`), so only stripping the variable (or an empty value) disables the restriction.
