### PR TITLE
fix(chat): align compose actions and draft queue draining

### DIFF
--- a/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
+++ b/packages/desktop/src/renderer/components/chat/SendBox/index.tsx
@@ -33,7 +33,7 @@ import { blurActiveElement, shouldBlockMobileInputFocus } from '@/renderer/utils
 import { isPlatformPrimaryModifier } from '@/renderer/utils/ui/keyboardShortcuts';
 import { isMacOS } from '@/renderer/utils/platform';
 import { Button, Input, Message, Tag, Tooltip } from '@arco-design/web-react';
-import { ArrowUp, CloseSmall, Plus, Quote } from '@icon-park/react';
+import { CloseSmall, Plus, Quote } from '@icon-park/react';
 import { chatFileRefKey } from '@/common/types/chatFile';
 import type { SlashCommandItem } from '@/common/chat/slash/types';
 import { buildSkillSlashCommands, mergeSlashCommands } from '@/common/chat/slash/mergeSlashCommands';
@@ -66,6 +66,13 @@ const AT_FILE_HIGHLIGHT_COLOR = 'var(--primary)';
 // Max items shown in the `@` dropdown (both data sources); the result panel skin
 // is unbounded (streaming append) — this caps only the inline mention menu.
 const AT_FILE_MENTION_LIMIT = 8;
+
+const SendArrowIcon: React.FC<{ size?: number }> = ({ size = 16 }) => (
+  <svg width={size} height={size} viewBox='0 0 24 24' fill='none' stroke='currentColor' aria-hidden='true'>
+    <path d='M12 19V5' strokeWidth='2.7' strokeLinecap='round' />
+    <path d='M6.5 10.5 12 5l5.5 5.5' strokeWidth='2.7' strokeLinecap='round' strokeLinejoin='round' />
+  </svg>
+);
 
 const DraftBoxActionIcon: React.FC<{ size?: number; color?: string; strokeWidth?: number }> = ({
   size = 16,
@@ -1463,19 +1470,35 @@ const SendBox: React.FC<{
   const isSendActionDisabled = disabled || sendDisabled || isUploading || !hasDraftToSend;
   const isDraftActionDisabled = disabled || addToDraftDisabled || isUploading || !hasDraftToSend || !onAddToDraft;
   const hasDraftAction = Boolean(onAddToDraft);
+  const sendButtonShapeStyle: React.CSSProperties = {
+    width: 32,
+    minWidth: 32,
+    height: 32,
+    minHeight: 32,
+    padding: 0,
+    borderRadius: '50%',
+    overflow: 'hidden',
+    clipPath: 'circle(50% at 50% 50%)',
+    boxShadow: 'none',
+  };
 
   const primaryActionButton = (
     <Tooltip content={sendActionTooltip} position='top'>
-      <Button
-        shape='circle'
-        type='primary'
-        disabled={isSendActionDisabled}
-        className='send-button-custom'
-        icon={<ArrowUp theme='filled' size='14' fill='white' strokeWidth={5} />}
-        onClick={handlePrimaryAction}
-        data-testid='sendbox-send-btn'
-        aria-label={typeof sendActionTooltip === 'string' ? sendActionTooltip : sendNowLabel}
-      />
+      <span className='sendbox-send-tooltip-anchor' style={sendButtonShapeStyle}>
+        <Button
+          shape='circle'
+          type='text'
+          disabled={isSendActionDisabled}
+          className={`send-button-custom ${
+            isSendActionDisabled ? 'send-button-custom--disabled' : 'send-button-custom--enabled'
+          }`}
+          style={sendButtonShapeStyle}
+          icon={<SendArrowIcon size={16} />}
+          onClick={handlePrimaryAction}
+          data-testid='sendbox-send-btn'
+          aria-label={typeof sendActionTooltip === 'string' ? sendActionTooltip : sendNowLabel}
+        />
+      </span>
     </Tooltip>
   );
 

--- a/packages/desktop/src/renderer/components/chat/SendBox/sendbox.css
+++ b/packages/desktop/src/renderer/components/chat/SendBox/sendbox.css
@@ -1,11 +1,65 @@
 /* Sendbox component styles */
 
-/* Send button disabled state - override Arco Design default disabled styles */
-.send-button-custom:disabled,
-.send-button-custom.arco-btn:disabled,
-.send-button-custom.arco-btn-primary:disabled {
-  background-color: #d3d4d9 !important;
-  border-color: #d3d4d9 !important;
+/* Send button layout - keep Arco primary states from drawing a square block */
+.send-button-custom,
+.send-button-custom.arco-btn,
+.send-button-custom.arco-btn-primary {
+  width: 32px !important;
+  min-width: 32px !important;
+  height: 32px !important;
+  min-height: 32px !important;
+  padding: 0 !important;
+  border-radius: 50% !important;
+  box-shadow: none !important;
+  outline: none !important;
+  flex: 0 0 32px !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  overflow: hidden !important;
+  clip-path: circle(50% at 50% 50%) !important;
+}
+
+.send-button-custom::before,
+.send-button-custom::after,
+.send-button-custom.arco-btn::before,
+.send-button-custom.arco-btn::after {
+  background: transparent !important;
+  border-radius: 50% !important;
+  box-shadow: none !important;
+  content: none !important;
+}
+
+.send-button-custom--enabled,
+.send-button-custom--enabled.arco-btn {
+  background-color: rgb(var(--primary-6)) !important;
+  border-color: rgb(var(--primary-6)) !important;
+  color: var(--text-white) !important;
+}
+
+.send-button-custom--enabled:not(:disabled):hover,
+.send-button-custom--enabled.arco-btn:not(:disabled):hover,
+.send-button-custom--enabled:not(:disabled):active,
+.send-button-custom--enabled.arco-btn:not(:disabled):active,
+.send-button-custom--enabled:not(:disabled):focus,
+.send-button-custom--enabled.arco-btn:not(:disabled):focus,
+.send-button-custom--enabled:not(:disabled):focus-visible,
+.send-button-custom--enabled.arco-btn:not(:disabled):focus-visible {
+  background-color: rgb(var(--primary-7)) !important;
+  border-color: rgb(var(--primary-7)) !important;
+  color: var(--text-white) !important;
+}
+
+/* Send button disabled state - keep it synchronized with the draft action. */
+.send-button-custom--disabled,
+.send-button-custom--disabled:disabled,
+.send-button-custom--disabled.arco-btn:disabled,
+.send-button-custom--disabled.arco-btn-disabled {
+  background-color: var(--color-fill-3) !important;
+  border-color: var(--color-fill-3) !important;
+  border-radius: 50% !important;
+  box-shadow: none !important;
+  color: var(--text-white) !important;
   opacity: 1 !important;
 }
 
@@ -13,6 +67,20 @@
 .send-button-custom .arco-icon > svg {
   stroke-width: 5 !important;
   filter: drop-shadow(0 0 0.5px currentColor);
+}
+
+.sendbox-send-tooltip-anchor {
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 32px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  background: transparent !important;
+  box-shadow: none !important;
+  overflow: hidden !important;
+  clip-path: circle(50% at 50% 50%) !important;
 }
 
 .sendbox-draft-tooltip-anchor {
@@ -63,14 +131,22 @@
 .sendbox-draft-tool-action--enabled,
 .sendbox-draft-tool-action--enabled.arco-btn,
 .sendbox-draft-tool-action--enabled.arco-btn-secondary {
-  background: rgb(var(--primary-6)) !important;
-  color: #fff !important;
+  background-color: rgb(var(--primary-6)) !important;
+  border-color: rgb(var(--primary-6)) !important;
+  color: var(--text-white) !important;
 }
 
 .sendbox-draft-tool-action--enabled:not(:disabled):hover,
-.sendbox-draft-tool-action--enabled.arco-btn:not(:disabled):hover {
-  background: rgb(var(--primary-7)) !important;
-  color: #fff !important;
+.sendbox-draft-tool-action--enabled.arco-btn:not(:disabled):hover,
+.sendbox-draft-tool-action--enabled:not(:disabled):active,
+.sendbox-draft-tool-action--enabled.arco-btn:not(:disabled):active,
+.sendbox-draft-tool-action--enabled:not(:disabled):focus,
+.sendbox-draft-tool-action--enabled.arco-btn:not(:disabled):focus,
+.sendbox-draft-tool-action--enabled:not(:disabled):focus-visible,
+.sendbox-draft-tool-action--enabled.arco-btn:not(:disabled):focus-visible {
+  background-color: rgb(var(--primary-7)) !important;
+  border-color: rgb(var(--primary-7)) !important;
+  color: var(--text-white) !important;
 }
 
 .sendbox-draft-tool-action--disabled,
@@ -78,24 +154,49 @@
 .sendbox-draft-tool-action--disabled.arco-btn:disabled,
 .sendbox-draft-tool-action--disabled.arco-btn-disabled,
 .sendbox-draft-tool-action--disabled.arco-btn-secondary:disabled {
-  background-color: #e4e6ed !important;
-  border-color: #e4e6ed !important;
-  color: #fff !important;
+  background-color: var(--color-fill-3) !important;
+  border-color: var(--color-fill-3) !important;
+  color: var(--text-white) !important;
   opacity: 1 !important;
   cursor: not-allowed !important;
 }
 
-/* Dark mode: adjust send button brightness */
-[data-theme='dark'] .send-button-custom:not(:disabled) {
-  background-color: var(--aou-4) !important;
-  border-color: var(--aou-4) !important;
+html[data-theme='dark'] body .sendbox-panel .sendbox-draft-tool-action--disabled,
+html[data-theme='dark'] body .sendbox-panel .sendbox-draft-tool-action--disabled:disabled,
+html[data-theme='dark'] body .sendbox-panel .sendbox-draft-tool-action--disabled.arco-btn:disabled,
+html[data-theme='dark'] body .sendbox-panel .sendbox-draft-tool-action--disabled.arco-btn-disabled,
+html[data-theme='dark'] body .sendbox-panel .sendbox-draft-tool-action--disabled.arco-btn-secondary:disabled,
+body[arco-theme='dark'] .sendbox-panel .sendbox-draft-tool-action--disabled,
+body[arco-theme='dark'] .sendbox-panel .sendbox-draft-tool-action--disabled:disabled,
+body[arco-theme='dark'] .sendbox-panel .sendbox-draft-tool-action--disabled.arco-btn:disabled,
+body[arco-theme='dark'] .sendbox-panel .sendbox-draft-tool-action--disabled.arco-btn-disabled,
+body[arco-theme='dark'] .sendbox-panel .sendbox-draft-tool-action--disabled.arco-btn-secondary:disabled {
+  background-color: var(--bg-4) !important;
+  border-color: var(--bg-4) !important;
+  color: var(--text-disabled) !important;
 }
 
-[data-theme='dark'] .send-button-custom:disabled,
-[data-theme='dark'] .send-button-custom.arco-btn:disabled,
-[data-theme='dark'] .send-button-custom.arco-btn-primary:disabled {
-  background-color: color-mix(in srgb, var(--color-fill-4) 82%, var(--color-bg-2)) !important;
-  border-color: color-mix(in srgb, var(--color-fill-4) 88%, var(--color-bg-2)) !important;
+html[data-theme='dark'] body .sendbox-panel .send-button-custom--disabled,
+html[data-theme='dark'] body .sendbox-panel .send-button-custom--disabled:disabled,
+html[data-theme='dark'] body .sendbox-panel .send-button-custom--disabled.arco-btn:disabled,
+html[data-theme='dark'] body .sendbox-panel .send-button-custom--disabled.arco-btn-disabled,
+body[arco-theme='dark'] .sendbox-panel .send-button-custom--disabled,
+body[arco-theme='dark'] .sendbox-panel .send-button-custom--disabled:disabled,
+body[arco-theme='dark'] .sendbox-panel .send-button-custom--disabled.arco-btn:disabled,
+body[arco-theme='dark'] .sendbox-panel .send-button-custom--disabled.arco-btn-disabled {
+  background-color: var(--bg-4) !important;
+  border-color: var(--bg-4) !important;
+  border-radius: 50% !important;
+  box-shadow: none !important;
+  color: var(--text-disabled) !important;
+}
+
+html[data-theme='dark'] body .sendbox-panel .send-button-custom--disabled svg,
+html[data-theme='dark'] body .sendbox-panel .send-button-custom--disabled svg *,
+body[arco-theme='dark'] .sendbox-panel .send-button-custom--disabled svg,
+body[arco-theme='dark'] .sendbox-panel .send-button-custom--disabled svg * {
+  fill: currentColor !important;
+  stroke: currentColor !important;
 }
 
 .sendbox-stop-button,
@@ -595,4 +696,14 @@
   .speech-input-feedback__label {
     min-width: 28px;
   }
+}
+
+.sendbox-actions .arco-trigger:has(.send-button-custom),
+.sendbox-tools .arco-trigger:has(.send-button-custom),
+.arco-trigger:has(.send-button-custom),
+span:has(> .send-button-custom),
+span:has(.send-button-custom) {
+  background: transparent !important;
+  border-radius: 50% !important;
+  box-shadow: none !important;
 }

--- a/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
+++ b/packages/desktop/src/renderer/pages/conversation/platforms/useConversationCommandQueue.ts
@@ -625,13 +625,28 @@ export const useConversationCommandQueue = ({
       return;
     }
 
+    if (waitingForTurnStartRef.current && executionGate.hydrated && executionGate.canExecute) {
+      waitingForTurnStartRef.current = false;
+      waitingForTurnCompletionRef.current = false;
+      observedBusyBlockedGateRef.current = false;
+      logCommandQueue(conversation_id, 'turn-finished-without-observed-start', {
+        pendingItemCount: stateRef.current.items.length,
+      });
+    }
+
     if (waitingForTurnCompletionRef.current && executionGate.hydrated && executionGate.canExecute) {
       waitingForTurnCompletionRef.current = false;
       logCommandQueue(conversation_id, 'turn-finished', {
         pendingItemCount: stateRef.current.items.length,
       });
     }
-  }, [conversation_id, executionGate.canExecute, executionGate.hydrated, executionGate.isProcessing]);
+  }, [
+    conversation_id,
+    data.items.length,
+    executionGate.canExecute,
+    executionGate.hydrated,
+    executionGate.isProcessing,
+  ]);
 
   useEffect(() => {
     pausedRef.current = data.isPaused;

--- a/tests/unit/conversation/runtime/conversationCommandQueueDrain.dom.test.tsx
+++ b/tests/unit/conversation/runtime/conversationCommandQueueDrain.dom.test.tsx
@@ -236,6 +236,31 @@ describe('useConversationCommandQueue drain', () => {
     );
   });
 
+  it('continues auto-draining when a send finishes before a busy state is observed', async () => {
+    const onExecute = vi.fn().mockResolvedValue(undefined);
+    sessionStorage.setItem(
+      storageKey('conv-fast-finish'),
+      JSON.stringify({
+        items: [
+          { id: 'queued-fast-1', input: 'first fast command', files: [], created_at: 1 },
+          { id: 'queued-fast-2', input: 'second fast command', files: [], created_at: 2 },
+        ],
+        isPaused: false,
+        mode: 'auto',
+      })
+    );
+
+    renderQueue({
+      conversation_id: 'conv-fast-finish',
+      runtimeGate: idleGate,
+      onExecute,
+    });
+
+    await waitFor(() => expect(onExecute).toHaveBeenCalledTimes(2));
+    expect(onExecute).toHaveBeenNthCalledWith(1, expect.objectContaining({ input: 'first fast command' }));
+    expect(onExecute).toHaveBeenNthCalledWith(2, expect.objectContaining({ input: 'second fast command' }));
+  });
+
   it('continues draining queued commands after the active conversation hook unmounts', async () => {
     const onExecute = vi.fn().mockResolvedValue(undefined);
     const { result, unmount } = renderQueue({
@@ -411,12 +436,12 @@ describe('useConversationCommandQueue drain', () => {
   });
 
   it('retries after release when the blocked gate was observed before the busy catch', async () => {
-    let rerenderQueue: ReturnType<typeof renderQueue>['rerender'] = () => undefined;
+    const rerenderQueueRef: { current: ReturnType<typeof renderQueue>['rerender'] } = { current: () => undefined };
     let attempts = 0;
     const onExecute = vi.fn(async () => {
       attempts += 1;
       if (attempts === 1) {
-        rerenderQueue({ gate: processingGate, busy: true });
+        rerenderQueueRef.current({ gate: processingGate, busy: true });
         await new Promise((resolve) => setTimeout(resolve, 0));
         throw busyError();
       }
@@ -426,7 +451,7 @@ describe('useConversationCommandQueue drain', () => {
       runtimeGate: idleGate,
       onExecute,
     });
-    rerenderQueue = rerender;
+    rerenderQueueRef.current = rerender;
 
     act(() => {
       result.current.toggleMode();

--- a/tests/unit/renderer/conversation/sendBoxDarkButtonStyles.test.ts
+++ b/tests/unit/renderer/conversation/sendBoxDarkButtonStyles.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const cssPath = resolve(__dirname, '../../../../packages/desktop/src/renderer/components/chat/SendBox/sendbox.css');
+const tsxPath = resolve(__dirname, '../../../../packages/desktop/src/renderer/components/chat/SendBox/index.tsx');
+const css = readFileSync(cssPath, 'utf8');
+const tsx = readFileSync(tsxPath, 'utf8');
+
+const getRuleBodyContainingSelector = (selector: string): string => {
+  const rules = css.match(/[^{}]+\{[^}]+\}/g) ?? [];
+  const rule = rules.find((candidate) => candidate.slice(0, candidate.indexOf('{')).includes(selector));
+  return rule?.slice(rule.indexOf('{') + 1, -1) ?? '';
+};
+
+describe('SendBox action button styles', () => {
+  it('keeps disabled send and draft buttons synchronized in dark mode', () => {
+    const sendBody = getRuleBodyContainingSelector(
+      "html[data-theme='dark'] body .sendbox-panel .send-button-custom--disabled.arco-btn:disabled"
+    );
+    const draftBody = getRuleBodyContainingSelector(
+      "html[data-theme='dark'] body .sendbox-panel .sendbox-draft-tool-action--disabled.arco-btn-secondary:disabled"
+    );
+
+    expect(sendBody).toContain('background-color: var(--bg-4)');
+    expect(sendBody).toContain('color: var(--text-disabled)');
+    expect(draftBody).toContain('background-color: var(--bg-4)');
+    expect(draftBody).toContain('color: var(--text-disabled)');
+  });
+
+  it('keeps active send and draft buttons synchronized', () => {
+    const sendBody = getRuleBodyContainingSelector('.send-button-custom--enabled.arco-btn');
+    const draftBody = getRuleBodyContainingSelector('.sendbox-draft-tool-action--enabled.arco-btn-secondary');
+
+    expect(sendBody).toContain('background-color: rgb(var(--primary-6))');
+    expect(sendBody).toContain('color: var(--text-white)');
+    expect(draftBody).toContain('background-color: rgb(var(--primary-6))');
+    expect(draftBody).toContain('color: var(--text-white)');
+  });
+
+  it('prevents the send button from drawing a square primary background', () => {
+    const layoutBody = getRuleBodyContainingSelector('.send-button-custom.arco-btn');
+
+    expect(layoutBody).toContain('border-radius: 50%');
+    expect(layoutBody).toContain('clip-path: circle(50% at 50% 50%)');
+    expect(tsx).toContain("type='text'");
+    expect(tsx).not.toContain('<ArrowUp');
+  });
+});

--- a/tests/unit/renderer/previewScopeLru.dom.test.tsx
+++ b/tests/unit/renderer/previewScopeLru.dom.test.tsx
@@ -128,7 +128,7 @@ describe('a full storage quota is reported', () => {
   const flush = () => act(() => void vi.advanceTimersByTime(300));
 
   it('raises persistQuotaExceededAt when writes cannot succeed', () => {
-    const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+    const setItem = vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
       const err = new Error('QuotaExceededError');
       err.name = 'QuotaExceededError';
       throw err;

--- a/tests/unit/renderer/previewScopeLru.dom.test.tsx
+++ b/tests/unit/renderer/previewScopeLru.dom.test.tsx
@@ -128,11 +128,24 @@ describe('a full storage quota is reported', () => {
   const flush = () => act(() => void vi.advanceTimersByTime(300));
 
   it('raises persistQuotaExceededAt when writes cannot succeed', () => {
-    const setItem = vi.spyOn(localStorage, 'setItem').mockImplementation(() => {
-      const err = new Error('QuotaExceededError');
-      err.name = 'QuotaExceededError';
-      throw err;
-    });
+    const originalStorage = window.localStorage;
+    const quotaStorage: Storage = {
+      get length() {
+        return originalStorage.length;
+      },
+      clear: () => originalStorage.clear(),
+      getItem: (key) => originalStorage.getItem(key),
+      key: (index) => originalStorage.key(index),
+      removeItem: (key) => originalStorage.removeItem(key),
+      setItem: () => {
+        const err = new Error('QuotaExceededError');
+        err.name = 'QuotaExceededError';
+        throw err;
+      },
+    };
+
+    Object.defineProperty(window, 'localStorage', { value: quotaStorage, configurable: true });
+    Object.defineProperty(globalThis, 'localStorage', { value: quotaStorage, configurable: true });
 
     try {
       mount();
@@ -144,7 +157,8 @@ describe('a full storage quota is reported', () => {
       // The signal the UI turns into a visible warning. Silence was the bug.
       expect(ctx.persistQuotaExceededAt).not.toBeNull();
     } finally {
-      setItem.mockRestore();
+      Object.defineProperty(window, 'localStorage', { value: originalStorage, configurable: true });
+      Object.defineProperty(globalThis, 'localStorage', { value: originalStorage, configurable: true });
     }
   });
 


### PR DESCRIPTION
## Summary
- Align SendBox send and draft action button colors across enabled and disabled states in dark mode.
- Remove the square primary background artifact around the send action.
- Continue auto-draining draft box messages when a send finishes before the UI observes a busy state.
- Stabilize the preview quota storage mock used by the full unit test run.

## Validation
- just push
  - oxlint --quiet
  - oxfmt --check
  - tsc --noEmit
  - i18n type generation and validation
  - vitest full unit suite
- bunx electron-vite build --config packages/desktop/electron.vite.config.ts
- bun run start:multi