### PR TITLE
fix(i18n): align directory paths to the page direction, not hardcoded end

### DIFF
--- a/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/DirInputItem.tsx
+++ b/packages/desktop/src/renderer/components/settings/SettingsModal/contents/SystemModalContent/DirInputItem.tsx
@@ -57,7 +57,7 @@ const DirInputItem: React.FC<{
           >
             <Tooltip content={current_value || t('settings.dirNotConfigured')} position='top'>
               {/* Paths are code-like; without dir=ltr the leading slash flips to the end under RTL. */}
-              <div dir='ltr' className='flex-1 min-w-0 text-13px text-t-primary truncate text-end'>
+              <div dir='ltr' className='flex-1 min-w-0 text-13px text-t-primary truncate rtl-text-right'>
                 {current_value || t('settings.dirNotConfigured')}
               </div>
             </Tooltip>

--- a/packages/desktop/src/renderer/styles/layout.css
+++ b/packages/desktop/src/renderer/styles/layout.css
@@ -266,3 +266,9 @@
 [dir='rtl'] .rtl-mirror {
   transform: scaleX(-1);
 }
+
+/* LTR islands (paths, file names) inside an RTL layout: pin the text to the
+   page's reading edge. LTR pages keep the island's natural left alignment. */
+[dir='rtl'] .rtl-text-right {
+  text-align: right;
+}


### PR DESCRIPTION
## Description

Regression fix for #4077. The RTL polish pinned `dir="ltr"` on the system-settings directory paths and added `text-end` so they sit at the field's reading edge under RTL — but `text-end` inside a forced-LTR island resolves to the **right in every layout**, so LTR languages (zh-CN, en-US, …) got right-aligned paths pressed against the folder button (reported by a zh-CN user).

Alignment now follows the page direction instead of being hardcoded: a new `[dir='rtl'] .rtl-text-right` rule (placed next to the existing `.rtl-mirror` utility) right-aligns LTR islands only under RTL layouts; LTR pages keep the island's natural left alignment.

## Verification

Verified in the running webui build in both directions:

| Language | Path alignment |
|---|---|
| zh-CN (LTR) | `/Users/zhoukai/.aionui-web-dev` left-aligned again (was right-aligned against the folder button) |
| fa-IR (RTL) | right-aligned, leading slash still in place — no regression of the #4077 fix |

## Related Issues

Regression from #4077; same i18n thread as #4068–#4077.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring
- [ ] Breaking change
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format

## Local Checks (Rule 3)

- [x] `bun run format` — passes
- [x] `bun run lint` — no errors
- [x] `bunx tsc --noEmit` — no errors
- [x] `bunx vitest run` — full suite green via `just push` gate
- [x] i18n validated — no key changes (one class + one CSS rule)
- [x] New/changed user-facing text uses i18n keys — no text changes

## Runtime Verification

- [x] Verified on macOS (webui build, zh-CN and fa-IR both screenshotted)
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code
