### PR TITLE
fix(markdown): render chat KaTeX formulas once in Shadow DOM

### DIFF
--- a/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
@@ -274,6 +274,39 @@ const createInitStyle = (
 let katexStyleSheet: CSSStyleSheet | null = null;
 
 /**
+ * Collect every KaTeX-related CSS rule from the given stylesheets.
+ *
+ * KaTeX ships as a single `katex.min.css`, but the bundler inlines it as an
+ * anonymous `<style>` with no `href`/`data-katex` marker, so it cannot be located
+ * by attribute. Other sheets (e.g. the preview `.aionui-markdown` theme) merely
+ * *reference* `.katex` selectors — picking the first sheet that mentions `.katex`
+ * can grab such a partial sheet, which lacks KaTeX's `.katex-mathml`
+ * accessibility-hide rule and `@font-face` declarations. Adopting that partial
+ * sheet into a Shadow DOM leaves the raw MathML annotation visible right next to
+ * the rendered formula (the "formula shows twice" bug in chat). Aggregating every
+ * katex-referencing rule across all sheets guarantees the hide rule and fonts are
+ * always included regardless of how many sheets the rules are spread across.
+ */
+export const collectKatexCssRules = (styleSheets: Iterable<CSSStyleSheet>): string[] => {
+  const collected: string[] = [];
+  for (const sheet of styleSheets) {
+    let rules: CSSRule[];
+    try {
+      rules = [...sheet.cssRules];
+    } catch {
+      // CORS may block access to cssRules for cross-origin stylesheets
+      continue;
+    }
+    for (const rule of rules) {
+      if (rule.cssText.toLowerCase().includes('katex')) {
+        collected.push(rule.cssText);
+      }
+    }
+  }
+  return collected;
+};
+
+/**
  * Get or create a shared KaTeX CSSStyleSheet for Shadow DOM adoption.
  * This extracts KaTeX styles from the document and creates a constructable stylesheet.
  */
@@ -281,35 +314,11 @@ const getKatexStyleSheet = (): CSSStyleSheet | null => {
   if (katexStyleSheet) return katexStyleSheet;
 
   try {
-    // Find the KaTeX stylesheet in the document
-    const katexSheet = [...document.styleSheets].find(
-      (sheet) => sheet.href?.includes('katex') || (sheet.ownerNode as HTMLElement)?.dataset?.katex
-    );
-
-    if (katexSheet) {
-      const cssRules = [...katexSheet.cssRules].map((rule) => rule.cssText).join('\n');
+    const cssRules = collectKatexCssRules([...document.styleSheets]);
+    if (cssRules.length > 0) {
       katexStyleSheet = new CSSStyleSheet();
-      katexStyleSheet.replaceSync(cssRules);
+      katexStyleSheet.replaceSync(cssRules.join('\n'));
       return katexStyleSheet;
-    }
-
-    // Fallback: try to find KaTeX styles by checking style tags
-    const styleSheets = [...document.styleSheets];
-    for (const sheet of styleSheets) {
-      try {
-        const rules = [...sheet.cssRules];
-        // Check if this stylesheet contains KaTeX rules
-        const hasKatexRules = rules.some((rule) => rule.cssText.includes('.katex'));
-        if (hasKatexRules) {
-          const cssRules = rules.map((rule) => rule.cssText).join('\n');
-          katexStyleSheet = new CSSStyleSheet();
-          katexStyleSheet.replaceSync(cssRules);
-          return katexStyleSheet;
-        }
-      } catch {
-        // CORS may block access to cssRules for external stylesheets
-        continue;
-      }
     }
   } catch (error) {
     console.warn('Failed to create KaTeX stylesheet for Shadow DOM:', error);

--- a/tests/unit/renderer/shadowViewKatexStyles.test.ts
+++ b/tests/unit/renderer/shadowViewKatexStyles.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { collectKatexCssRules } from '@renderer/components/Markdown/ShadowView';
+
+/**
+ * Build a minimal CSSStyleSheet-like stub. `collectKatexCssRules` only reads
+ * `sheet.cssRules` and each `rule.cssText`, so a plain object is enough — and it
+ * avoids the constructable-stylesheet / adoptedStyleSheets APIs that jsdom lacks.
+ */
+const sheet = (...cssTexts: string[]): CSSStyleSheet =>
+  ({ cssRules: cssTexts.map((cssText) => ({ cssText })) as unknown as CSSRuleList }) as CSSStyleSheet;
+
+// The accessibility-hide rule that KaTeX ships to keep the MathML annotation out
+// of view; missing it is exactly what makes the formula render twice in chat.
+const KATEX_MATHML_HIDE =
+  '.katex .katex-mathml { position: absolute; clip: rect(1px, 1px, 1px, 1px); height: 1px; overflow: hidden; }';
+const KATEX_FONT_FACE = '@font-face { font-family: KaTeX_Main; src: url(fonts/KaTeX_Main.woff2); }';
+// A sheet that only *references* `.katex` (mirrors the preview `.aionui-markdown` theme).
+const PARTIAL_THEME_RULE = '.aionui-markdown :where(.katex, .katex *) { line-height: normal; }';
+
+describe('collectKatexCssRules', () => {
+  it('includes the real KaTeX hide rule even when a partial theme sheet appears first', () => {
+    // Regression: the old "first sheet mentioning .katex wins" logic grabbed the
+    // partial theme sheet and dropped the essential .katex-mathml hide rule.
+    const styleSheets = [
+      sheet('.unrelated { color: red; }', PARTIAL_THEME_RULE),
+      sheet(KATEX_MATHML_HIDE, KATEX_FONT_FACE),
+    ];
+
+    const rules = collectKatexCssRules(styleSheets);
+
+    expect(rules).toContain(KATEX_MATHML_HIDE);
+    expect(rules).toContain(KATEX_FONT_FACE);
+    // The partial theme rule is katex-related too, so it is still collected.
+    expect(rules).toContain(PARTIAL_THEME_RULE);
+  });
+
+  it('excludes rules that do not reference KaTeX', () => {
+    const rules = collectKatexCssRules([sheet('.unrelated { color: red; }', KATEX_MATHML_HIDE)]);
+
+    expect(rules).toEqual([KATEX_MATHML_HIDE]);
+  });
+
+  it('skips stylesheets whose cssRules throw (cross-origin) without losing later sheets', () => {
+    const corsSheet = {
+      get cssRules(): CSSRuleList {
+        throw new DOMException('insecure operation', 'SecurityError');
+      },
+    } as CSSStyleSheet;
+
+    const rules = collectKatexCssRules([corsSheet, sheet(KATEX_MATHML_HIDE)]);
+
+    expect(rules).toEqual([KATEX_MATHML_HIDE]);
+  });
+
+  it('returns an empty array when no stylesheet mentions KaTeX', () => {
+    const rules = collectKatexCssRules([sheet('.a { color: red; }'), sheet('.b { color: blue; }')]);
+
+    expect(rules).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Description

Chat-area KaTeX formulas rendered **twice** (the raw LaTeX/MathML annotation showed next to the rendered formula), while the file-preview panel rendered them correctly.

Root cause, confirmed by probing the live app: the chat renders markdown inside a **Shadow DOM**, so it cannot inherit the document's KaTeX stylesheet — it adopts one via `adoptedStyleSheets`. `getKatexStyleSheet()` picked the **first** stylesheet whose rules mention `.katex`. In bundled builds that first match is the preview `.aionui-markdown` theme (39 rules), a *partial* sheet that merely references `.katex` and lacks KaTeX's `.katex-mathml` accessibility-hide rule. The real `katex.min.css` (251 rules, with the hide rule + `@font-face`) is a later sheet. Adopting the partial sheet left `.katex-mathml` visible (`position: static` instead of the hidden `position: absolute; clip: rect(1px,1px,1px,1px)`), so the MathML annotation text showed alongside the formula.

The preview panel is unaffected because it renders in the light DOM where the full KaTeX sheet cascades directly.

### Fix

- Aggregate **every** katex-related CSS rule across **all** document stylesheets instead of taking the first sheet that mentions `.katex`. This guarantees the `.katex-mathml` hide rule and `@font-face` declarations are always adopted into the Shadow DOM, regardless of how the bundler splits them.
- Extract `collectKatexCssRules` as a pure, testable helper.

### Verification

- Measured on the running app: adopting the aggregated sheet (253 rules, includes the hide rule) flips `.katex-mathml` from `position: static` → `position: absolute; clip: rect(1px,1px,1px,1px); height: 1px` → hidden → formula shows once.
- Added regression tests (`shadowViewKatexStyles.test.ts`) covering: partial theme sheet ordered first, CORS-throwing sheets skipped, non-katex rules excluded, empty case.

## Related Issues

- Closes #

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (pre-existing warnings only)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (4195 passed / 5 skipped via `just push`)
- [x] i18n validated — no i18n-relevant changes; validation still passed
- [x] New/changed user-facing text uses i18n keys (no user-facing text changed)

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

Behavior change is limited to how the shared KaTeX stylesheet is located for Shadow DOM adoption; the preview panel and non-math markdown are unaffected.
