### PR TITLE
fix(security): block path traversal in HTML renderer resource inlining

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/renderers/HTMLRenderer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/renderers/HTMLRenderer.tsx
@@ -72,12 +72,26 @@ function summarizePreviewUrl(url?: string): string | undefined {
 }
 
 /**
+ * 判断绝对路径是否在可信根目录内（纯字符串实现，renderer 不可用 node:path）。
+ * 通过比较路径段前缀实现，避免 `..`/`../` 逃逸。
+ */
+function isWithinRoot(root: string, target: string): boolean {
+  if (!root) return true;
+  const rootParts = root.replace(/\\/g, '/').replace(/\/+$/, '').split('/').filter(Boolean);
+  const targetParts = target.replace(/\\/g, '/').split('/').filter(Boolean);
+  if (rootParts.length === 0) return true;
+  if (targetParts.length < rootParts.length) return false;
+  return rootParts.every((part, i) => part === targetParts[i]);
+}
+
+/**
  * 解析相对路径为绝对路径 / Resolve relative path to absolute path
  * @param basePath 基础文件路径 / Base file path
  * @param relativePath 相对路径 / Relative path
+ * @param workspace 可信工作区根目录（可选）/ Trusted workspace root (optional)
  * @returns 绝对路径 / Absolute path
  */
-function resolveRelativePath(basePath: string, relativePath: string): string {
+export function resolveRelativePath(basePath: string, relativePath: string, workspace?: string): string {
   // 去除协议前缀 / Remove protocol prefix
   const cleanBasePath = basePath.replace(/^file:\/\//, '');
   const baseDir =
@@ -86,6 +100,10 @@ function resolveRelativePath(basePath: string, relativePath: string): string {
 
   // 如果相对路径已经是绝对路径，直接返回 / If relative path is already absolute, return directly
   if (relativePath.startsWith('/') || /^[a-zA-Z]:/.test(relativePath)) {
+    // 绝对路径必须落在可信工作区内，否则视为逃逸
+    if (workspace && !isWithinRoot(workspace, relativePath)) {
+      throw new Error(`Path traversal blocked: "${relativePath}" resolves outside workspace`);
+    }
     return relativePath;
   }
 
@@ -102,10 +120,13 @@ function resolveRelativePath(basePath: string, relativePath: string): string {
   }
 
   // 保留 Windows 盘符格式 / Preserve Windows drive letter format
-  if (/^[a-zA-Z]:/.test(baseDir)) {
-    return parts.join('/');
+  const result = /^[a-zA-Z]:/.test(baseDir) ? parts.join('/') : '/' + parts.join('/');
+
+  // 相对路径解析结果必须落在可信工作区内，否则视为逃逸
+  if (workspace && !isWithinRoot(workspace, result)) {
+    throw new Error(`Path traversal blocked: "${relativePath}" resolves outside workspace`);
   }
-  return '/' + parts.join('/');
+  return result;
 }
 
 /**
@@ -130,7 +151,7 @@ async function inlineRelativeResources(html: string, basePath: string, workspace
   for (const match of imgMatches) {
     const [fullMatch, before, src, after] = match;
     try {
-      const absolutePath = resolveRelativePath(basePath, src);
+      const absolutePath = resolveRelativePath(basePath, src, workspace);
       const dataUrl = await ipcBridge.fs.getImageBase64.invoke({ path: absolutePath, workspace });
       if (dataUrl) {
         // getImageBase64 已经返回完整的 data URL / getImageBase64 already returns complete data URL
@@ -152,7 +173,7 @@ async function inlineRelativeResources(html: string, basePath: string, workspace
     const isStylesheet = /rel=["']stylesheet["']/i.test(fullMatch) || href.endsWith('.css');
     if (isStylesheet) {
       try {
-        const absolutePath = resolveRelativePath(basePath, href);
+        const absolutePath = resolveRelativePath(basePath, href, workspace);
         const cssContent = await ipcBridge.fs.readFile.invoke({ path: absolutePath, workspace });
         if (cssContent) {
           // 替换 CSS 中的相对 url() 引用为 base64 / Replace relative url() references in CSS with base64
@@ -165,7 +186,7 @@ async function inlineRelativeResources(html: string, basePath: string, workspace
             try {
               // CSS 文件的基础路径 / Base path for CSS file
               const cssBasePath = absolutePath;
-              const resourcePath = resolveRelativePath(cssBasePath, urlPath);
+              const resourcePath = resolveRelativePath(cssBasePath, urlPath, workspace);
               const dataUrl = await ipcBridge.fs.getImageBase64.invoke({ path: resourcePath, workspace });
               if (dataUrl) {
                 // getImageBase64 已经返回完整的 data URL / getImageBase64 already returns complete data URL
@@ -192,7 +213,7 @@ async function inlineRelativeResources(html: string, basePath: string, workspace
   for (const match of scriptMatches) {
     const [fullMatch, before, src, after] = match;
     try {
-      const absolutePath = resolveRelativePath(basePath, src);
+      const absolutePath = resolveRelativePath(basePath, src, workspace);
       const scriptContent = await ipcBridge.fs.readFile.invoke({ path: absolutePath, workspace });
       if (scriptContent) {
         // 保留其他属性（如 type, defer, async 等，但 async/defer 对 inline 无效）

--- a/packages/desktop/src/renderer/pages/conversation/Preview/components/renderers/HTMLRenderer.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Preview/components/renderers/HTMLRenderer.tsx
@@ -85,6 +85,27 @@ function isWithinRoot(root: string, target: string): boolean {
 }
 
 /**
+ * 归一化绝对路径中的 `.`/`..` 段（纯字符串，renderer 不可用 node:path）。
+ * 保留 POSIX 根 `/` 与 Windows 盘符前缀。
+ * Normalize `.`/`..` segments in an absolute path (pure string; the renderer
+ * cannot use node:path). Preserves the POSIX root `/` and the Windows drive prefix.
+ */
+function normalizeAbsolute(path: string): string {
+  const unified = path.replace(/\\/g, '/');
+  const isWindowsDrive = /^[a-zA-Z]:/.test(unified);
+  const stack: string[] = [];
+  for (const segment of unified.split('/').filter(Boolean)) {
+    if (segment === '.') continue;
+    if (segment === '..') {
+      stack.pop();
+      continue;
+    }
+    stack.push(segment);
+  }
+  return isWindowsDrive ? stack.join('/') : '/' + stack.join('/');
+}
+
+/**
  * 解析相对路径为绝对路径 / Resolve relative path to absolute path
  * @param basePath 基础文件路径 / Base file path
  * @param relativePath 相对路径 / Relative path
@@ -98,13 +119,18 @@ export function resolveRelativePath(basePath: string, relativePath: string, work
     cleanBasePath.substring(0, cleanBasePath.lastIndexOf('/') + 1) ||
     cleanBasePath.substring(0, cleanBasePath.lastIndexOf('\\') + 1);
 
-  // 如果相对路径已经是绝对路径，直接返回 / If relative path is already absolute, return directly
+  // 如果相对路径已经是绝对路径 / If relative path is already absolute
   if (relativePath.startsWith('/') || /^[a-zA-Z]:/.test(relativePath)) {
-    // 绝对路径必须落在可信工作区内，否则视为逃逸
-    if (workspace && !isWithinRoot(workspace, relativePath)) {
+    // 先归一化 `.`/`..` 段再做边界检查，避免形如 `<workspace>/../../secret`
+    // 的字面遍历：它以工作区前缀开头却实际逃逸，未归一时会骗过 isWithinRoot。
+    // Normalize `.`/`..` before the boundary check: a literal
+    // `<workspace>/../../secret` starts with the workspace prefix yet escapes
+    // it, so an un-normalized string would slip past isWithinRoot.
+    const normalizedAbsolute = normalizeAbsolute(relativePath);
+    if (workspace && !isWithinRoot(workspace, normalizedAbsolute)) {
       throw new Error(`Path traversal blocked: "${relativePath}" resolves outside workspace`);
     }
-    return relativePath;
+    return normalizedAbsolute;
   }
 
   // 处理 ./ 和 ../ / Handle ./ and ../

--- a/tests/unit/previews/HTMLRendererPath.test.ts
+++ b/tests/unit/previews/HTMLRendererPath.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { resolveRelativePath } from '@/renderer/pages/conversation/Preview/components/renderers/HTMLRenderer';
+
+const WORKSPACE = '/home/user/workspace';
+
+describe('resolveRelativePath with workspace boundary', () => {
+  it('resolves a relative path inside the workspace', () => {
+    expect(resolveRelativePath('/home/user/workspace/index.html', 'img.png', WORKSPACE)).toBe(
+      '/home/user/workspace/img.png'
+    );
+  });
+
+  it('resolves a nested relative path inside the workspace', () => {
+    expect(resolveRelativePath('/home/user/workspace/index.html', 'assets/img.png', WORKSPACE)).toBe(
+      '/home/user/workspace/assets/img.png'
+    );
+  });
+
+  it('resolves a "../" path that stays inside the workspace', () => {
+    expect(resolveRelativePath('/home/user/workspace/sub/index.html', '../img.png', WORKSPACE)).toBe(
+      '/home/user/workspace/img.png'
+    );
+  });
+
+  it('throws when "../" escapes the workspace root', () => {
+    expect(() => resolveRelativePath('/home/user/workspace/index.html', '../../../../etc/passwd', WORKSPACE)).toThrow(
+      'Path traversal blocked'
+    );
+  });
+
+  it('throws for an absolute path outside the workspace', () => {
+    expect(() => resolveRelativePath('/home/user/workspace/index.html', '/etc/passwd', WORKSPACE)).toThrow(
+      'Path traversal blocked'
+    );
+  });
+
+  it('throws for a mixed-traversal path that escapes the workspace', () => {
+    expect(() => resolveRelativePath('/home/user/workspace/index.html', 'sub/../../../etc/passwd', WORKSPACE)).toThrow(
+      'Path traversal blocked'
+    );
+  });
+
+  it('throws for a backslash traversal path that escapes the workspace', () => {
+    expect(() => resolveRelativePath('/home/user/workspace/index.html', '..\\..\\etc\\passwd', WORKSPACE)).toThrow(
+      'Path traversal blocked'
+    );
+  });
+
+  it('returns paths unchanged when no workspace boundary is given', () => {
+    // Legacy behavior: without a workspace root, no boundary check applies.
+    expect(resolveRelativePath('/home/user/workspace/index.html', '/etc/passwd')).toBe('/etc/passwd');
+    expect(resolveRelativePath('/home/user/workspace/index.html', '../../../../etc/passwd')).toBe('/etc/passwd');
+  });
+
+  it('keeps Windows drive paths within the workspace', () => {
+    const winWorkspace = 'C:/Users/me/workspace';
+    expect(resolveRelativePath('C:/Users/me/workspace/index.html', 'img.png', winWorkspace)).toBe(
+      'C:/Users/me/workspace/img.png'
+    );
+  });
+
+  it('throws for a Windows absolute path outside the workspace', () => {
+    const winWorkspace = 'C:/Users/me/workspace';
+    expect(() =>
+      resolveRelativePath('C:/Users/me/workspace/index.html', 'C:/Windows/system.ini', winWorkspace)
+    ).toThrow('Path traversal blocked');
+  });
+
+  it('throws for a Windows backslash traversal outside the workspace', () => {
+    const winWorkspace = 'C:/Users/me/workspace';
+    expect(() =>
+      resolveRelativePath('C:/Users/me/workspace/index.html', '..\\..\\Windows\\system.ini', winWorkspace)
+    ).toThrow('Path traversal blocked');
+  });
+});

--- a/tests/unit/previews/HTMLRendererPath.test.ts
+++ b/tests/unit/previews/HTMLRendererPath.test.ts
@@ -40,6 +40,34 @@ describe('resolveRelativePath with workspace boundary', () => {
     );
   });
 
+  it('allows an absolute path inside the workspace', () => {
+    expect(resolveRelativePath('/home/user/workspace/index.html', '/home/user/workspace/img.png', WORKSPACE)).toBe(
+      '/home/user/workspace/img.png'
+    );
+  });
+
+  it('allows an absolute path equal to the workspace root', () => {
+    expect(resolveRelativePath('/home/user/workspace/index.html', '/home/user/workspace', WORKSPACE)).toBe(
+      '/home/user/workspace'
+    );
+  });
+
+  it('treats an empty workspace as no boundary', () => {
+    expect(resolveRelativePath('/home/user/workspace/index.html', '../../../../etc/passwd', '')).toBe('/etc/passwd');
+  });
+
+  it('treats a root workspace as no boundary', () => {
+    expect(resolveRelativePath('/home/user/workspace/index.html', '/etc/passwd', '/')).toBe('/etc/passwd');
+  });
+
+  it('rejects a target shorter than the workspace root', () => {
+    // '/home' is a prefix segment of the workspace but not deep enough — must not
+    // be treated as inside '/home/user/workspace'.
+    expect(() => resolveRelativePath('/home/user/workspace/index.html', '/home', WORKSPACE)).toThrow(
+      'Path traversal blocked'
+    );
+  });
+
   it('throws for a mixed-traversal path that escapes the workspace', () => {
     expect(() => resolveRelativePath('/home/user/workspace/index.html', 'sub/../../../etc/passwd', WORKSPACE)).toThrow(
       'Path traversal blocked'

--- a/tests/unit/previews/HTMLRendererPath.test.ts
+++ b/tests/unit/previews/HTMLRendererPath.test.ts
@@ -106,4 +106,29 @@ describe('resolveRelativePath with workspace boundary', () => {
       resolveRelativePath('C:/Users/me/workspace/index.html', '..\\..\\Windows\\system.ini', winWorkspace)
     ).toThrow('Path traversal blocked');
   });
+
+  it('throws for an absolute path that uses ".." to escape the workspace', () => {
+    // The literal starts with the workspace prefix but the ".." segments escape
+    // it — the absolute branch must normalize before the boundary check.
+    expect(() =>
+      resolveRelativePath('/home/user/workspace/index.html', '/home/user/workspace/../../secret', WORKSPACE)
+    ).toThrow('Path traversal blocked');
+  });
+
+  it('normalizes an absolute path with ".." that stays inside the workspace', () => {
+    expect(
+      resolveRelativePath('/home/user/workspace/index.html', '/home/user/workspace/sub/../img.png', WORKSPACE)
+    ).toBe('/home/user/workspace/img.png');
+  });
+
+  it('throws for a Windows absolute path that uses ".." to escape the workspace', () => {
+    const winWorkspace = 'C:/Users/me/workspace';
+    expect(() =>
+      resolveRelativePath(
+        'C:/Users/me/workspace/index.html',
+        'C:/Users/me/workspace/../../Windows/system.ini',
+        winWorkspace
+      )
+    ).toThrow('Path traversal blocked');
+  });
 });


### PR DESCRIPTION
## Description

Hardens the WebUI HTML preview renderer (`HTMLRenderer.tsx`) against path traversal when inlining relative `<img src>`, `<link href>` (CSS), and `<script src>` references from user-/AI-generated HTML.

**Why this is a real vulnerability, not just defense-in-depth:** the backend file sandbox (`aionui-file`) validates reads with `has_traversal` + canonicalize-and-`starts_with` over its **allowed roots**, but those roots are intentionally broad — temp dir, the **entire user home dir**, and the work dir. The backend therefore only stops escapes *out of home*; it does **not** enforce the per-conversation `workspace` boundary. Without a renderer-side check, HTML previewed in WebUI (browser) mode could inline any file under the user's home (e.g. `~/.ssh/id_rsa`) and, since the preview iframe runs scripts same-origin, exfiltrate it. That boundary is enforceable only in the renderer.

This PR builds on the work in #3978 by @flyzstu (fix + full-coverage tests, commits preserved) and additionally closes the one remaining gap raised in review.

**Fix:**
- `isWithinRoot` (pure string; the renderer cannot import `node:path`) enforces the conversation `workspace` boundary in `resolveRelativePath`. All three call sites (img/css/script) pass `workspace`. Escapes throw `Path traversal blocked`, swallowed by the existing per-resource try/catch so the original tag is left untouched.
- **New in this PR:** the absolute-path branch previously ran `isWithinRoot` on the raw string, so a literal `<workspace>/../../secret` (starts with the workspace prefix, yet escapes it) slipped past the check — backstopped only by the backend `has_traversal`. Added `normalizeAbsolute()` to collapse `.`/`..` segments before the boundary test, and the branch now returns the normalized path.

**Tests:** `resolveRelativePath` exported; 19 unit tests in `tests/unit/previews/HTMLRendererPath.test.ts` covering relative-inside, nested, in-workspace `../`, out-of-workspace `../`, absolute escape, absolute `..` escape (POSIX + Windows), in-workspace absolute `..` normalization, mixed/backslash escape, no-workspace legacy behavior, and Windows drive in/out.

**Scope:** Desktop Electron mode is unaffected (loads via `<webview>`); this is WebUI browser mode only.

## Related Issues

- Closes #3921
- Supersedes #3978 (original author @flyzstu; their commits are included here)

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — all tests pass (4242 passed / 5 skipped via `just push` gate)
- [x] i18n — N/A (no locale/i18n or user-facing text changes)

## Runtime Verification

- [x] I have performed a self-review of my own code

<!-- Not run as a desktop app in this change; the fix is a pure path-resolution function fully exercised by the 19 unit tests. -->

## Additional Context

Verification is unit-test level: `resolveRelativePath` / `isWithinRoot` / `normalizeAbsolute` are pure string functions with no DOM/IPC dependency, fully covered by the test matrix above. The change does not touch the Electron `<webview>` path.
