### PR TITLE
fix(desktop): stop renderer launch-failed reload storm with backoff and throttled relaunch

### DIFF
--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -8,6 +8,7 @@
 // ANY module that calls app.getPath('userData'), because Electron caches the path on first call.
 import './process/utils/configureChromium';
 import { installGpuCrashHandler } from './process/utils/gpuRecovery';
+import { createRendererRecoveryPolicy } from './process/utils/rendererRecovery';
 import { captureBackendStartupFailure, initSentry, scheduleStartupLogReport, setSentryDeviceId } from './sentry';
 
 initSentry();
@@ -581,13 +582,35 @@ const createWindow = ({ showOnReady = true }: { showOnReady?: boolean } = {}): v
     console.error('[AionUi] did-fail-load:', { errorCode, errorDescription, validatedURL, isMainFrame });
   });
 
+  // Recovery policy for renderer crashes: reload with backoff for ordinary
+  // crashes, escalate to a throttled app relaunch when the renderer cannot
+  // launch at all (e.g. app files replaced by an update while running).
+  // An unconditional immediate reload here caused a ~50/s crash storm on
+  // `launch-failed` (Sentry AIONUI-DESKTOP-A).
+  const rendererRecovery = createRendererRecoveryPolicy();
+
   mainWindow.webContents.on('render-process-gone', (_event, details) => {
     console.error('[AionUi] render-process-gone:', details);
+    if (mainWindow.isDestroyed()) return;
 
-    // Reload the renderer to recover from the crash.
+    const action = rendererRecovery.onCrash(details.reason);
+
+    if (action.kind === 'relaunch') {
+      console.warn(`[AionUi] renderer cannot be recovered in-place (reason=${details.reason}); relaunching app`);
+      app.relaunch();
+      app.exit(0);
+      return;
+    }
+
+    if (action.kind === 'give-up') {
+      console.error(`[AionUi] renderer recovery exhausted (reason=${details.reason}); not retrying`);
+      return;
+    }
+
     // The isDestroyed() guard in adapter/main.ts prevents further sends
     // to the dead webContents while the reload is in progress.
-    if (!mainWindow.isDestroyed()) {
+    const reload = () => {
+      if (mainWindow.isDestroyed()) return;
       console.log('[AionUi] Attempting to recover from renderer crash by reloading...');
 
       if (!app.isPackaged && rendererUrl) {
@@ -599,6 +622,12 @@ const createWindow = ({ showOnReady = true }: { showOnReady?: boolean } = {}): v
           console.error('[AionUi] Recovery loadFile failed:', error.message || error);
         });
       }
+    };
+
+    if (action.delayMs === 0) {
+      reload();
+    } else {
+      setTimeout(reload, action.delayMs);
     }
   });
 

--- a/packages/desktop/src/process/utils/rendererRecovery.ts
+++ b/packages/desktop/src/process/utils/rendererRecovery.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { app } from 'electron';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// 持久化文件：userData/renderer-recovery.json
+const STATE_FILE = 'renderer-recovery.json';
+
+// 同一崩溃窗口内的重载退避序列；超出后升级为整个应用重启。
+export const RENDERER_RELOAD_BACKOFF_MS = [0, 1000, 3000];
+
+// 距上次崩溃超过此时间后视作新一轮故障，重置重载计数。
+export const RENDERER_CRASH_RESET_MS = 60 * 1000;
+
+// 应用级自动重启的最小间隔；窗口内再次触发则放弃自动恢复，避免重启死循环。
+export const RENDERER_RELAUNCH_THROTTLE_MS = 5 * 60 * 1000;
+
+export type RendererCrashAction = { kind: 'reload'; delayMs: number } | { kind: 'relaunch' } | { kind: 'give-up' };
+
+export interface RendererRecoveryPolicy {
+  onCrash(reason: string): RendererCrashAction;
+}
+
+interface RecoveryState {
+  lastRelaunchAt?: number;
+}
+
+function getStatePath(): string {
+  return path.join(app.getPath('userData'), STATE_FILE);
+}
+
+function readState(): RecoveryState {
+  try {
+    const p = getStatePath();
+    if (!fs.existsSync(p)) return {};
+    const parsed = JSON.parse(fs.readFileSync(p, 'utf-8'));
+    return parsed && typeof parsed === 'object' ? (parsed as RecoveryState) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeState(state: RecoveryState): void {
+  try {
+    fs.writeFileSync(getStatePath(), JSON.stringify(state, null, 2), 'utf-8');
+  } catch (err) {
+    console.warn('[RendererRecovery] Failed to write recovery state:', err);
+  }
+}
+
+/**
+ * Decides how to recover from a renderer `render-process-gone` event.
+ *
+ * Ordinary crashes get an in-place reload with backoff. A `launch-failed`
+ * renderer can never be recovered by reloading (the process fails before it
+ * starts — e.g. app files were replaced by an update while running), so it
+ * escalates straight to an app relaunch. Relaunches are throttled through a
+ * timestamp persisted in userData so a fresh process that still cannot launch
+ * its renderer gives up instead of relaunch-looping.
+ */
+export function createRendererRecoveryPolicy(now: () => number = Date.now): RendererRecoveryPolicy {
+  let attempts = 0;
+  let lastCrashAt = 0;
+
+  const escalate = (t: number): RendererCrashAction => {
+    const state = readState();
+    if (state.lastRelaunchAt && t - state.lastRelaunchAt < RENDERER_RELAUNCH_THROTTLE_MS) {
+      return { kind: 'give-up' };
+    }
+    writeState({ ...state, lastRelaunchAt: t });
+    return { kind: 'relaunch' };
+  };
+
+  return {
+    onCrash(reason: string): RendererCrashAction {
+      const t = now();
+      if (t - lastCrashAt > RENDERER_CRASH_RESET_MS) attempts = 0;
+      lastCrashAt = t;
+
+      // Reloading spawns another renderer launch attempt, which hits the same
+      // failure — retrying in-place would recreate the crash storm.
+      if (reason === 'launch-failed') return escalate(t);
+
+      if (attempts >= RENDERER_RELOAD_BACKOFF_MS.length) return escalate(t);
+      const delayMs = RENDERER_RELOAD_BACKOFF_MS[attempts];
+      attempts++;
+      return { kind: 'reload', delayMs };
+    },
+  };
+}

--- a/tests/unit/rendererRecovery.test.ts
+++ b/tests/unit/rendererRecovery.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Unit tests for process/utils/rendererRecovery — covers the backoff/relaunch
+ * policy that stops the renderer 'launch-failed' reload storm (AIONUI-DESKTOP-A).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { vi } from 'vitest';
+
+let userDataDir: string;
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => {
+      if (name === 'userData') return userDataDir;
+      throw new Error(`unexpected getPath: ${name}`);
+    },
+  },
+}));
+
+const stateFile = () => path.join(userDataDir, 'renderer-recovery.json');
+
+const loadPolicy = async () => {
+  const mod = await import('@/process/utils/rendererRecovery');
+  return mod;
+};
+
+describe('rendererRecovery', () => {
+  let fakeNow: number;
+  const now = () => fakeNow;
+
+  beforeEach(() => {
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'renderer-recovery-test-'));
+    fakeNow = 1_000_000;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  it('reloads immediately on the first ordinary crash', async () => {
+    const { createRendererRecoveryPolicy } = await loadPolicy();
+    const policy = createRendererRecoveryPolicy(now);
+    expect(policy.onCrash('crashed')).toEqual({ kind: 'reload', delayMs: 0 });
+  });
+
+  it('backs off on consecutive crashes', async () => {
+    const { createRendererRecoveryPolicy } = await loadPolicy();
+    const policy = createRendererRecoveryPolicy(now);
+    policy.onCrash('crashed');
+    fakeNow += 100;
+    expect(policy.onCrash('crashed')).toEqual({ kind: 'reload', delayMs: 1000 });
+    fakeNow += 100;
+    expect(policy.onCrash('crashed')).toEqual({ kind: 'reload', delayMs: 3000 });
+  });
+
+  it('escalates to relaunch once reload attempts are exhausted', async () => {
+    const { createRendererRecoveryPolicy } = await loadPolicy();
+    const policy = createRendererRecoveryPolicy(now);
+    policy.onCrash('crashed');
+    policy.onCrash('crashed');
+    policy.onCrash('crashed');
+    expect(policy.onCrash('crashed')).toEqual({ kind: 'relaunch' });
+  });
+
+  it('relaunches directly on launch-failed without trying to reload', async () => {
+    const { createRendererRecoveryPolicy } = await loadPolicy();
+    const policy = createRendererRecoveryPolicy(now);
+    expect(policy.onCrash('launch-failed')).toEqual({ kind: 'relaunch' });
+  });
+
+  it('persists the relaunch timestamp so a fresh process can throttle', async () => {
+    const { createRendererRecoveryPolicy } = await loadPolicy();
+    const policy = createRendererRecoveryPolicy(now);
+    policy.onCrash('launch-failed');
+    const persisted = JSON.parse(fs.readFileSync(stateFile(), 'utf-8'));
+    expect(persisted.lastRelaunchAt).toBe(fakeNow);
+  });
+
+  it('gives up instead of relaunching again within the throttle window', async () => {
+    fs.writeFileSync(stateFile(), JSON.stringify({ lastRelaunchAt: fakeNow - 1000 }));
+    const { createRendererRecoveryPolicy } = await loadPolicy();
+    const policy = createRendererRecoveryPolicy(now);
+    expect(policy.onCrash('launch-failed')).toEqual({ kind: 'give-up' });
+  });
+
+  it('relaunches again once the throttle window has passed', async () => {
+    const { createRendererRecoveryPolicy, RENDERER_RELAUNCH_THROTTLE_MS } = await loadPolicy();
+    fs.writeFileSync(stateFile(), JSON.stringify({ lastRelaunchAt: fakeNow - RENDERER_RELAUNCH_THROTTLE_MS - 1 }));
+    const policy = createRendererRecoveryPolicy(now);
+    expect(policy.onCrash('launch-failed')).toEqual({ kind: 'relaunch' });
+  });
+
+  it('resets reload attempts after a quiet period', async () => {
+    const { createRendererRecoveryPolicy, RENDERER_CRASH_RESET_MS } = await loadPolicy();
+    const policy = createRendererRecoveryPolicy(now);
+    policy.onCrash('crashed');
+    policy.onCrash('crashed');
+    fakeNow += RENDERER_CRASH_RESET_MS + 1;
+    expect(policy.onCrash('crashed')).toEqual({ kind: 'reload', delayMs: 0 });
+  });
+
+  it('treats a corrupt state file as no prior relaunch', async () => {
+    fs.writeFileSync(stateFile(), 'not-json');
+    const { createRendererRecoveryPolicy } = await loadPolicy();
+    const policy = createRendererRecoveryPolicy(now);
+    expect(policy.onCrash('launch-failed')).toEqual({ kind: 'relaunch' });
+  });
+});


### PR DESCRIPTION
## Problem

Sentry issue [AIONUI-DESKTOP-A](https://pionex.sentry.io/issues/7654044521/) — `'renderer' process exited with 'launch-failed'` — shows 3932 fatal events from only 19 users, with 100+ events per device inside 2 seconds.

The `render-process-gone` handler in `packages/desktop/src/index.ts` reloaded the renderer unconditionally and immediately. When the renderer exits with `launch-failed` (captured breadcrumbs show `ERR_FAILED (-2)` loading `app.asar/out/renderer/...`, i.e. the on-disk app files were replaced — typically by an update installed while the app was running), every reload spawns another failing launch attempt. The result is a ~50/s crash loop: dead white window, pinned CPU, and a Sentry event per iteration until the user kills the app.

## Fix

Recovery decisions now go through a small policy module (`process/utils/rendererRecovery.ts`):

- **Ordinary crashes** (`crashed`, `oom`, `killed`, …): reload in-place with backoff — 0s / 1s / 3s, max 3 attempts per 60s window (window resets after quiet time).
- **`launch-failed`**: reloading can never recover a renderer that fails before it starts, so escalate straight to `app.relaunch() + app.exit(0)`. A fresh process picks up the updated `app.asar` and the user lands back in a working app.
- **Relaunch throttle**: automatic relaunches are limited to one per 5 minutes via a timestamp persisted in `userData/renderer-recovery.json`, so a machine whose renderer can never launch gives up (logs and stops retrying) instead of relaunch-looping the whole app.

## Testing

- New unit tests `tests/unit/rendererRecovery.test.ts` (9 cases): backoff sequence, escalation after exhausted reloads, direct escalation on `launch-failed`, persisted throttle across process restarts, throttle expiry, attempt reset after quiet period, corrupt state file tolerance.
- `bunx tsc --noEmit`, `oxlint`, and `bun run test tests/unit/rendererRecovery.test.ts tests/unit/gpuRecovery.test.ts` all clean.