### PR TITLE
fix(markdown): keep inline markup at the heading's size inside chat headings

### DIFF
--- a/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
@@ -12,8 +12,10 @@ import { useLayoutContext } from '@/renderer/hooks/context/LayoutContext';
 
 /**
  * Create the base style element for Shadow DOM with CSS variables, theme styles, and optional custom CSS.
+ *
+ * Exported for tests (heading inline-markup sizing regression).
  */
-const createInitStyle = (
+export const createInitStyle = (
   currentTheme = 'light',
   cssVars?: Record<string, string>,
   customCss?: string,
@@ -165,6 +167,17 @@ const createInitStyle = (
   strong {
     font-weight: 600;
     color: var(--text-primary);
+  }
+  /* Inline markup inside a heading must keep the heading's sizing. The
+     universal flattener above pins font-size/line-height on EVERY element,
+     and the h1/h2-h6 rules style only the heading element itself — so
+     "# a **b** c" rendered b at body size in the middle of a 24px heading.
+     :is() gives (0,0,1), outranking the (0,0,0) flattener; placed after
+     the strong rule so its font-weight reset also defers to inherit here. */
+  :is(h1, h2, h3, h4, h5, h6) * {
+    font-size: inherit;
+    line-height: inherit;
+    font-weight: inherit;
   }
   .markdown-shadow-body code:not(pre code) {
     background: var(--bg-3);

--- a/tests/unit/renderer/shadowViewHeadingStyles.dom.test.ts
+++ b/tests/unit/renderer/shadowViewHeadingStyles.dom.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createInitStyle } from '@renderer/components/Markdown/ShadowView';
+
+/**
+ * Regression: inline markup inside a heading fell back to body sizing.
+ *
+ * The init style's universal flattener (`* { font-size; line-height }`) pins
+ * every element to the chat body size, and the h1/h2-h6 rules style only the
+ * heading element itself — a heading's <strong>/<em>/<a> child therefore
+ * rendered at 14px in the middle of a 24px heading ("# a **b** c" showed b
+ * small). The fix is a `:is(h1..h6) *` rule restoring inheritance.
+ *
+ * jsdom does not run the real cascade, so these tests pin the two things the
+ * fix depends on: the rule exists with the right declarations, and it appears
+ * AFTER both the universal flattener and the `strong` font-weight reset (same
+ * specificity → source order decides the tie).
+ */
+const parsedRules = (): CSSRule[] => {
+  const style = createInitStyle('light');
+  document.head.appendChild(style);
+  const rules = [...(style.sheet?.cssRules ?? [])];
+  style.remove();
+  return rules;
+};
+
+const selectorOf = (rule: CSSRule): string => (rule as CSSStyleRule).selectorText ?? '';
+
+describe('createInitStyle heading inline-markup sizing', () => {
+  it('restores inheritance for elements nested in headings', () => {
+    const rule = parsedRules().find((r) => selectorOf(r).replace(/\s/g, '') === ':is(h1,h2,h3,h4,h5,h6)*') as
+      | CSSStyleRule
+      | undefined;
+
+    expect(rule, 'the :is(h1..h6) * inheritance rule must exist').toBeDefined();
+    expect(rule?.style.getPropertyValue('font-size')).toBe('inherit');
+    expect(rule?.style.getPropertyValue('line-height')).toBe('inherit');
+    expect(rule?.style.getPropertyValue('font-weight')).toBe('inherit');
+  });
+
+  it('orders the inheritance rule after the universal flattener and the strong reset', () => {
+    const rules = parsedRules();
+    const indexOf = (predicate: (sel: string) => boolean) => rules.findIndex((r) => predicate(selectorOf(r)));
+
+    const flattener = indexOf((sel) => sel === '*');
+    const strongReset = indexOf((sel) => sel === 'strong');
+    const inheritance = indexOf((sel) => sel.replace(/\s/g, '') === ':is(h1,h2,h3,h4,h5,h6)*');
+
+    expect(flattener).toBeGreaterThanOrEqual(0);
+    expect(strongReset).toBeGreaterThanOrEqual(0);
+    expect(inheritance).toBeGreaterThan(flattener);
+    // Same (0,0,1) specificity as `strong` — source order is what lets
+    // font-weight: inherit win inside a heading.
+    expect(inheritance).toBeGreaterThan(strongReset);
+  });
+});


### PR DESCRIPTION
## Problem

Inline markup inside a chat-message heading falls back to body sizing. `# a **b** c` renders **b** at 14px in the middle of a 24px heading — the heading reads as if random words shrank:

- h1 computes to `24px / 700 / 32px`
- its `<strong>` child computes to `14px / 600 / 24px` (live-verified in the WebUI on a real conversation)

## Root cause

The Shadow DOM init style (`ShadowView.tsx` `createInitStyle`) flattens every element to the chat body size with a universal rule:

```css
* { line-height: …; font-size: var(--chat-font-size, …); color: inherit; }
h1 { font-size: 24px; line-height: 32px; font-weight: bold; }
```

`h1 { }` styles only the heading element itself; its inline children match `*`, which sets font-size **explicitly**, so inheritance from the heading never happens. Present since the initial commit — it only shows once a reply actually puts inline markup inside a heading.

## Fix

One rule, placed after the `strong { font-weight: 600 }` reset:

```css
:is(h1, h2, h3, h4, h5, h6) * {
  font-size: inherit;
  line-height: inherit;
  font-weight: inherit;
}
```

- `:is()` gives (0,0,1), outranking the (0,0,0) flattener.
- Source order after `strong` resolves the same-specificity tie, so bold inside a heading keeps the heading's weight instead of dropping to 600.
- Inline code inside a heading still gets its `0.875em` rule (higher specificity), now relative to the heading size instead of the body size.
- `em` italics, link colors, and code backgrounds are untouched.

`createInitStyle` is now exported for the test.

## Tests

New `tests/unit/renderer/shadowViewHeadingStyles.dom.test.ts` pins the rule's declarations and its source order after both the flattener and the `strong` reset (jsdom cannot run the real cascade, so order is the contract). It fails without the fix.

`bun run vitest run` on the new file + `shadowViewKatexStyles.test.ts`: 6 passed. `prek run --files` on the two changed files: TypeScript Check / Oxlint / Oxfmt all pass.