### PR TITLE
chore: bump version to 2.1.59

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## [2.1.59](https://github.com/iOfficeAI/AionUi/compare/v2.1.58...v2.1.59) (2026-08-19)
+
+### Desktop
+
+#### Features
+
+- **explorer:** new file/dir + grouped row menu (#4102)
+- **feedback:** add optional contact email field (#4096)
+- **explorer:** drag-to-transfer files across the project tree (#4090)
+
+#### Bug Fixes
+
+- **markdown:** keep inline markup at the heading's size inside chat headings (#4104)
+- **acp:** render relative images in agent replies (#4103)
+- **desktop:** stop renderer launch-failed reload storm with backoff and throttled relaunch (#4100)
+- **ui:** make monochrome logos follow the theme color (#3614)
+- **security:** block path traversal in HTML renderer resource inlining (#4097)
+- **markdown:** render chat KaTeX formulas once in Shadow DOM (#4091)
+
+#### Refactoring
+
+- **media:** read image root from ConversationContext (#4105)
+
+### Core ([v0.1.70](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.70))
+
+#### Features
+
+- **monitor:** add fs/createFile command (#891)
+- **monitor:** back explorer drag-transfer with fs/copy and fs/move (#877)
+- **session:** distinguish Task subagents from background tasks (#890)
+
+#### Bug Fixes
+
+- **agent:** pair native media blocks with a link to the same file (#876)
+- **antigravity:** collapse agy's U+FFFD runs at text_delta joins (#888)
+- **antigravity:** route Team over the CLI, which is what agy was already using (#881)
+- **app:** bound the graceful-shutdown tail so the data-dir instance lock is released (#884)
+- **app:** harden the shutdown watchdog force-exit path
+- **app:** harden the shutdown watchdog force-exit path
+- **app:** keep backend_binary_path cmd.exe-launchable on Windows (#887)
+- **app:** reuse the app-level ConversationService in build_cron_state (#885)
+
+---
+
 ## [2.1.58](https://github.com/iOfficeAI/AionUi/compare/v2.1.57...v2.1.58) (2026-08-18)
 
 ### Desktop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.1.58",
+  "version": "2.1.59",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",
@@ -259,7 +259,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aioncoreVersion": "v0.1.69",
+  "aioncoreVersion": "v0.1.70",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
# Pull Request

> Please read [CONTRIBUTING.md](CONTRIBUTING.md) before submitting. PRs that ignore the rules below may be closed and asked to resubmit.

## Description

Bump AionUi from `2.1.58` to `2.1.59` and AionCore from `v0.1.69` to `v0.1.70`.

### Changelog

#### Desktop

##### Features

- **explorer:** new file/dir + grouped row menu (#4102)
- **feedback:** add optional contact email field (#4096)
- **explorer:** drag-to-transfer files across the project tree (#4090)

##### Bug Fixes

- **markdown:** keep inline markup at the heading's size inside chat headings (#4104)
- **acp:** render relative images in agent replies (#4103)
- **desktop:** stop renderer launch-failed reload storm with backoff and throttled relaunch (#4100)
- **ui:** make monochrome logos follow the theme color (#3614)
- **security:** block path traversal in HTML renderer resource inlining (#4097)
- **markdown:** render chat KaTeX formulas once in Shadow DOM (#4091)

##### Refactoring

- **media:** read image root from ConversationContext (#4105)

#### Core ([v0.1.70](https://github.com/iOfficeAI/AionCore/releases/tag/v0.1.70))

##### Features

- **monitor:** add fs/createFile command (#891)
- **monitor:** back explorer drag-transfer with fs/copy and fs/move (#877)
- **session:** distinguish Task subagents from background tasks (#890)

##### Bug Fixes

- **agent:** pair native media blocks with a link to the same file (#876)
- **antigravity:** collapse agy's U+FFFD runs at text_delta joins (#888)
- **antigravity:** route Team over the CLI, which is what agy was already using (#881)
- **app:** bound the graceful-shutdown tail so the data-dir instance lock is released (#884)
- **app:** harden the shutdown watchdog force-exit path
- **app:** harden the shutdown watchdog force-exit path
- **app:** keep backend_binary_path cmd.exe-launchable on Windows (#887)
- **app:** reuse the app-level ConversationService in build_cron_state (#885)

## Related Issues

N/A

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A

## Additional Context

All seven expected AionCore `v0.1.70` release artifacts were verified before updating the pinned version.
