### PR TITLE
fix(desktop): log attribution for uncaught main-process errors

### DIFF
--- a/packages/desktop/src/index.ts
+++ b/packages/desktop/src/index.ts
@@ -8,6 +8,8 @@
 // ANY module that calls app.getPath('userData'), because Electron caches the path on first call.
 import './process/utils/configureChromium';
 import { installGpuCrashHandler } from './process/utils/gpuRecovery';
+import { describeUncaughtError } from './process/utils/describeUncaughtError';
+import type { UncaughtErrorDiagnostics } from './process/utils/describeUncaughtError';
 import { createRendererRecoveryPolicy } from './process/utils/rendererRecovery';
 import { captureBackendStartupFailure, initSentry, scheduleStartupLogReport, setSentryDeviceId } from './sentry';
 
@@ -150,14 +152,27 @@ if (electronSquirrelStartup) {
 }
 
 // Global error handlers for main process
-// Sentry automatically captures these, but we keep the handlers to prevent Electron's default error dialog
-process.on('uncaughtException', (_error) => {
-  // Sentry captures this automatically
+// Sentry automatically captures these, but we keep the handlers to prevent Electron's default error dialog.
+// Control flow is unchanged — both handlers still swallow the failure and keep the process alive; they only
+// log allow-listed attribution first, because a Sentry event for e.g. `read ECONNRESET` otherwise carries
+// nothing but Node-internal frames (TCP.onStreamRead) and cannot be traced back to a subsystem (AIONUI-128).
+process.on('uncaughtException', (error, origin) => {
+  logUncaught(describeUncaughtError(error, origin));
 });
 
-process.on('unhandledRejection', (_reason, _promise) => {
-  // Sentry captures this automatically
+process.on('unhandledRejection', (reason, _promise) => {
+  logUncaught(describeUncaughtError(reason, 'unhandledRejection'));
 });
+
+function logUncaught(diagnostics: UncaughtErrorDiagnostics): void {
+  try {
+    console.error(`[AionUi] ${diagnostics.origin}:`, diagnostics);
+  } catch {
+    // Logging must never escalate a swallowed error into a fatal one: a throw inside an
+    // uncaughtException listener terminates the process, and the log transport itself can
+    // fail (e.g. ENOSPC while appending to the daily log file).
+  }
+}
 
 const hasSwitch = (flag: string) => process.argv.includes(`--${flag}`) || app.commandLine.hasSwitch(flag);
 const getSwitchValue = (flag: string): string | undefined => {

--- a/packages/desktop/src/process/utils/describeUncaughtError.ts
+++ b/packages/desktop/src/process/utils/describeUncaughtError.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Extracts triage-friendly diagnostics from an arbitrary thrown value.
+ *
+ * The main process swallows `uncaughtException` / `unhandledRejection` so the app keeps
+ * running, which used to mean the only record left behind was a bare Node-internal stack
+ * (e.g. `TCP.onStreamRead`) with no attribution — impossible to tell which subsystem's
+ * socket produced an `ECONNRESET`. This module turns whatever was thrown into a small,
+ * fixed set of fields that identify the failure without dumping the raw value.
+ *
+ * Only an explicit allow-list is read (`name`, `message`, `code`, `syscall`, `errno`,
+ * `stack`). Arbitrary properties of the thrown value are never copied out, because a
+ * rejected value can carry request bodies, tokens or other sensitive payloads.
+ *
+ * The function is total: it never throws and never returns a partially built value, so it
+ * is safe to call from inside a global error handler where a secondary throw would be fatal.
+ */
+
+/** Where the failure came from. Node passes this as the 2nd arg of `uncaughtException`. */
+export type UncaughtErrorOrigin = 'uncaughtException' | 'unhandledRejection';
+
+export interface UncaughtErrorDiagnostics {
+  /** Which global handler observed the failure. */
+  origin: UncaughtErrorOrigin;
+  /** Runtime shape of the raw value: 'Error' for Error instances, otherwise `typeof` (or 'null'). */
+  valueType: string;
+  /** `error.name`, or 'UnknownError' when the value carries no usable name. */
+  name: string;
+  /** `error.message`, the raw string when a string was thrown, or a non-revealing class tag. */
+  message: string;
+  /** libuv / Node error code, e.g. 'ECONNRESET', 'ENOSPC'. */
+  code?: string;
+  /** Failing syscall, e.g. 'read', 'write'. */
+  syscall?: string;
+  /** Negative libuv errno paired with `code`. */
+  errno?: number;
+  /** Stack trace, truncated. Paths are kept — they are the attribution signal. */
+  stack?: string;
+}
+
+const MAX_MESSAGE_LENGTH = 1000;
+const MAX_STACK_LENGTH = 4000;
+const TRUNCATION_SUFFIX = '... (truncated)';
+
+function truncate(text: string, limit: number): string {
+  return text.length <= limit ? text : `${text.slice(0, limit)}${TRUNCATION_SUFFIX}`;
+}
+
+/** Reads a property without letting a throwing getter or exotic proxy escape. */
+function readProperty(value: unknown, key: string): unknown {
+  if (value === null || (typeof value !== 'object' && typeof value !== 'function')) return undefined;
+  try {
+    return (value as Record<string, unknown>)[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function readString(value: unknown, key: string): string | undefined {
+  const raw = readProperty(value, key);
+  if (typeof raw === 'string') return raw.length > 0 ? raw : undefined;
+  // Node occasionally surfaces numeric codes (e.g. Windows error numbers) on `code`.
+  if (typeof raw === 'number' && Number.isFinite(raw)) return String(raw);
+  return undefined;
+}
+
+function readNumber(value: unknown, key: string): number | undefined {
+  const raw = readProperty(value, key);
+  return typeof raw === 'number' && Number.isFinite(raw) ? raw : undefined;
+}
+
+function describeValueType(value: unknown): string {
+  if (value === null) return 'null';
+  if (value instanceof Error) return 'Error';
+  return typeof value;
+}
+
+/**
+ * Builds a message that is useful but never leaks the raw payload of a rejected object.
+ * Primitives are safe to render verbatim; objects fall back to their class tag.
+ */
+function describeMessage(value: unknown): string {
+  if (typeof value === 'string') return value;
+
+  const message = readString(value, 'message');
+  if (message !== undefined) return message;
+
+  if (value === null) return 'null';
+  if (value === undefined) return 'undefined';
+
+  const valueType = typeof value;
+  if (valueType === 'number' || valueType === 'boolean' || valueType === 'bigint' || valueType === 'symbol') {
+    try {
+      return String(value);
+    } catch {
+      return `[unserializable ${valueType}]`;
+    }
+  }
+
+  try {
+    return Object.prototype.toString.call(value);
+  } catch {
+    return `[unserializable ${valueType}]`;
+  }
+}
+
+/**
+ * Describes an arbitrary thrown/rejected value using the allow-listed diagnostic fields.
+ *
+ * @param value  Whatever reached the global handler — an Error, a string, a plain object, or nothing at all.
+ * @param origin Which handler observed it.
+ */
+export function describeUncaughtError(value: unknown, origin: UncaughtErrorOrigin): UncaughtErrorDiagnostics {
+  try {
+    const diagnostics: UncaughtErrorDiagnostics = {
+      origin,
+      valueType: describeValueType(value),
+      name: readString(value, 'name') ?? 'UnknownError',
+      message: truncate(describeMessage(value), MAX_MESSAGE_LENGTH),
+    };
+
+    const code = readString(value, 'code');
+    if (code !== undefined) diagnostics.code = code;
+
+    const syscall = readString(value, 'syscall');
+    if (syscall !== undefined) diagnostics.syscall = syscall;
+
+    const errno = readNumber(value, 'errno');
+    if (errno !== undefined) diagnostics.errno = errno;
+
+    const stack = readString(value, 'stack');
+    if (stack !== undefined) diagnostics.stack = truncate(stack, MAX_STACK_LENGTH);
+
+    return diagnostics;
+  } catch {
+    // Never let diagnostics extraction itself become the failure the caller has to handle.
+    return {
+      origin,
+      valueType: 'unknown',
+      name: 'UnknownError',
+      message: '[failed to describe thrown value]',
+    };
+  }
+}

--- a/tests/unit/describeUncaughtError.test.ts
+++ b/tests/unit/describeUncaughtError.test.ts
@@ -1,0 +1,186 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Unit tests for process/utils/describeUncaughtError — covers the attribution fields the
+ * global uncaughtException / unhandledRejection handlers log so that Node-internal stacks
+ * (e.g. TCP.onStreamRead / ECONNRESET) stay triageable (AIONUI-128).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { describeUncaughtError } from '@/process/utils/describeUncaughtError';
+
+/** Shape Node produces for a socket reset: an Error carrying code/syscall/errno. */
+function makeSystemError(): NodeJS.ErrnoException {
+  const error = new Error('read ECONNRESET') as NodeJS.ErrnoException;
+  error.code = 'ECONNRESET';
+  error.syscall = 'read';
+  error.errno = -54;
+  return error;
+}
+
+describe('describeUncaughtError', () => {
+  it('extracts code/syscall/errno from a Node system error', () => {
+    const diagnostics = describeUncaughtError(makeSystemError(), 'uncaughtException');
+
+    expect(diagnostics.origin).toBe('uncaughtException');
+    expect(diagnostics.valueType).toBe('Error');
+    expect(diagnostics.name).toBe('Error');
+    expect(diagnostics.message).toBe('read ECONNRESET');
+    expect(diagnostics.code).toBe('ECONNRESET');
+    expect(diagnostics.syscall).toBe('read');
+    expect(diagnostics.errno).toBe(-54);
+    expect(diagnostics.stack).toContain('read ECONNRESET');
+  });
+
+  it('records the origin passed by the caller', () => {
+    expect(describeUncaughtError(makeSystemError(), 'unhandledRejection').origin).toBe('unhandledRejection');
+  });
+
+  it('omits code/syscall/errno for a plain Error', () => {
+    const error = new TypeError('boom');
+
+    const diagnostics = describeUncaughtError(error, 'uncaughtException');
+
+    expect(diagnostics.name).toBe('TypeError');
+    expect(diagnostics.message).toBe('boom');
+    expect(diagnostics).not.toHaveProperty('code');
+    expect(diagnostics).not.toHaveProperty('syscall');
+    expect(diagnostics).not.toHaveProperty('errno');
+  });
+
+  it('uses a thrown string as the message', () => {
+    const diagnostics = describeUncaughtError('something went wrong', 'unhandledRejection');
+
+    expect(diagnostics.valueType).toBe('string');
+    expect(diagnostics.name).toBe('UnknownError');
+    expect(diagnostics.message).toBe('something went wrong');
+    expect(diagnostics.stack).toBeUndefined();
+  });
+
+  it('reads allow-listed fields from a non-Error rejection object', () => {
+    const reason = { name: 'SocketFailure', message: 'connection dropped', code: 'ECONNRESET', syscall: 'read' };
+
+    const diagnostics = describeUncaughtError(reason, 'unhandledRejection');
+
+    expect(diagnostics.valueType).toBe('object');
+    expect(diagnostics.name).toBe('SocketFailure');
+    expect(diagnostics.message).toBe('connection dropped');
+    expect(diagnostics.code).toBe('ECONNRESET');
+    expect(diagnostics.syscall).toBe('read');
+  });
+
+  it('never copies non-allow-listed properties out of a rejection object', () => {
+    const reason = {
+      message: 'request failed',
+      code: 'EAUTH',
+      token: 'super-secret-token',
+      body: { password: 'hunter2' },
+    };
+
+    const diagnostics = describeUncaughtError(reason, 'unhandledRejection');
+
+    expect(Object.keys(diagnostics).sort()).toEqual(['code', 'message', 'name', 'origin', 'valueType']);
+    expect(JSON.stringify(diagnostics)).not.toContain('super-secret-token');
+    expect(JSON.stringify(diagnostics)).not.toContain('hunter2');
+  });
+
+  it('does not reveal the payload of an object without a message', () => {
+    const diagnostics = describeUncaughtError({ token: 'super-secret-token' }, 'unhandledRejection');
+
+    expect(diagnostics.message).toBe('[object Object]');
+    expect(JSON.stringify(diagnostics)).not.toContain('super-secret-token');
+  });
+
+  it('handles null and undefined rejections', () => {
+    const nullDiagnostics = describeUncaughtError(null, 'unhandledRejection');
+    expect(nullDiagnostics.valueType).toBe('null');
+    expect(nullDiagnostics.name).toBe('UnknownError');
+    expect(nullDiagnostics.message).toBe('null');
+
+    const undefinedDiagnostics = describeUncaughtError(undefined, 'unhandledRejection');
+    expect(undefinedDiagnostics.valueType).toBe('undefined');
+    expect(undefinedDiagnostics.message).toBe('undefined');
+  });
+
+  it('renders thrown primitives without throwing', () => {
+    expect(describeUncaughtError(42, 'uncaughtException').message).toBe('42');
+    expect(describeUncaughtError(false, 'uncaughtException').message).toBe('false');
+    expect(describeUncaughtError(Symbol('sym'), 'uncaughtException').message).toBe('Symbol(sym)');
+  });
+
+  it('truncates an oversized message and stack', () => {
+    const error = new Error('x'.repeat(5000));
+    error.stack = 'y'.repeat(9000);
+
+    const diagnostics = describeUncaughtError(error, 'uncaughtException');
+
+    expect(diagnostics.message).toHaveLength(1000 + '... (truncated)'.length);
+    expect(diagnostics.message.endsWith('... (truncated)')).toBe(true);
+    expect(diagnostics.stack).toHaveLength(4000 + '... (truncated)'.length);
+  });
+
+  it('survives values whose getters throw', () => {
+    const hostile = {
+      get message(): string {
+        throw new Error('getter exploded');
+      },
+      get code(): string {
+        throw new Error('getter exploded');
+      },
+      get stack(): string {
+        throw new Error('getter exploded');
+      },
+    };
+
+    const diagnostics = describeUncaughtError(hostile, 'uncaughtException');
+
+    expect(diagnostics.name).toBe('UnknownError');
+    expect(diagnostics.message).toBe('[object Object]');
+    expect(diagnostics.code).toBeUndefined();
+    expect(diagnostics.stack).toBeUndefined();
+  });
+
+  it('survives a null-prototype object with no toString', () => {
+    const bare = Object.create(null) as Record<string, unknown>;
+    bare.code = 'ENOSPC';
+
+    const diagnostics = describeUncaughtError(bare, 'uncaughtException');
+
+    expect(diagnostics.code).toBe('ENOSPC');
+    expect(diagnostics.message).toBe('[object Object]');
+  });
+
+  it('never throws for any input shape', () => {
+    const inputs: unknown[] = [
+      makeSystemError(),
+      new Error('plain'),
+      'string reason',
+      42,
+      0,
+      '',
+      true,
+      null,
+      undefined,
+      {},
+      [],
+      Object.create(null),
+      Symbol('s'),
+      10n,
+      () => undefined,
+      new Proxy(
+        {},
+        {
+          get() {
+            throw new Error('proxy trap exploded');
+          },
+        }
+      ),
+    ];
+
+    for (const input of inputs) {
+      expect(() => describeUncaughtError(input, 'uncaughtException')).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`packages/desktop/src/index.ts:154-160` (before this change) registered both global handlers with empty bodies and discarded arguments:

```ts
process.on('uncaughtException', (_error) => {
  // Sentry captures this automatically
});

process.on('unhandledRejection', (_reason, _promise) => {
  // Sentry captures this automatically
});
```

Nothing is recorded locally, so the only artifact of a swallowed failure is a Sentry event. For socket-level failures such as `read ECONNRESET` that event contains only Node-internal frames (`TCP.onStreamRead`, `inApp=false`) and carries no `error.code`, `syscall` or `errno` — there is no way to tell which subsystem's socket died, so the issue cannot be triaged. The same blind spot affects the ENOSPC reports tracked separately.

## Fix

New pure module `packages/desktop/src/process/utils/describeUncaughtError.ts`:

```ts
describeUncaughtError(value: unknown, origin: UncaughtErrorOrigin): UncaughtErrorDiagnostics
```

It maps an arbitrary thrown/rejected value to a fixed allow-list of diagnostic fields: `origin`, `valueType`, `name`, `message`, and — when present — `code`, `syscall`, `errno`, `stack`. Properties outside that allow-list are never copied out, because a rejected value can carry request bodies or tokens. `message` and `stack` are truncated (1000 / 4000 chars).

The function is total. It handles non-Error rejections (strings, primitives, plain objects, `null`/`undefined`, null-prototype objects, throwing getters, proxies with throwing traps) and never throws, which matters because it is called from inside a global error handler where a secondary throw is fatal.

Both handlers now call it and log the result through `console.error`, the convention used throughout `index.ts` (e.g. `index.ts:582`, `index.ts:593`); `configureConsoleLog` already persists main-process console output to the daily electron-log file. No new logging dependency is introduced. The `console.error` call is wrapped in `try/catch` so a failing log transport (e.g. ENOSPC while appending to the log file) cannot escalate a swallowed error into a process-terminating throw.

## Control flow is unchanged

Both handlers still swallow the error and the process still does not exit. No `process.exit`, no rethrow, no Electron error dialog, no change to Sentry's own capture path. The only behavioral difference is one extra structured log line before the failure is swallowed, and that line is emitted defensively.

## Test plan

New `tests/unit/describeUncaughtError.test.ts` (13 cases): Node system error with `code`/`syscall`/`errno` (ECONNRESET shape), plain `Error` without a code, thrown string, non-Error rejection object, allow-list enforcement (asserts a `token` / `password` payload never reaches the output), object without a message, `null`/`undefined`, primitives, truncation, throwing getters, null-prototype object, and a never-throws sweep across every input shape.

```
bunx vitest run tests/unit/describeUncaughtError.test.ts --project node
  Test Files  1 passed (1)
       Tests  13 passed (13)
```

```
bunx tsc --noEmit                       # exit 0
prek run --files packages/desktop/src/index.ts \
  packages/desktop/src/process/utils/describeUncaughtError.ts \
  tests/unit/describeUncaughtError.test.ts
  TypeScript Check ... Passed
  Oxlint ........... Passed
  Oxfmt ............ Passed
```

## Follow-ups (intentionally out of scope)

- Triaging benign transient network errors in Sentry's `beforeSend` (`packages/desktop/src/sentry.ts:120`, which already drops GPU-crash and backend-startup noise). That is a triage-policy decision and is left for a separate change now that the events carry `code`/`syscall` to filter on.
- Any user-facing notification for these errors — a UX decision, not part of this fix.

Fixes AIONUI-128 (Jira)
