### PR TITLE
fix(desktop): surface image pick failures instead of failing silently (AIONUI-224)

### DIFF
--- a/packages/desktop/src/renderer/components/media/imagePickError.ts
+++ b/packages/desktop/src/renderer/components/media/imagePickError.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isBackendHttpError } from '@/common/adapter/httpBridge';
+import type { TFunction } from 'i18next';
+
+/**
+ * 后端沙箱拒绝的错误码 / Backend error code for a sandbox rejection.
+ *
+ * `POST /api/fs/image-base64` answers 403 with this machine-readable `code`
+ * whenever the requested path resolves outside the allowed roots (temp dir /
+ * home dir / work dir). The native file dialog is free to hand back exactly
+ * such a path — another drive, or a cloud-redirected Desktop — so this is the
+ * most likely way an otherwise valid image fails to load.
+ *
+ * The same code is already consumed by `renderer/utils/previewError.ts`.
+ */
+const PATH_OUTSIDE_SANDBOX = 'PATH_OUTSIDE_SANDBOX';
+
+/**
+ * 把选图失败映射为提示文案 / Map an image-pick failure onto a display message.
+ *
+ * `error` is whatever the picker path produced: a `BackendHttpError` thrown by
+ * the HTTP bridge, some other thrown value, or `null` when the call resolved
+ * but handed back an empty payload.
+ *
+ * Only the sandbox rejection gets a specific, actionable message, because it is
+ * the only case the backend guarantees a stable `code` for. Everything else
+ * falls back to the generic failure text on purpose — matching against error
+ * message strings would be guesswork, and a wrong-but-specific message is worse
+ * than an honest generic one.
+ */
+export const getImagePickErrorMessage = (error: unknown, t: TFunction): string => {
+  if (isBackendHttpError(error) && error.code === PATH_OUTSIDE_SANDBOX) {
+    return t('settings.imagePickOutsideSandbox', {
+      defaultValue: 'This location is not accessible. Pick an image under your home directory or workspace.',
+    });
+  }
+  return t('common.failed', { defaultValue: 'Failed' });
+};

--- a/packages/desktop/src/renderer/pages/settings/AgentSettings/InlineAgentEditor.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AgentSettings/InlineAgentEditor.tsx
@@ -13,6 +13,7 @@ import { resolveAssistantAvatar } from '@/renderer/utils/model/assistantAvatar';
 import { Alert, Avatar, Button, Collapse, Input, Message, Typography } from '@arco-design/web-react';
 import { CheckOne, CloseOne } from '@icon-park/react';
 import EmojiPicker from '@/renderer/components/chat/EmojiPicker';
+import { getImagePickErrorMessage } from '@/renderer/components/media/imagePickError';
 import CodeMirror from '@uiw/react-codemirror';
 import { json } from '@codemirror/lang-json';
 import { useThemeContext } from '@/renderer/hooks/context/ThemeContext';
@@ -249,12 +250,17 @@ const InlineAgentEditor: React.FC<InlineAgentEditorProps> = ({ agent, onSave, on
       // The backend reads the file and returns a `data:` URL; we then shrink
       // it client-side so the persisted `icon` value stays small.
       const rawDataUrl = await fs.getImageBase64.invoke({ path: pickedPath });
-      if (!rawDataUrl) return;
+      // Read succeeded with an empty payload — silently returning here left the
+      // user with no feedback at all.
+      if (!rawDataUrl) {
+        Message.error(getImagePickErrorMessage(null, t));
+        return;
+      }
       const resized = await downscaleAvatarDataUrl(rawDataUrl);
       setAvatar(resized);
     } catch (error) {
       console.error('Failed to pick custom agent avatar image:', error);
-      Message.error(t('common.failed', { defaultValue: 'Failed' }));
+      Message.error(getImagePickErrorMessage(error, t));
     }
   }, [t]);
 

--- a/packages/desktop/src/renderer/pages/settings/AppearanceSettings/CssThemeModal.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AppearanceSettings/CssThemeModal.tsx
@@ -8,8 +8,9 @@ import type { Theme } from '@/common/theme/types';
 import { ipcBridge } from '@/common';
 import { useThemeContext } from '@renderer/hooks/context/ThemeContext.tsx';
 import { iconColors } from '@renderer/styles/colors';
-import { Button, Input, Radio } from '@arco-design/web-react';
+import { Button, Input, Message, Radio } from '@arco-design/web-react';
 import AionModal from '@renderer/components/base/AionModal.tsx';
+import { getImagePickErrorMessage } from '@renderer/components/media/imagePickError.ts';
 import { Plus, Delete } from '@icon-park/react';
 import CodeMirror from '@uiw/react-codemirror';
 import { css as cssLang } from '@codemirror/lang-css';
@@ -84,18 +85,29 @@ const CssThemeModal: React.FC<CssThemeModalProps> = ({ visible, theme, onClose, 
         filters: [{ name: 'Images', extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp'] }],
       });
 
-      if (files && files[0]) {
-        // 使用 IPC 读取图片并转换为 base64 / Use IPC to read image and convert to base64
-        const base64 = await ipcBridge.fs.getImageBase64.invoke({ path: files[0] });
-        if (base64) {
-          setCover(base64);
-          applyBackgroundImageToCss(base64);
-        }
+      // 用户取消对话框，不是失败 / Dialog dismissed by the user — not a failure
+      if (!files || !files[0]) return;
+
+      // 使用 IPC 读取图片并转换为 base64 / Use IPC to read image and convert to base64
+      const base64 = await ipcBridge.fs.getImageBase64.invoke({ path: files[0] });
+      // 读取成功但载荷为空，同样要提示 / Read succeeded with an empty payload — still a failure
+      if (!base64) {
+        Message.error(getImagePickErrorMessage(null, t));
+        return;
       }
+
+      setCover(base64);
+      applyBackgroundImageToCss(base64);
     } catch (error) {
+      // 后端会以 403 PATH_OUTSIDE_SANDBOX 拒绝沙箱外的路径（如 D 盘、被重定向的桌面），
+      // 此前只写 console，用户看到的是"点了没反应"
+      // The backend rejects out-of-sandbox paths (another drive, a redirected
+      // Desktop) with 403 PATH_OUTSIDE_SANDBOX. This used to only reach the
+      // console, so the user just saw nothing happen.
       console.error('Failed to upload cover:', error);
+      Message.error(getImagePickErrorMessage(error, t));
     }
-  }, [applyBackgroundImageToCss]);
+  }, [applyBackgroundImageToCss, t]);
 
   /**
    * 处理保存 / Handle save

--- a/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantEditorSections.tsx
+++ b/packages/desktop/src/renderer/pages/settings/AssistantSettings/AssistantEditorSections.tsx
@@ -14,7 +14,8 @@ import type { AvailableBackend } from './types';
 import { filterAssistantEditorBackends } from './assistantUtils';
 import { AionInlineSearchInput } from '@/renderer/components/base';
 import { DROPDOWN_SEARCH_THRESHOLD } from '@/renderer/components/agent/runtimeSelectorOptions';
-import { Avatar, Select, Tag } from '@arco-design/web-react';
+import { getImagePickErrorMessage } from '@/renderer/components/media/imagePickError';
+import { Avatar, Message, Select, Tag } from '@arco-design/web-react';
 import { Info, Robot } from '@icon-park/react';
 import React, { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -229,13 +230,24 @@ const AssistantEditorSections: React.FC<AssistantEditorSectionsProps> = ({ edito
         ],
       });
       const nextAvatar = selectedFiles?.[0];
-      if (nextAvatar) {
-        const previewBase64 = await ipcBridge.fs.getImageBase64.invoke({ path: nextAvatar });
-        setEditAvatar(nextAvatar);
-        setEditAvatarPreview(previewBase64 || undefined);
+      // Dialog dismissed by the user — not a failure.
+      if (!nextAvatar) return;
+
+      const previewBase64 = await ipcBridge.fs.getImageBase64.invoke({ path: nextAvatar });
+      // An unreadable image must not be committed as the avatar: keeping the
+      // path while the preview stays empty leaves a permanently broken avatar.
+      if (!previewBase64) {
+        Message.error(getImagePickErrorMessage(null, t));
+        return;
       }
+
+      setEditAvatar(nextAvatar);
+      setEditAvatarPreview(previewBase64);
     } catch (error) {
+      // The backend rejects out-of-sandbox paths with 403 PATH_OUTSIDE_SANDBOX;
+      // this used to only reach the console, leaving the user with no feedback.
       console.error('Failed to pick assistant avatar image:', error);
+      Message.error(getImagePickErrorMessage(error, t));
     }
   };
   const editableSkillOptions = useMemo(() => {

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1987,6 +1987,7 @@ export type I18nKey =
   | 'settings.imageInputSupported'
   | 'settings.imageInputTip'
   | 'settings.imageInputUnsupported'
+  | 'settings.imagePickOutsideSandbox'
   | 'settings.includePrereleaseUpdates'
   | 'settings.installed'
   | 'settings.language'

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
@@ -153,6 +153,7 @@
   "assistantDescriptionPlaceholder": "Wobei kann dieser Assistent helfen?",
   "assistantAvatarUploadImage": "Bild hochladen",
   "assistantAvatarImageFiles": "Bilddateien",
+  "imagePickOutsideSandbox": "Auf diesen Ort kann nicht zugegriffen werden. Wählen Sie ein Bild in Ihrem Benutzerordner oder Arbeitsbereich.",
   "assistantAvatarEmojiTab": "Emoji",
   "assistantAvatarBuiltinTab": "Eingebaut",
   "assistantAvatarNoBuiltinImages": "Keine eingebauten Bilder",

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
@@ -153,6 +153,7 @@
   "assistantDescriptionPlaceholder": "What can this assistant help with?",
   "assistantAvatarUploadImage": "Upload image",
   "assistantAvatarImageFiles": "Image files",
+  "imagePickOutsideSandbox": "This location is not accessible. Pick an image under your home directory or workspace.",
   "assistantAvatarEmojiTab": "Emoji",
   "assistantAvatarBuiltinTab": "Built-in",
   "assistantAvatarNoBuiltinImages": "No built-in images",

--- a/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
@@ -153,6 +153,7 @@
   "assistantDescriptionPlaceholder": "¿En qué puede ayudar este asistente?",
   "assistantAvatarUploadImage": "Subir imagen",
   "assistantAvatarImageFiles": "Archivos de imagen",
+  "imagePickOutsideSandbox": "No se puede acceder a esta ubicación. Elige una imagen dentro de tu carpeta personal o del espacio de trabajo.",
   "assistantAvatarEmojiTab": "Emoji",
   "assistantAvatarBuiltinTab": "Integrado",
   "assistantAvatarNoBuiltinImages": "Sin imágenes integradas",

--- a/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
@@ -153,6 +153,7 @@
   "assistantDescriptionPlaceholder": "این دستیار در چه مواردی کمک می‌کند؟",
   "assistantAvatarUploadImage": "آپلود تصویر",
   "assistantAvatarImageFiles": "فایل‌های تصویری",
+  "imagePickOutsideSandbox": "این مکان قابل دسترسی نیست. لطفاً تصویری در پوشه خانگی یا فضای کاری خود انتخاب کنید.",
   "assistantAvatarEmojiTab": "ایموجی",
   "assistantAvatarBuiltinTab": "داخلی",
   "assistantAvatarNoBuiltinImages": "تصویر داخلی وجود ندارد",

--- a/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
@@ -153,6 +153,7 @@
   "assistantDescriptionPlaceholder": "Avec quoi cet assistant peut-il aider ?",
   "assistantAvatarUploadImage": "Télécharger une image",
   "assistantAvatarImageFiles": "Fichiers images",
+  "imagePickOutsideSandbox": "Cet emplacement n'est pas accessible. Choisissez une image dans votre dossier personnel ou votre espace de travail.",
   "assistantAvatarEmojiTab": "Émoji",
   "assistantAvatarBuiltinTab": "Intégré",
   "assistantAvatarNoBuiltinImages": "Aucune image intégrée",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -153,6 +153,7 @@
   "assistantDescriptionPlaceholder": "どんな支援ができるかを入力",
   "assistantAvatarUploadImage": "画像をアップロード",
   "assistantAvatarImageFiles": "画像ファイル",
+  "imagePickOutsideSandbox": "この場所にはアクセスできません。ホームディレクトリまたはワークスペース内の画像を選択してください。",
   "assistantAvatarEmojiTab": "絵文字",
   "assistantAvatarBuiltinTab": "内蔵画像",
   "assistantAvatarNoBuiltinImages": "利用可能な内蔵画像はありません",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -153,6 +153,7 @@
   "assistantDescriptionPlaceholder": "이 어시스턴트는 무엇을 도와줄 수 있나요?",
   "assistantAvatarUploadImage": "이미지 업로드",
   "assistantAvatarImageFiles": "이미지 파일",
+  "imagePickOutsideSandbox": "이 위치에 접근할 수 없습니다. 홈 디렉터리 또는 작업 공간 안의 이미지를 선택하세요.",
   "assistantAvatarEmojiTab": "이모지",
   "assistantAvatarBuiltinTab": "내장 이미지",
   "assistantAvatarNoBuiltinImages": "사용 가능한 내장 이미지가 없습니다",

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
@@ -153,6 +153,7 @@
   "assistantDescriptionPlaceholder": "What can this assistant help with?",
   "assistantAvatarUploadImage": "Enviar imagem",
   "assistantAvatarImageFiles": "Arquivos de imagem",
+  "imagePickOutsideSandbox": "Este local não está acessível. Escolha uma imagem dentro da sua pasta pessoal ou do espaço de trabalho.",
   "assistantAvatarEmojiTab": "Emoji",
   "assistantAvatarBuiltinTab": "Imagens integradas",
   "assistantAvatarNoBuiltinImages": "Nenhuma imagem integrada",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -161,6 +161,7 @@
   "assistantDescriptionPlaceholder": "С какими задачами помогает этот ассистент?",
   "assistantAvatarUploadImage": "Загрузить изображение",
   "assistantAvatarImageFiles": "Файлы изображений",
+  "imagePickOutsideSandbox": "Это расположение недоступно. Выберите изображение в домашнем каталоге или рабочей области.",
   "assistantAvatarEmojiTab": "Эмодзи",
   "assistantAvatarBuiltinTab": "Встроенные изображения",
   "assistantAvatarNoBuiltinImages": "Нет встроенных изображений",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -153,6 +153,7 @@
   "assistantDescriptionPlaceholder": "Bu asistan neye yardımcı olabilir?",
   "assistantAvatarUploadImage": "Görsel yükle",
   "assistantAvatarImageFiles": "Görsel dosyaları",
+  "imagePickOutsideSandbox": "Bu konuma erişilemiyor. Lütfen giriş dizininiz veya çalışma alanınız içindeki bir görsel seçin.",
   "assistantAvatarEmojiTab": "Emoji",
   "assistantAvatarBuiltinTab": "Yerleşik görseller",
   "assistantAvatarNoBuiltinImages": "Yerleşik görsel yok",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
@@ -161,6 +161,7 @@
   "assistantDescriptionPlaceholder": "З чим може допомогти цей асистент?",
   "assistantAvatarUploadImage": "Завантажити зображення",
   "assistantAvatarImageFiles": "Файли зображень",
+  "imagePickOutsideSandbox": "Це розташування недоступне. Виберіть зображення в домашньому каталозі або робочій області.",
   "assistantAvatarEmojiTab": "Емодзі",
   "assistantAvatarBuiltinTab": "Вбудовані зображення",
   "assistantAvatarNoBuiltinImages": "Немає вбудованих зображень",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -153,6 +153,7 @@
   "assistantDescriptionPlaceholder": "帮你解决什么问题",
   "assistantAvatarUploadImage": "上传图片",
   "assistantAvatarImageFiles": "图片文件",
+  "imagePickOutsideSandbox": "无法访问该位置。请选择位于主目录或工作区内的图片。",
   "assistantAvatarEmojiTab": "表情",
   "assistantAvatarBuiltinTab": "内置图片",
   "assistantAvatarNoBuiltinImages": "暂无内置图片",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
@@ -153,6 +153,7 @@
   "assistantDescriptionPlaceholder": "能幫你解決什麼問題",
   "assistantAvatarUploadImage": "上傳圖片",
   "assistantAvatarImageFiles": "圖片檔案",
+  "imagePickOutsideSandbox": "無法存取該位置。請選擇位於主目錄或工作區內的圖片。",
   "assistantAvatarEmojiTab": "表情符號",
   "assistantAvatarBuiltinTab": "內建圖片",
   "assistantAvatarNoBuiltinImages": "暫無內建圖片",

--- a/tests/unit/assistants/AssistantEditorSections.dom.test.tsx
+++ b/tests/unit/assistants/AssistantEditorSections.dom.test.tsx
@@ -4,6 +4,7 @@ import { ConfigProvider } from '@arco-design/web-react';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import AssistantEditorSections from '@/renderer/pages/settings/AssistantSettings/AssistantEditorSections';
+import { BackendHttpError } from '@/common/adapter/httpBridge';
 import type { AssistantEditorViewModel } from '@/renderer/pages/settings/AssistantSettings/types';
 
 const mockUseModelProviderList = vi.fn(() => ({
@@ -45,6 +46,16 @@ const translateAgentMode = (key: string) => {
 
   return (mockLanguage === 'zh-CN' ? zhCN : enUS)[modeKey] ?? null;
 };
+
+// Message.error is what makes an avatar-pick failure visible (AIONUI-224).
+const messageErrorMock = vi.fn();
+vi.mock('@arco-design/web-react', async () => {
+  const actual = await vi.importActual<typeof import('@arco-design/web-react')>('@arco-design/web-react');
+  return {
+    ...actual,
+    Message: { ...actual.Message, error: (...args: unknown[]) => messageErrorMock(...args) },
+  };
+});
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -192,6 +203,7 @@ describe('AssistantEditorSections', () => {
     showOpenInvokeMock.mockReset();
     getImageBase64InvokeMock.mockReset();
     getImageBase64InvokeMock.mockResolvedValue('data:image/png;base64,preview');
+    messageErrorMock.mockReset();
     mockUseModelProviderList.mockReturnValue({
       providers: [],
       getAvailableModels: () => [],
@@ -782,6 +794,98 @@ describe('AssistantEditorSections', () => {
       expect(setEditAvatar).toHaveBeenCalledWith('/tmp/avatar.png');
       expect(getImageBase64InvokeMock).toHaveBeenCalledWith({ path: '/tmp/avatar.png' });
       expect(setEditAvatarPreview).toHaveBeenCalledWith('data:image/png;base64,preview');
+    });
+    expect(messageErrorMock).not.toHaveBeenCalled();
+  });
+
+  // AIONUI-224 / issue #4073: the avatar picker used to swallow every failure
+  // into console.error, so a sandbox-rejected path looked like a dead button.
+  describe('avatar pick failures surface a message', () => {
+    const renderAvatarEditor = () => {
+      const setAvatar = vi.fn();
+      const setAvatarPreview = vi.fn();
+      renderWithProviders(
+        <AssistantEditorSections
+          editor={createEditor({
+            profile: {
+              avatar: '✍️',
+              setAvatar,
+              setAvatarPreview,
+              name: 'Writer',
+              setName: vi.fn(),
+              description: 'desc',
+              setDescription: vi.fn(),
+            },
+            defaults: {
+              mcps: { mode: 'auto', setMode: vi.fn(), availableServers: [], selectedIds: [], setSelectedIds: vi.fn() },
+            },
+          })}
+          activeAssistant={null}
+        />
+      );
+      fireEvent.click(screen.getByTestId('btn-assistant-avatar-upload'));
+      return { setAvatar, setAvatarPreview };
+    };
+
+    it('shows the actionable sandbox message when the backend answers 403', async () => {
+      showOpenInvokeMock.mockResolvedValue(['D:/photos/avatar.png']);
+      getImageBase64InvokeMock.mockRejectedValue(
+        new BackendHttpError({
+          method: 'POST',
+          path: '/api/fs/image-base64',
+          status: 403,
+          body: {
+            success: false,
+            error: 'Path is outside the allowed sandbox.',
+            code: 'PATH_OUTSIDE_SANDBOX',
+            details: { field: 'path', operation: 'access' },
+          },
+        })
+      );
+
+      const { setAvatar, setAvatarPreview } = renderAvatarEditor();
+
+      await waitFor(() => expect(messageErrorMock).toHaveBeenCalledTimes(1));
+      expect(messageErrorMock).toHaveBeenCalledWith(
+        'This location is not accessible. Pick an image under your home directory or workspace.'
+      );
+      expect(setAvatar).not.toHaveBeenCalled();
+      expect(setAvatarPreview).not.toHaveBeenCalled();
+    });
+
+    it('shows the generic message when the read fails for any other reason', async () => {
+      showOpenInvokeMock.mockResolvedValue(['/tmp/avatar.png']);
+      getImageBase64InvokeMock.mockRejectedValue(new Error('boom'));
+
+      const { setAvatar } = renderAvatarEditor();
+
+      await waitFor(() => expect(messageErrorMock).toHaveBeenCalledTimes(1));
+      expect(messageErrorMock).toHaveBeenCalledWith('Failed');
+      expect(setAvatar).not.toHaveBeenCalled();
+    });
+
+    it('reports an empty payload instead of committing an unreadable avatar', async () => {
+      showOpenInvokeMock.mockResolvedValue(['/tmp/avatar.png']);
+      getImageBase64InvokeMock.mockResolvedValue(null);
+
+      const { setAvatar, setAvatarPreview } = renderAvatarEditor();
+
+      await waitFor(() => expect(messageErrorMock).toHaveBeenCalledTimes(1));
+      expect(messageErrorMock).toHaveBeenCalledWith('Failed');
+      // Committing the path while the preview stays empty would leave a
+      // permanently broken avatar behind.
+      expect(setAvatar).not.toHaveBeenCalled();
+      expect(setAvatarPreview).not.toHaveBeenCalled();
+    });
+
+    it('stays silent when the user dismisses the file dialog', async () => {
+      showOpenInvokeMock.mockResolvedValue([]);
+
+      renderAvatarEditor();
+
+      await waitFor(() => expect(showOpenInvokeMock).toHaveBeenCalled());
+      expect(getImageBase64InvokeMock).not.toHaveBeenCalled();
+      expect(messageErrorMock).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/feedback/InlineAgentEditorAvatar.dom.test.tsx
+++ b/tests/unit/feedback/InlineAgentEditorAvatar.dom.test.tsx
@@ -17,6 +17,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ConfigProvider } from '@arco-design/web-react';
+import { BackendHttpError } from '@/common/adapter/httpBridge';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en-US' } }),
@@ -248,7 +249,55 @@ describe('InlineAgentEditor — image avatar', () => {
     });
 
     await waitFor(() => expect(messageErrorMock).toHaveBeenCalledTimes(1));
+    expect(messageErrorMock).toHaveBeenCalledWith('common.failed');
     // Avatar stays at the default emoji.
+    expect(lastEmojiPickerProps.value).toBe('🤖');
+  });
+
+  // AIONUI-224 / issue #4073: the native dialog can hand back a path the
+  // backend sandbox refuses, and a bare "Failed" gives the user nothing to act
+  // on. The 403 carries a machine-readable code, so say what actually happened.
+  it('shows the actionable sandbox message when the backend answers 403', async () => {
+    showOpenMock.mockResolvedValue(['D:/photos/avatar.png']);
+    getImageBase64Mock.mockRejectedValue(
+      new BackendHttpError({
+        method: 'POST',
+        path: '/api/fs/image-base64',
+        status: 403,
+        body: {
+          success: false,
+          error: 'Path is outside the allowed sandbox.',
+          code: 'PATH_OUTSIDE_SANDBOX',
+          details: { field: 'path', operation: 'access' },
+        },
+      })
+    );
+
+    renderEditor();
+    const user = userEvent.setup();
+
+    await act(async () => {
+      await user.click(screen.getByTestId('btn-agent-avatar-upload'));
+    });
+
+    await waitFor(() => expect(messageErrorMock).toHaveBeenCalledTimes(1));
+    expect(messageErrorMock).toHaveBeenCalledWith('settings.imagePickOutsideSandbox');
+    expect(lastEmojiPickerProps.value).toBe('🤖');
+  });
+
+  it('shows an error toast when the backend resolves with an empty payload', async () => {
+    showOpenMock.mockResolvedValue(['/tmp/avatar.png']);
+    getImageBase64Mock.mockResolvedValue('');
+
+    renderEditor();
+    const user = userEvent.setup();
+
+    await act(async () => {
+      await user.click(screen.getByTestId('btn-agent-avatar-upload'));
+    });
+
+    await waitFor(() => expect(messageErrorMock).toHaveBeenCalledTimes(1));
+    expect(messageErrorMock).toHaveBeenCalledWith('common.failed');
     expect(lastEmojiPickerProps.value).toBe('🤖');
   });
 });

--- a/tests/unit/media/imagePickError.test.ts
+++ b/tests/unit/media/imagePickError.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Covers the image-pick failure classifier (AIONUI-224 / issue #4073).
+ *
+ * The native file dialog can return a path the backend refuses to read —
+ * another drive, or a cloud-redirected Desktop — and `POST /api/fs/image-base64`
+ * answers 403 with `code: "PATH_OUTSIDE_SANDBOX"`. That case earns a specific,
+ * actionable message; every other failure falls back to the generic text.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { TFunction } from 'i18next';
+import { BackendHttpError } from '@/common/adapter/httpBridge';
+import { getImagePickErrorMessage } from '@/renderer/components/media/imagePickError';
+
+/** Stub `t` that echoes the key, so assertions pin the key that was chosen. */
+const t = ((key: string) => key) as unknown as TFunction;
+
+/** A 403 shaped exactly like the backend `ErrorResponse` envelope. */
+const sandboxError = () =>
+  new BackendHttpError({
+    method: 'POST',
+    path: '/api/fs/image-base64',
+    status: 403,
+    body: {
+      success: false,
+      error: 'Path is outside the allowed sandbox.',
+      code: 'PATH_OUTSIDE_SANDBOX',
+      details: { field: 'path', operation: 'access' },
+    },
+  });
+
+describe('getImagePickErrorMessage', () => {
+  it('returns the actionable message for a PATH_OUTSIDE_SANDBOX rejection', () => {
+    expect(getImagePickErrorMessage(sandboxError(), t)).toBe('settings.imagePickOutsideSandbox');
+  });
+
+  it('recognises the sandbox rejection through the duck-typed guard', () => {
+    // vite-dev HMR can split the module so `instanceof` fails; isBackendHttpError
+    // falls back to shape detection and the classifier must follow it.
+    const duckTyped = {
+      name: 'BackendHttpError',
+      status: 403,
+      code: 'PATH_OUTSIDE_SANDBOX',
+    };
+    expect(getImagePickErrorMessage(duckTyped, t)).toBe('settings.imagePickOutsideSandbox');
+  });
+
+  it('falls back to the generic message for a different backend error code', () => {
+    const other = new BackendHttpError({
+      method: 'POST',
+      path: '/api/fs/image-base64',
+      status: 404,
+      body: { success: false, error: 'not found', code: 'NOT_FOUND' },
+    });
+    expect(getImagePickErrorMessage(other, t)).toBe('common.failed');
+  });
+
+  it('falls back to the generic message for a plain Error', () => {
+    expect(getImagePickErrorMessage(new Error('boom'), t)).toBe('common.failed');
+  });
+
+  it('falls back to the generic message for an empty payload (null)', () => {
+    expect(getImagePickErrorMessage(null, t)).toBe('common.failed');
+  });
+
+  it('does not string-match the sandbox wording on a non-backend error', () => {
+    // Guards against a message-sniffing heuristic creeping back in: only the
+    // machine-readable `code` may select the specific message.
+    expect(getImagePickErrorMessage(new Error('Path is outside the allowed sandbox.'), t)).toBe('common.failed');
+  });
+
+  it('never returns an empty string', () => {
+    for (const input of [sandboxError(), new Error('x'), null, undefined, 'oops', 42]) {
+      expect(getImagePickErrorMessage(input, t)).not.toBe('');
+    }
+  });
+});

--- a/tests/unit/theme/CssThemeModalCover.dom.test.tsx
+++ b/tests/unit/theme/CssThemeModalCover.dom.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Regression test for AIONUI-224 / issue #4073.
+ *
+ * Picking a CSS-theme cover image from a location the backend sandbox refuses
+ * (another drive, a cloud-redirected Desktop) made `POST /api/fs/image-base64`
+ * answer 403 `PATH_OUTSIDE_SANDBOX`. The modal swallowed that into a
+ * `console.error`, so the UI showed nothing at all and users retried, assuming
+ * the image was too large. Every failing branch must now raise a toast.
+ */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { BackendHttpError } from '@/common/adapter/httpBridge';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (k: string) => k, i18n: { language: 'en-US' } }),
+}));
+
+vi.mock('@renderer/hooks/context/ThemeContext.tsx', () => ({
+  useThemeContext: () => ({ theme: 'light' }),
+}));
+
+// CodeMirror needs a real editor surface; jsdom has none.
+vi.mock('@uiw/react-codemirror', () => ({
+  default: () => <div data-testid='codemirror-stub' />,
+}));
+
+const showOpenMock = vi.fn();
+const getImageBase64Mock = vi.fn();
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    dialog: { showOpen: { invoke: (...args: unknown[]) => showOpenMock(...args) } },
+    fs: { getImageBase64: { invoke: (...args: unknown[]) => getImageBase64Mock(...args) } },
+  },
+}));
+
+const messageErrorMock = vi.fn();
+vi.mock('@arco-design/web-react', async () => {
+  const actual = await vi.importActual<typeof import('@arco-design/web-react')>('@arco-design/web-react');
+  return {
+    ...actual,
+    Message: { ...actual.Message, error: (...args: unknown[]) => messageErrorMock(...args) },
+  };
+});
+
+import CssThemeModal from '@/renderer/pages/settings/AppearanceSettings/CssThemeModal';
+
+const renderModal = () => {
+  const onSave = vi.fn();
+  render(<CssThemeModal visible theme={null} onClose={vi.fn()} onSave={onSave} onDelete={undefined} />);
+  return { onSave };
+};
+
+/** Click the dashed cover placeholder — the click bubbles to its onClick parent. */
+const clickCoverPicker = async (user: ReturnType<typeof userEvent.setup>) => {
+  await act(async () => {
+    await user.click(screen.getByText('common.upload'));
+  });
+};
+
+/** A 403 shaped exactly like the backend `ErrorResponse` envelope. */
+const sandboxError = () =>
+  new BackendHttpError({
+    method: 'POST',
+    path: '/api/fs/image-base64',
+    status: 403,
+    body: {
+      success: false,
+      error: 'Path is outside the allowed sandbox.',
+      code: 'PATH_OUTSIDE_SANDBOX',
+      details: { field: 'path', operation: 'access' },
+    },
+  });
+
+describe('CssThemeModal — cover image picking', () => {
+  beforeEach(() => {
+    showOpenMock.mockReset();
+    getImageBase64Mock.mockReset();
+    messageErrorMock.mockReset();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('shows the actionable sandbox message when the backend answers 403', async () => {
+    showOpenMock.mockResolvedValue(['D:/photos/cover.png']);
+    getImageBase64Mock.mockRejectedValue(sandboxError());
+
+    renderModal();
+    await clickCoverPicker(userEvent.setup());
+
+    await waitFor(() => expect(messageErrorMock).toHaveBeenCalledTimes(1));
+    expect(messageErrorMock).toHaveBeenCalledWith('settings.imagePickOutsideSandbox');
+    // The cover must stay empty — the placeholder is still on screen.
+    expect(screen.getByText('common.upload')).toBeTruthy();
+  });
+
+  it('shows the generic message when the read fails for any other reason', async () => {
+    showOpenMock.mockResolvedValue(['/home/me/cover.png']);
+    getImageBase64Mock.mockRejectedValue(new Error('boom'));
+
+    renderModal();
+    await clickCoverPicker(userEvent.setup());
+
+    await waitFor(() => expect(messageErrorMock).toHaveBeenCalledTimes(1));
+    expect(messageErrorMock).toHaveBeenCalledWith('common.failed');
+  });
+
+  it('shows the generic message when the backend resolves with an empty payload', async () => {
+    showOpenMock.mockResolvedValue(['/home/me/cover.png']);
+    getImageBase64Mock.mockResolvedValue(null);
+
+    renderModal();
+    await clickCoverPicker(userEvent.setup());
+
+    await waitFor(() => expect(messageErrorMock).toHaveBeenCalledTimes(1));
+    expect(messageErrorMock).toHaveBeenCalledWith('common.failed');
+  });
+
+  it('stays silent and applies the cover when the read succeeds', async () => {
+    const dataUrl = 'data:image/png;base64,COVER';
+    showOpenMock.mockResolvedValue(['/home/me/cover.png']);
+    getImageBase64Mock.mockResolvedValue(dataUrl);
+
+    renderModal();
+    await clickCoverPicker(userEvent.setup());
+
+    await waitFor(() => {
+      expect(document.querySelector('img[alt="cover"]')?.getAttribute('src')).toBe(dataUrl);
+    });
+    expect(messageErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when the user dismisses the file dialog', async () => {
+    showOpenMock.mockResolvedValue([]);
+
+    renderModal();
+    await clickCoverPicker(userEvent.setup());
+
+    await waitFor(() => expect(showOpenMock).toHaveBeenCalledTimes(1));
+    expect(getImageBase64Mock).not.toHaveBeenCalled();
+    expect(messageErrorMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

Picking an image through a native file dialog could fail with **no UI feedback at all**.

All three pickers call `POST /api/fs/image-base64`. The backend answers **403** with the
machine-readable code **`PATH_OUTSIDE_SANDBOX`** whenever the chosen path resolves outside its
allowed roots (temp dir / home dir / work dir). The native dialog is free to return exactly such a
path — a `D:` drive, or a OneDrive-redirected Desktop — so this is easy to hit in normal use. The
reporter's aioncore log in #4073 shows three consecutive 403s while the UI stayed completely silent,
so they kept retrying, assuming the image was too large.

### The three call sites, before → after

| Call site | Before | After |
| --- | --- | --- |
| `AppearanceSettings/CssThemeModal.tsx` `handleCoverUpload` (the reported one) | `catch { console.error(...) }` only — **no UI feedback**. Plus a silent `if (base64) {…}` with no `else`. | `Message.error(...)` on both the throwing branch and the empty-payload branch. |
| `AssistantSettings/AssistantEditorSections.tsx` `handlePickAvatarImage` | `console.error('Failed to pick assistant avatar image:', error)` only. Empty payload also silent. | `Message.error(...)` on both branches. |
| `AgentSettings/InlineAgentEditor.tsx` `handlePickAvatarImage` | Already correct for the `catch` (`console.error` + `Message.error(t('common.failed'))`), but a silent `if (!rawDataUrl) return;`. | Empty payload now reports too; the sandbox case gets the specific message instead of a bare "Failed". |

`InlineAgentEditor` was the in-repo pattern the other two now follow.

### What the `getImageBase64` failure contract actually is

I traced it rather than assuming, because the handling had to match the real contract:

- `common/adapter/ipcBridge.ts:790` — `getImageBase64` is `httpPost<string | null, …>('/api/fs/image-base64')`.
- `common/adapter/httpBridge.ts` — `httpRequest` **throws** `BackendHttpError` on any non-2xx. Its
  constructor lifts the parsed body's `code` → `.code`, `error` → `.backendMessage`, plus `.status`
  and `.details`. An exported `isBackendHttpError` guard handles the vite-dev HMR case where
  `instanceof` breaks, by duck-typing.
- Backend side (AionCore): `aionui-api-types/src/response.rs:63-69` defines
  `ErrorResponse { success, error, code, details }` — the JSON key is literally **`code`** (the
  `error_code=` seen in logs is only the log field name, not the wire key).
  `aionui-common/src/error.rs:126,150` maps `PathOutsideSandbox` → `403` + `"PATH_OUTSIDE_SANDBOX"`,
  and `aionui-file/src/service.rs:962-975` is where `/api/fs/image-base64` runs the path validation.

**So the error does carry a distinguishable code**, and I took the specific-message branch. This is
not a string-matching heuristic — it reads the machine-readable `code` field, exactly as the existing
`renderer/utils/previewError.ts` already does for the very same `PATH_OUTSIDE_SANDBOX` value.

The new pure helper `renderer/components/media/imagePickError.ts` returns the specific, actionable
message for that code and falls back to the generic `common.failed` for everything else — including a
`null`/empty payload, which resolves rather than throwing and therefore carries no code.

### Deliberately out of scope

**Widening the backend sandbox** (`allowed_roots` / `default_allowed_roots` in AionCore) or switching
to client-side local file reads that bypass sandbox validation. AIONUI-224 flags that as an
unverified architectural trade-off needing product/architecture sign-off. This PR is AionUi-only and
changes **no backend behaviour and no security boundary** — a rejected path is still rejected, it is
just no longer invisible.

### One deliberate behaviour change

`AssistantEditorSections` previously ran `setEditAvatar(nextAvatar)` *before* checking the preview, so
an unreadable image left the avatar pointing at a path the backend refuses to read — a permanently
broken avatar. It now returns early and reports instead.

## Related Issues

Reported in #4073. No closing keyword on purpose — the owner decides when it closes.

Jira: AIONUI-224.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes (touched only the files in this diff)
- [x] `bun run lint` — exit 0, **0 errors** (910 pre-existing warnings, none on changed lines)
- [x] `bunx tsc --noEmit` — exit 0, no type errors
- [ ] `bunx vitest run` — **not run in full.** Ran the scoped suites instead:
      `tests/unit/settings tests/unit/assistants tests/unit/feedback tests/unit/theme tests/unit/media`
      → **56 files / 481 tests passed**.
- [x] i18n validated — `bun run i18n:types` + `node scripts/check-i18n.js` both pass (exit 0)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

Also ran the full CI-equivalent gate:

```
prek run --from-ref origin/main --to-ref HEAD
```

→ every hook **Passed** (check json, merge conflicts, case conflicts, large files, end of files,
trailing whitespace, TypeScript Check, Oxlint, Oxfmt, i18n Check), exit 0.

## Tests — including reverse-verification

New coverage:

- `tests/unit/media/imagePickError.test.ts` — 7 pure tests on the classifier, including one that
  pins that a plain `Error` whose *message* reads "Path is outside the allowed sandbox." still gets
  the generic text, guarding against a message-sniffing heuristic creeping back in.
- `tests/unit/theme/CssThemeModalCover.dom.test.tsx` — 5 DOM tests for the reported picker.
- Extended `tests/unit/assistants/AssistantEditorSections.dom.test.tsx` (+4) and
  `tests/unit/feedback/InlineAgentEditorAvatar.dom.test.tsx` (+2).

**Reverse-verified.** I reverted only the three call sites to their `origin/main` content, kept the
new tests, and re-ran them:

```
Test Files  3 failed (3)
     Tests  8 failed | 31 passed (39)
```

The 8 failures are exactly the defect: `expected "vi.fn()" to be called 1 times, but got 0 times`
for CssThemeModal (×3) and AssistantEditorSections (×3) — the toast never fires — plus
InlineAgentEditor's `expected "vi.fn()" to be called with arguments: [ 'settings.imagePickOutsideSandbox' ]`
(old code showed the generic message where the specific one applies) and its silent empty-payload
branch. The happy-path and dialog-dismissed cases passed both before and after, as they should.

Restoring the fix: **46/46 pass**.

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

Not launched as a packaged app — the change is covered by DOM tests that drive the real components
through the actual failing paths. The original report is Windows 11; the sandbox check is
platform-independent, so the fix is too.

## Additional Context

`settings.imagePickOutsideSandbox` was added to **all 13 locales** and `i18n-keys.d.ts` regenerated
(it is a strict key union, so a missing key would fail typecheck). The helper lives in
`components/media/` — the repo's designated file-preview/image domain, which already hosts the other
`getImageBase64` consumers and a precedent non-component module (`webviewHistory.ts`) — keeping that
directory at the 10-child limit rather than pushing an already-full one over it.
