### PR TITLE
feat(settings): page archived groups with load-more

### DIFF
--- a/packages/desktop/src/common/adapter/ipcBridge.ts
+++ b/packages/desktop/src/common/adapter/ipcBridge.ts
@@ -2431,17 +2431,20 @@ export const sidebar = {
     fromApiSidebar
   ),
   // One more window of a single group (the "+10" paging). `scope` is the group token,
-  // `cursor` the keyset cursor from the previous page.
+  // `cursor` the keyset cursor from the previous page. `archived` pages the archive
+  // slice (mirrors `get`) — the archived management page pages its groups this way.
   items: withResponseMap(
-    httpGet<import('@/common/types/sidebar').SidebarItemsResponse, { scope: string; cursor?: string; limit?: number }>(
-      (p) => {
-        const params = new URLSearchParams();
-        params.set('scope', p.scope);
-        if (p.cursor) params.set('cursor', p.cursor);
-        if (p.limit) params.set('limit', String(p.limit));
-        return `/api/sidebar/items?${params.toString()}`;
-      }
-    ),
+    httpGet<
+      import('@/common/types/sidebar').SidebarItemsResponse,
+      { scope: string; cursor?: string; limit?: number; archived?: boolean }
+    >((p) => {
+      const params = new URLSearchParams();
+      params.set('scope', p.scope);
+      if (p.cursor) params.set('cursor', p.cursor);
+      if (p.limit) params.set('limit', String(p.limit));
+      if (p.archived) params.set('archived', 'true');
+      return `/api/sidebar/items?${params.toString()}`;
+    }),
     fromApiSidebarItems
   ),
   // Remove a project and everything classified into its group (teams + standalone

--- a/packages/desktop/src/renderer/pages/settings/ArchivedSettings/index.tsx
+++ b/packages/desktop/src/renderer/pages/settings/ArchivedSettings/index.tsx
@@ -5,6 +5,7 @@
  */
 
 import { ipcBridge } from '@/common';
+import { scopeToToken } from '@/common/adapter/sidebarMapper';
 import type { SidebarItem } from '@/common/types/sidebar';
 import { useAgentLogos } from '@/renderer/utils/model/agentLogo';
 import { emitter } from '@/renderer/utils/emitter';
@@ -19,6 +20,22 @@ import SettingsPageWrapper from '../components/SettingsPageWrapper';
 import { resolveConversationLeadingMark } from '@/renderer/pages/conversation/utils/conversationAssistantIdentity';
 
 const ARCHIVED_SWR_KEY = 'sidebar-archived';
+
+/**
+ * Per-group window sizes for the archived page. The first screen shows a small
+ * window per group; "load more" then pages `sidebar.items` in larger steps.
+ * Made explicit (rather than relying on the backend defaults) so the paging
+ * intent is local to this page. Both stay well under the backend `MAX_LIMIT`.
+ */
+const FIRST_SCREEN_LIMIT = 5;
+const LOAD_MORE_LIMIT = 10;
+
+/** An appended window for one group, keyed by its scope token. */
+type ExtraPage = {
+  items: SidebarItem[];
+  hasMore: boolean;
+  cursor?: string;
+};
 
 /** A single archived row, resolved from a {@link SidebarItem} for uniform rendering. */
 type ArchivedRow = {
@@ -42,6 +59,12 @@ type ProjectBlock = {
    * project record and fall back to per-row restore/delete.
    */
   projectId?: string;
+  /** Backend scope token, used to page this block via `sidebar.items`. */
+  scopeToken: string;
+  /** True when the group has archived items beyond the loaded rows. */
+  hasMore: boolean;
+  /** Keyset cursor for the next page; absent iff `hasMore` is false. */
+  cursor?: string;
 };
 
 /**
@@ -57,8 +80,22 @@ const ArchivedSettings: React.FC = () => {
   const logos = useAgentLogos();
   const [selectionMode, setSelectionMode] = React.useState(false);
   const [selectedKeys, setSelectedKeys] = React.useState<ReadonlySet<string>>(() => new Set<string>());
+  // Appended "load more" windows, keyed by scope token. Reset on any refetch
+  // (restore/delete) so paging restarts from the fresh first screen — the
+  // keyset cursors and windows are stale once the underlying set changes.
+  const [extraPages, setExtraPages] = React.useState<Record<string, ExtraPage>>({});
+  const [loadingTokens, setLoadingTokens] = React.useState<ReadonlySet<string>>(() => new Set<string>());
 
-  const { data, isLoading, mutate } = useSWR(ARCHIVED_SWR_KEY, () => ipcBridge.sidebar.get.invoke({ archived: true }));
+  const { data, isLoading, mutate } = useSWR(ARCHIVED_SWR_KEY, () =>
+    ipcBridge.sidebar.get.invoke({ archived: true, limit: FIRST_SCREEN_LIMIT })
+  );
+
+  // Refetch the first screen and drop appended windows in one step. Used after
+  // every mutation so stale paged rows/cursors never linger.
+  const refresh = React.useCallback(async () => {
+    setExtraPages({});
+    await mutate();
+  }, [mutate]);
 
   // The active (left) sidebar is an event-driven singleton with no route/focus
   // revalidation, so it only reflects a restore once `chat.history.refresh`
@@ -130,9 +167,20 @@ const ArchivedSettings: React.FC = () => {
 
     const archivedBlocks: ProjectBlock[] = [];
     const noProjectRows: ArchivedRow[] = [];
+    // Paging metadata for the chats group, carried onto the synthetic no-project
+    // block (chats is the only group folded into it).
+    let chatsPaging: { token: string; hasMore: boolean; cursor?: string } | null = null;
     for (const group of data?.groups ?? []) {
+      const token = scopeToToken(group.scope);
+      const extra = extraPages[token];
+      // First-screen window + any appended pages, in keyset order. Cursors are
+      // exclusive, so the appended items never overlap the first screen.
+      const combined = extra ? [...group.items, ...extra.items] : group.items;
+      const hasMore = extra ? extra.hasMore : group.has_more;
+      const cursor = extra ? extra.cursor : group.next_cursor;
+
       const rows: ArchivedRow[] = [];
-      for (const item of group.items as SidebarItem[]) {
+      for (const item of combined as SidebarItem[]) {
         const row = toRow(item);
         if (row) rows.push(row);
       }
@@ -141,17 +189,25 @@ const ArchivedSettings: React.FC = () => {
       if (scope.type === 'project' || scope.type === 'dir') {
         const key = scope.type === 'project' ? scope.project_id : scope.key;
         const projectId = scope.type === 'project' ? scope.project_id : undefined;
-        archivedBlocks.push({ key, name: scope.name, rows, projectId });
+        archivedBlocks.push({ key, name: scope.name, rows, projectId, scopeToken: token, hasMore, cursor });
       } else {
         // Ordinary archived chats are still grouped as a project-like block, named "No project".
         noProjectRows.push(...rows);
+        chatsPaging = { token, hasMore, cursor };
       }
     }
     if (noProjectRows.length > 0) {
-      archivedBlocks.push({ key: 'no-project', name: t('settings.archived.noProject'), rows: noProjectRows });
+      archivedBlocks.push({
+        key: 'no-project',
+        name: t('settings.archived.noProject'),
+        rows: noProjectRows,
+        scopeToken: chatsPaging?.token ?? 'chats',
+        hasMore: chatsPaging?.hasMore ?? false,
+        cursor: chatsPaging?.cursor,
+      });
     }
     return { archivedBlocks, total: seen.size };
-  }, [data, logos, t]);
+  }, [data, extraPages, logos, t]);
 
   const allRows = React.useMemo(() => archivedBlocks.flatMap((block) => block.rows), [archivedBlocks]);
 
@@ -224,14 +280,47 @@ const ArchivedSettings: React.FC = () => {
       try {
         await ipcBridge.sidebar.unarchive.invoke({ item_type: row.item_type, item_id: row.item_id });
         restoredRef.current = true;
-        await mutate();
+        await refresh();
         Message.success(t('settings.archived.restoreSuccess'));
       } catch (error) {
         console.error('Failed to restore archived item:', error);
         Message.error(t('settings.archived.restoreFailed'));
       }
     },
-    [mutate, t]
+    [refresh, t]
+  );
+
+  const handleLoadMore = React.useCallback(
+    async (block: ProjectBlock) => {
+      if (!block.hasMore || !block.cursor) return;
+      const token = block.scopeToken;
+      setLoadingTokens((prev) => new Set(prev).add(token));
+      try {
+        const page = await ipcBridge.sidebar.items.invoke({
+          scope: token,
+          cursor: block.cursor,
+          limit: LOAD_MORE_LIMIT,
+          archived: true,
+        });
+        setExtraPages((prev) => {
+          const existing = prev[token]?.items ?? [];
+          return {
+            ...prev,
+            [token]: { items: [...existing, ...page.items], hasMore: page.has_more, cursor: page.next_cursor },
+          };
+        });
+      } catch (error) {
+        console.error('Failed to load more archived items:', error);
+        Message.error(t('settings.archived.loadMoreFailed'));
+      } finally {
+        setLoadingTokens((prev) => {
+          const next = new Set(prev);
+          next.delete(token);
+          return next;
+        });
+      }
+    },
+    [t]
   );
 
   const handleDelete = React.useCallback(
@@ -245,7 +334,7 @@ const ArchivedSettings: React.FC = () => {
         onOk: async () => {
           try {
             await ipcBridge.sidebar.deleteArchivedItem.invoke({ item_type: row.item_type, item_id: row.item_id });
-            await mutate();
+            await refresh();
             Message.success(t('settings.archived.deleteSuccess'));
           } catch (error) {
             console.error('Failed to delete archived item:', error);
@@ -257,7 +346,7 @@ const ArchivedSettings: React.FC = () => {
         getPopupContainer: () => document.body,
       });
     },
-    [mutate, t]
+    [refresh, t]
   );
 
   const handleDeleteSelected = React.useCallback(() => {
@@ -290,7 +379,7 @@ const ArchivedSettings: React.FC = () => {
 
           setSelectedKeys(new Set<string>());
           setSelectionMode(false);
-          await mutate();
+          await refresh();
           Message.success(t('settings.archived.deleteSelectedSuccess'));
         } catch (error) {
           console.error('Failed to delete selected archived items:', error);
@@ -301,7 +390,7 @@ const ArchivedSettings: React.FC = () => {
       alignCenter: true,
       getPopupContainer: () => document.body,
     });
-  }, [mutate, archivedBlocks, selectedKeys, selectedRows, t]);
+  }, [refresh, archivedBlocks, selectedKeys, selectedRows, t]);
 
   const formatArchivedTime = React.useCallback(
     (timestamp?: number) => {
@@ -453,6 +542,18 @@ const ArchivedSettings: React.FC = () => {
                   <div className='overflow-hidden rd-12px border border-solid border-[var(--color-border-2)] bg-bg-1'>
                     {block.rows.map((row, index) => renderRow(row, index === block.rows.length - 1))}
                   </div>
+                  {block.hasMore ? (
+                    <div className='flex justify-center'>
+                      <Button
+                        type='text'
+                        size='small'
+                        loading={loadingTokens.has(block.scopeToken)}
+                        onClick={() => void handleLoadMore(block)}
+                      >
+                        {t('settings.archived.loadMore')}
+                      </Button>
+                    </div>
+                  ) : null}
                 </section>
               );
             })}

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1537,6 +1537,8 @@ export type I18nKey =
   | 'settings.archived.deleteSuccess'
   | 'settings.archived.description'
   | 'settings.archived.empty'
+  | 'settings.archived.loadMore'
+  | 'settings.archived.loadMoreFailed'
   | 'settings.archived.multiSelect'
   | 'settings.archived.navLabel'
   | 'settings.archived.noProject'

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
@@ -1392,7 +1392,9 @@
     "deleteSelectedConfirmTitle": "Delete selected archived items?",
     "deleteSelectedConfirmContent": "This permanently deletes {{count}} selected archived items. This can't be undone.",
     "deleteSelectedSuccess": "Selected archived items deleted",
-    "selectAll": "Select all"
+    "selectAll": "Select all",
+    "loadMore": "Mehr laden",
+    "loadMoreFailed": "Laden weiterer Einträge fehlgeschlagen"
   },
   "crossSessionMessage": "Nachrichten zwischen Unterhaltungen",
   "crossSessionMessageDesc": "Erlaubt Agenten, Nachrichten an Ihre anderen Unterhaltungen zu senden. Beim Ausschalten wird auch die @@-Erwähnung im Eingabefeld deaktiviert.",

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
@@ -1392,7 +1392,9 @@
     "deleteSelectedConfirmTitle": "Delete selected archived items?",
     "deleteSelectedConfirmContent": "This permanently deletes {{count}} selected archived items. This can't be undone.",
     "deleteSelectedSuccess": "Selected archived items deleted",
-    "selectAll": "Select all"
+    "selectAll": "Select all",
+    "loadMore": "Load more",
+    "loadMoreFailed": "Failed to load more"
   },
   "crossSessionMessage": "Cross-conversation messages",
   "crossSessionMessageDesc": "Let agents send messages to your other conversations. Turning this off also disables the @@ conversation mention in the input box.",

--- a/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
@@ -1392,7 +1392,9 @@
     "deleteSelectedConfirmTitle": "Delete selected archived items?",
     "deleteSelectedConfirmContent": "This permanently deletes {{count}} selected archived items. This can't be undone.",
     "deleteSelectedSuccess": "Selected archived items deleted",
-    "selectAll": "Select all"
+    "selectAll": "Select all",
+    "loadMore": "Cargar más",
+    "loadMoreFailed": "No se pudo cargar más"
   },
   "crossSessionMessage": "Mensajes entre conversaciones",
   "crossSessionMessageDesc": "Permite que los agentes envíen mensajes a tus otras conversaciones. Al desactivarlo también se desactiva la mención @@ en el cuadro de texto.",

--- a/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
@@ -1392,7 +1392,9 @@
     "deleteSelectedConfirmTitle": "Delete selected archived items?",
     "deleteSelectedConfirmContent": "This permanently deletes {{count}} selected archived items. This can't be undone.",
     "deleteSelectedSuccess": "Selected archived items deleted",
-    "selectAll": "Select all"
+    "selectAll": "Select all",
+    "loadMore": "بارگذاری بیشتر",
+    "loadMoreFailed": "بارگذاری موارد بیشتر ناموفق بود"
   },
   "crossSessionMessage": "پیام‌های بین گفتگوها",
   "crossSessionMessageDesc": "به عامل‌ها اجازه می‌دهد به گفتگوهای دیگر شما پیام بفرستند. با خاموش کردن، منشن @@ در کادر ورودی نیز غیرفعال می‌شود.",

--- a/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
@@ -1392,7 +1392,9 @@
     "deleteSelectedConfirmTitle": "Delete selected archived items?",
     "deleteSelectedConfirmContent": "This permanently deletes {{count}} selected archived items. This can't be undone.",
     "deleteSelectedSuccess": "Selected archived items deleted",
-    "selectAll": "Select all"
+    "selectAll": "Select all",
+    "loadMore": "Charger plus",
+    "loadMoreFailed": "Échec du chargement"
   },
   "crossSessionMessage": "Messages entre conversations",
   "crossSessionMessageDesc": "Permet aux agents d'envoyer des messages à vos autres conversations. La désactivation coupe aussi la mention @@ dans la zone de saisie.",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -1394,7 +1394,9 @@
     "deleteSelectedConfirmTitle": "Delete selected archived items?",
     "deleteSelectedConfirmContent": "This permanently deletes {{count}} selected archived items. This can't be undone.",
     "deleteSelectedSuccess": "Selected archived items deleted",
-    "selectAll": "Select all"
+    "selectAll": "Select all",
+    "loadMore": "さらに読み込む",
+    "loadMoreFailed": "追加の読み込みに失敗しました"
   },
   "crossSessionMessage": "会話間メッセージ",
   "crossSessionMessageDesc": "エージェントが他の会話にメッセージを送れるようにします。オフにすると入力欄の @@ 会話メンションも無効になります。",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -1394,7 +1394,9 @@
     "deleteSelectedConfirmTitle": "Delete selected archived items?",
     "deleteSelectedConfirmContent": "This permanently deletes {{count}} selected archived items. This can't be undone.",
     "deleteSelectedSuccess": "Selected archived items deleted",
-    "selectAll": "Select all"
+    "selectAll": "Select all",
+    "loadMore": "더 보기",
+    "loadMoreFailed": "더 불러오지 못했습니다"
   },
   "crossSessionMessage": "대화 간 메시지",
   "crossSessionMessageDesc": "에이전트가 다른 대화로 메시지를 보낼 수 있게 합니다. 끄면 입력창의 @@ 대화 멘션도 비활성화됩니다.",

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
@@ -1395,7 +1395,9 @@
     "deleteSelectedConfirmTitle": "Delete selected archived items?",
     "deleteSelectedConfirmContent": "This permanently deletes {{count}} selected archived items. This can't be undone.",
     "deleteSelectedSuccess": "Selected archived items deleted",
-    "selectAll": "Select all"
+    "selectAll": "Select all",
+    "loadMore": "Carregar mais",
+    "loadMoreFailed": "Falha ao carregar mais"
   },
   "crossSessionMessage": "Mensagens entre conversas",
   "crossSessionMessageDesc": "Permite que agentes enviem mensagens para suas outras conversas. Desativar também desliga a menção @@ na caixa de entrada.",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -1406,7 +1406,9 @@
     "deleteSelectedConfirmTitle": "Delete selected archived items?",
     "deleteSelectedConfirmContent": "This permanently deletes {{count}} selected archived items. This can't be undone.",
     "deleteSelectedSuccess": "Selected archived items deleted",
-    "selectAll": "Select all"
+    "selectAll": "Select all",
+    "loadMore": "Загрузить ещё",
+    "loadMoreFailed": "Не удалось загрузить ещё"
   },
   "crossSessionMessage": "Сообщения между беседами",
   "crossSessionMessageDesc": "Разрешить агентам отправлять сообщения в ваши другие беседы. При отключении также отключается упоминание @@ в поле ввода.",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -1392,7 +1392,9 @@
     "deleteSelectedConfirmTitle": "Delete selected archived items?",
     "deleteSelectedConfirmContent": "This permanently deletes {{count}} selected archived items. This can't be undone.",
     "deleteSelectedSuccess": "Selected archived items deleted",
-    "selectAll": "Select all"
+    "selectAll": "Select all",
+    "loadMore": "Daha fazla yükle",
+    "loadMoreFailed": "Daha fazlası yüklenemedi"
   },
   "crossSessionMessage": "Sohbetler arası mesajlar",
   "crossSessionMessageDesc": "Aracıların diğer sohbetlerinize mesaj göndermesine izin verir. Kapatmak giriş alanındaki @@ sohbet etiketini de devre dışı bırakır.",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
@@ -1407,7 +1407,9 @@
     "deleteSelectedConfirmTitle": "Delete selected archived items?",
     "deleteSelectedConfirmContent": "This permanently deletes {{count}} selected archived items. This can't be undone.",
     "deleteSelectedSuccess": "Selected archived items deleted",
-    "selectAll": "Select all"
+    "selectAll": "Select all",
+    "loadMore": "Завантажити ще",
+    "loadMoreFailed": "Не вдалося завантажити ще"
   },
   "crossSessionMessage": "Повідомлення між розмовами",
   "crossSessionMessageDesc": "Дозволяє агентам надсилати повідомлення до ваших інших розмов. Вимкнення також відключає згадку @@ у полі введення.",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -1393,7 +1393,9 @@
     "deleteSelectedConfirmTitle": "删除所选归档项？",
     "deleteSelectedConfirmContent": "将永久删除已选的 {{count}} 个归档项，此操作无法撤销。",
     "deleteSelectedSuccess": "已删除所选归档项",
-    "selectAll": "全选"
+    "selectAll": "全选",
+    "loadMore": "加载更多",
+    "loadMoreFailed": "加载更多失败"
   },
   "crossSessionMessage": "跨会话消息",
   "crossSessionMessageDesc": "允许 Agent 向你的其他会话发送消息。关闭后，输入框的 @@ 会话提及与投递能力同时停用。",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
@@ -1394,7 +1394,9 @@
     "deleteSelectedConfirmTitle": "刪除所選歸檔項目？",
     "deleteSelectedConfirmContent": "將永久刪除已選的 {{count}} 個歸檔項目，此操作無法復原。",
     "deleteSelectedSuccess": "已刪除所選歸檔項目",
-    "selectAll": "全選"
+    "selectAll": "全選",
+    "loadMore": "載入更多",
+    "loadMoreFailed": "載入更多失敗"
   },
   "crossSessionMessage": "跨對話訊息",
   "crossSessionMessageDesc": "允許 Agent 向你的其他對話傳送訊息。關閉後，輸入框的 @@ 對話提及與投遞功能會同時停用。",

--- a/tests/unit/settings/ArchivedSettingsPaging.dom.test.tsx
+++ b/tests/unit/settings/ArchivedSettingsPaging.dom.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { SWRConfig } from 'swr';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const { getMock, itemsMock } = vi.hoisted(() => ({
+  getMock: vi.fn(),
+  itemsMock: vi.fn(),
+}));
+
+// The component reads `ipcBridge` from `@/common`. Only the sidebar surface is
+// exercised here; the mutation endpoints are stubbed so per-row buttons render.
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    sidebar: {
+      get: { invoke: getMock },
+      items: { invoke: itemsMock },
+      unarchive: { invoke: vi.fn(() => Promise.resolve()) },
+      deleteArchivedItem: { invoke: vi.fn(() => Promise.resolve()) },
+      deleteArchivedProject: { invoke: vi.fn(() => Promise.resolve()) },
+    },
+  },
+}));
+
+// Keep the real `scopeToToken` — the token grammar it produces is exactly what
+// the paging assertions verify. Only i18n / logos / passthrough shells are mocked.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts && 'count' in opts ? `${key}:${String(opts.count)}` : key,
+    i18n: { language: 'en-US' },
+  }),
+}));
+
+vi.mock('@/renderer/utils/model/agentLogo', () => ({ useAgentLogos: () => ({}) }));
+
+vi.mock('@/renderer/utils/emitter', () => ({ emitter: { emit: vi.fn() } }));
+
+vi.mock('@/renderer/pages/conversation/utils/conversationAssistantIdentity', () => ({
+  resolveConversationLeadingMark: () => ({ kind: 'assistant_fallback' as const }),
+}));
+
+vi.mock('@/renderer/pages/settings/components/SettingsPageWrapper', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('@/renderer/pages/settings/components/SettingsPageHeader', () => ({
+  default: ({ title, actions }: { title: React.ReactNode; actions?: React.ReactNode }) => (
+    <div>
+      <div>{title}</div>
+      <div>{actions}</div>
+    </div>
+  ),
+}));
+
+import ArchivedSettings from '@/renderer/pages/settings/ArchivedSettings';
+
+type Conv = { id: string; name: string; created_at: number };
+
+const conv = (id: string, name: string): { type: 'conversation'; conversation: Conv } => ({
+  type: 'conversation',
+  conversation: { id, name, created_at: 1_700_000_000_000 },
+});
+
+/** A project group with the given items / paging signals. */
+const projectGroup = (
+  projectId: string,
+  name: string,
+  items: ReturnType<typeof conv>[],
+  hasMore: boolean,
+  nextCursor?: string
+) => ({
+  scope: { type: 'project' as const, project_id: projectId, name },
+  items,
+  has_more: hasMore,
+  next_cursor: nextCursor,
+});
+
+const renderPage = () =>
+  render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <ArchivedSettings />
+    </SWRConfig>
+  );
+
+describe('ArchivedSettings paging', () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    itemsMock.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('requests the first screen with an explicit page-size limit and the archived flag', async () => {
+    getMock.mockResolvedValue({
+      groups: [projectGroup('P1', 'Alpha', [conv('c1', 'Chat One')], false)],
+      has_more_groups: false,
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(getMock).toHaveBeenCalled());
+    expect(getMock).toHaveBeenCalledWith({ archived: true, limit: 5 });
+    // A fully-loaded group (has_more false) shows no "load more" affordance.
+    await screen.findByText('Chat One');
+    expect(screen.queryByText('settings.archived.loadMore')).toBeNull();
+  });
+
+  it('renders a load-more button only for a group with more archived items', async () => {
+    getMock.mockResolvedValue({
+      groups: [projectGroup('P1', 'Alpha', [conv('c1', 'Chat One')], true, 'cursor-1')],
+      has_more_groups: false,
+    });
+
+    renderPage();
+
+    await screen.findByText('Chat One');
+    expect(screen.getByText('settings.archived.loadMore')).toBeTruthy();
+  });
+
+  it('pages the group via sidebar.items with the derived scope token, appends the window, and clears the button when drained', async () => {
+    getMock.mockResolvedValue({
+      groups: [projectGroup('P1', 'Alpha', [conv('c1', 'Chat One')], true, 'cursor-1')],
+      has_more_groups: false,
+    });
+    itemsMock.mockResolvedValue({ items: [conv('c2', 'Chat Two')], has_more: false, next_cursor: undefined });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByText('settings.archived.loadMore'));
+
+    await screen.findByText('Chat Two');
+    expect(itemsMock).toHaveBeenCalledWith({ scope: 'project:P1', cursor: 'cursor-1', limit: 10, archived: true });
+    // Both the first-screen and appended rows are present…
+    expect(screen.getByText('Chat One')).toBeTruthy();
+    // …and with the group drained, the button is gone.
+    await waitFor(() => expect(screen.queryByText('settings.archived.loadMore')).toBeNull());
+  });
+
+  it('keeps paging when the appended window still reports more', async () => {
+    getMock.mockResolvedValue({
+      groups: [projectGroup('P1', 'Alpha', [conv('c1', 'Chat One')], true, 'cursor-1')],
+      has_more_groups: false,
+    });
+    itemsMock.mockResolvedValue({ items: [conv('c2', 'Chat Two')], has_more: true, next_cursor: 'cursor-2' });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByText('settings.archived.loadMore'));
+
+    await screen.findByText('Chat Two');
+    // Still more to page: the next click carries the advanced cursor.
+    fireEvent.click(screen.getByText('settings.archived.loadMore'));
+    await waitFor(() =>
+      expect(itemsMock).toHaveBeenLastCalledWith({ scope: 'project:P1', cursor: 'cursor-2', limit: 10, archived: true })
+    );
+  });
+});


### PR DESCRIPTION
# Pull Request

## Description

The archived conversations page ("已归档的对话") only ever showed the first few chats per group. `sidebar.get({ archived: true })` was called without consuming `has_more` / `next_cursor`, so the backend windowed each group to its per-group default and the rest stayed hidden with no way to reach them.

This adds true paging:

- The first screen requests a small window per archived group (5 items) and now reads `has_more` / `next_cursor`.
- Each group with more items renders a "load more" button that pages `GET /api/sidebar/items` with the group's derived scope token and the `archived` flag, appending 10 more items per click.
- Appended windows are cleared on every refetch (after unarchive/delete) so paged rows and cursors never go stale.
- `ipcBridge` `sidebar.items` gains an `archived` query param so the paging endpoint targets the archived slice.
- `loadMore` / `loadMoreFailed` i18n keys added across all 13 locales.
- New DOM tests cover the first-screen request, button visibility, paging append + drain, and cursor advance.

No backend change was needed — `/api/sidebar/items` already supports the archived slice via its `archived` query param.

## Related Issues

- Closes #

## Type of Change

- [x] `feat` — New feature (non-breaking change which adds functionality)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass (4733 passed)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

Paging window sizes: first screen shows 5 per group, "load more" fetches 10 at a time. Keyset cursors are exclusive, so appended pages never overlap the first-screen window.