### PR TITLE
fix(security): mask plaintext API keys in ApiKeyManager.getStatus

### DIFF
--- a/packages/desktop/src/common/api/ApiKeyManager.ts
+++ b/packages/desktop/src/common/api/ApiKeyManager.ts
@@ -5,6 +5,7 @@
  */
 
 import { AuthType } from '@/common/types/provider/authType';
+import { maskApiKey } from '@/common/utils/protocolDetector';
 
 /**
  * Multi-API Key Manager with Time-based Blacklisting
@@ -137,14 +138,14 @@ export class ApiKeyManager {
   }
 
   /**
-   * Get current key status for debugging
+   * Get current key status for debugging — keys are masked, never plaintext.
    */
   getStatus(): {
     authType: AuthType;
     envKey: string;
     current: number;
     total: number;
-    keys: string[];
+    maskedKeys: string[];
     blacklisted: number[];
   } {
     const now = Date.now();
@@ -161,7 +162,7 @@ export class ApiKeyManager {
       envKey: this.envKey,
       current: this.currentIndex + 1,
       total: this.keys.length,
-      keys: this.keys,
+      maskedKeys: this.keys.map((k) => maskApiKey(k)),
       blacklisted,
     };
   }

--- a/tests/unit/common/ApiKeyManager.test.ts
+++ b/tests/unit/common/ApiKeyManager.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ApiKeyManager } from '@/common/api/ApiKeyManager';
+import { AuthType } from '@/common/types/provider/authType';
+
+describe('ApiKeyManager.getStatus', () => {
+  it('returns maskedKeys instead of plaintext keys', () => {
+    const manager = new ApiKeyManager('sk-test-key-1234567890abcdef', AuthType.USE_OPENAI);
+    const status = manager.getStatus();
+
+    // new field exists, old field does not
+    expect(status).toHaveProperty('maskedKeys');
+    expect(status).not.toHaveProperty('keys');
+    expect(status.maskedKeys).toHaveLength(1);
+    // masked value must not equal plaintext
+    expect(status.maskedKeys[0]).not.toBe('sk-test-key-1234567890abcdef');
+    expect(status.maskedKeys[0]).toContain('...');
+  });
+
+  it('masks each key when multiple keys are configured', () => {
+    const manager = new ApiKeyManager(
+      'sk-key-one-1234567890, sk-key-two-0987654321, sk-key-three-abcdefghij',
+      AuthType.USE_ANTHROPIC
+    );
+    const status = manager.getStatus();
+
+    expect(status.total).toBe(3);
+    expect(status.maskedKeys).toHaveLength(3);
+    for (const mk of status.maskedKeys) {
+      expect(mk).toContain('...');
+    }
+    // ensure no plaintext leaked
+    expect(JSON.stringify(status)).not.toContain('sk-key-one');
+    expect(JSON.stringify(status)).not.toContain('sk-key-two');
+  });
+
+  it('masks short keys as ***', () => {
+    const manager = new ApiKeyManager('short, tiny', AuthType.USE_GEMINI);
+    const status = manager.getStatus();
+
+    expect(status.maskedKeys).toEqual(['***', '***']);
+  });
+
+  it('reports empty maskedKeys for empty input', () => {
+    const manager = new ApiKeyManager('', AuthType.USE_OPENAI);
+    const status = manager.getStatus();
+
+    expect(status.total).toBe(0);
+    expect(status.maskedKeys).toHaveLength(0);
+    expect(status.current).toBe(1); // 0 + 1, no keys
+  });
+
+  it('reports current/total/blacklisted correctly', () => {
+    const manager = new ApiKeyManager('k1-1234567890abcd, k2-1234567890efgh', AuthType.USE_OPENAI);
+    const before = manager.getStatus();
+    expect(before.current).toBeGreaterThanOrEqual(1);
+    expect(before.current).toBeLessThanOrEqual(2);
+    expect(before.total).toBe(2);
+    expect(before.blacklisted).toEqual([]);
+
+    // rotate blacklists current key
+    manager.rotateKey();
+    const after = manager.getStatus();
+    expect(after.blacklisted).toHaveLength(1);
+    expect(after.maskedKeys).toHaveLength(2);
+  });
+
+  it('never exposes plaintext via JSON serialization', () => {
+    const secret = 'sk-super-secret-key-9999';
+    const manager = new ApiKeyManager(secret, AuthType.USE_OPENAI);
+    const status = manager.getStatus();
+    const serialized = JSON.stringify(status);
+    expect(serialized).not.toContain(secret);
+    expect(serialized).not.toContain('super-secret');
+  });
+});

--- a/tests/unit/providers/ApiKeyManager.test.ts
+++ b/tests/unit/providers/ApiKeyManager.test.ts
@@ -35,7 +35,7 @@ describe('ApiKeyManager', () => {
       const manager = new ApiKeyManager('key1,key2,key3', AuthType.USE_OPENAI);
       expect(manager.hasMultipleKeys()).toBe(true);
       const status = manager.getStatus();
-      expect(status.keys).toEqual(['key1', 'key2', 'key3']);
+      expect(status.maskedKeys).toEqual(['***', '***', '***']);
       expect(status.total).toBe(3);
     });
 
@@ -43,14 +43,14 @@ describe('ApiKeyManager', () => {
       const manager = new ApiKeyManager('key1\nkey2\nkey3', AuthType.USE_ANTHROPIC);
       expect(manager.hasMultipleKeys()).toBe(true);
       const status = manager.getStatus();
-      expect(status.keys).toEqual(['key1', 'key2', 'key3']);
+      expect(status.maskedKeys).toEqual(['***', '***', '***']);
       expect(status.envKey).toBe('ANTHROPIC_API_KEY');
     });
 
     it('trims whitespace and filters empty lines', () => {
       const manager = new ApiKeyManager(' key1 , key2 ,  ,key3  ', AuthType.USE_OPENAI);
       const status = manager.getStatus();
-      expect(status.keys).toEqual(['key1', 'key2', 'key3']);
+      expect(status.maskedKeys).toEqual(['***', '***', '***']);
     });
   });
 
@@ -180,7 +180,8 @@ describe('ApiKeyManager', () => {
       expect(status).toHaveProperty('envKey', 'ANTHROPIC_API_KEY');
       expect(status).toHaveProperty('current');
       expect(status).toHaveProperty('total', 3);
-      expect(status).toHaveProperty('keys');
+      expect(status).toHaveProperty('maskedKeys');
+      expect(status).not.toHaveProperty('keys');
       expect(status).toHaveProperty('blacklisted');
       expect(Array.isArray(status.blacklisted)).toBe(true);
     });


### PR DESCRIPTION
## Description

`ApiKeyManager.getStatus()` (`ApiKeyManager.ts:142-167`) returned the full plaintext API key array `keys: string[]` for debugging. Any caller that logged or serialized the status object (via `RotatingApiClient.getKeyStatus()`) leaked all configured API keys.

Change return type to `maskedKeys: string[]` using `maskApiKey()` (`protocolDetector.ts:320`, `sk-****` or `***` for ≤8), never plaintext. Keep `total/current/blacklisted` for debugging, drop `keys`. No callers read `.keys` (`trace_path 0`), so breaking change is safe.

## Related Issues

- Closes #4125

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks

- [x] `bun run format` — oxfmt applied
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 6 new tests pass, full suite 436 files
- [x] i18n — N/A

## Runtime Verification

- [x] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

Follow-up to split out `IProvider.api_key` plaintext transmission (requires `aioncore` backend `GET /api/providers` masking, tracked separately per atomic rule). This PR covers pure frontend `ApiKeyManager` only.

Tests: `tests/unit/common/ApiKeyManager.test.ts` — 6 cases covering single/multiple/short/empty keys, rotation, and JSON serialization leakage.