### PR TITLE
perf(conversation): cache messages across navigation

### DIFF
--- a/packages/desktop/src/renderer/hooks/context/AuthContext.tsx
+++ b/packages/desktop/src/renderer/hooks/context/AuthContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { PREVIEW_SCOPE_KEY_PREFIX } from '@/renderer/pages/conversation/Preview/context/previewScope';
+import { emitter } from '@/renderer/utils/emitter';
 // M6: CSRF removed with legacy webserver — stub functions for compatibility, re-implement in M7
 const withCsrfToken = <T extends Record<string, unknown>>(data: T): T => data;
 const hasValidCsrfToken = (): boolean => true;
@@ -81,6 +82,7 @@ function clearAuthCache(): void {
   } catch (error) {
     console.error('Failed to clear auth cache:', error);
   }
+  emitter.emit('auth.cacheCleared');
 }
 
 async function fetchCurrentUser(signal?: AbortSignal): Promise<AuthUser | null> {

--- a/packages/desktop/src/renderer/pages/conversation/Messages/anchorRail/useConversationAnchors.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/anchorRail/useConversationAnchors.ts
@@ -6,8 +6,66 @@
 
 import type { TMessage } from '@/common/chat/chatLib';
 import { loadAllConversationMessagesPaged } from '@/renderer/utils/chat/messagePagination';
+import { addEventListener } from '@/renderer/utils/emitter';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { buildMessageAnchors, type MessageAnchorItem } from './anchors';
+
+type CachedAnchorList = {
+  anchors: MessageAnchorItem[];
+  cachedAt: number;
+};
+
+const ANCHOR_CACHE_MAX_ENTRIES = 20;
+const ANCHOR_CACHE_FRESH_MS = 30_000;
+const anchorCache = new Map<string, CachedAnchorList>();
+const anchorRequests = new Map<string, Promise<MessageAnchorItem[]>>();
+let anchorCacheEpoch = 0;
+
+const readCachedAnchors = (conversationId: string): CachedAnchorList | undefined => {
+  const cached = anchorCache.get(conversationId);
+  if (!cached) return undefined;
+  anchorCache.delete(conversationId);
+  anchorCache.set(conversationId, cached);
+  return cached;
+};
+
+const writeCachedAnchors = (conversationId: string, anchors: MessageAnchorItem[]): void => {
+  anchorCache.delete(conversationId);
+  anchorCache.set(conversationId, { anchors, cachedAt: Date.now() });
+  while (anchorCache.size > ANCHOR_CACHE_MAX_ENTRIES) {
+    const oldestKey = anchorCache.keys().next().value;
+    if (typeof oldestKey !== 'string') break;
+    anchorCache.delete(oldestKey);
+  }
+};
+
+const loadConversationAnchors = (conversationId: string): Promise<MessageAnchorItem[]> => {
+  const activeRequest = anchorRequests.get(conversationId);
+  if (activeRequest) return activeRequest;
+  const request = loadAllConversationMessagesPaged(conversationId, { contentMode: 'compact' })
+    .then((messages) => {
+      const anchors = buildMessageAnchors(messages);
+      if (anchorRequests.get(conversationId) !== request) return [];
+      writeCachedAnchors(conversationId, anchors);
+      return anchors;
+    })
+    .finally(() => {
+      if (anchorRequests.get(conversationId) === request) anchorRequests.delete(conversationId);
+    });
+  anchorRequests.set(conversationId, request);
+  return request;
+};
+
+export const clearConversationAnchorCache = (): void => {
+  anchorCacheEpoch++;
+  anchorCache.clear();
+  anchorRequests.clear();
+};
+
+const deleteConversationAnchorCache = (conversationId: string): void => {
+  anchorCache.delete(conversationId);
+  anchorRequests.delete(conversationId);
+};
 
 /**
  * Anchors for a conversation's *whole* history, not just the pages currently held
@@ -28,9 +86,29 @@ export const useConversationAnchors = (
   conversationId: string | undefined,
   liveMessages: TMessage[]
 ): MessageAnchorItem[] => {
-  const [historyAnchors, setHistoryAnchors] = useState<MessageAnchorItem[]>([]);
+  const [historyAnchors, setHistoryAnchors] = useState<MessageAnchorItem[]>(() =>
+    conversationId ? (readCachedAnchors(conversationId)?.anchors ?? []) : []
+  );
+  const cacheEpochRef = useRef(anchorCacheEpoch);
+  const cacheConversationRef = useRef(conversationId);
+  if (cacheConversationRef.current !== conversationId) {
+    cacheConversationRef.current = conversationId;
+    cacheEpochRef.current = anchorCacheEpoch;
+  }
   // Guards against a stale conversation's response landing after a switch.
   const requestedIdRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    const removeAuthListener = addEventListener('auth.cacheCleared', clearConversationAnchorCache);
+    const removeDeletionListener = addEventListener('conversation.deleted', (deletedConversationId) => {
+      deleteConversationAnchorCache(deletedConversationId);
+      if (deletedConversationId === conversationId) cacheEpochRef.current = -1;
+    });
+    return () => {
+      removeAuthListener();
+      removeDeletionListener();
+    };
+  }, [conversationId]);
 
   useEffect(() => {
     requestedIdRef.current = conversationId;
@@ -39,23 +117,31 @@ export const useConversationAnchors = (
       return;
     }
 
+    const cached = readCachedAnchors(conversationId);
+    if (cached) {
+      setHistoryAnchors(cached.anchors);
+    }
+    if (cached && Date.now() - cached.cachedAt <= ANCHOR_CACHE_FRESH_MS) {
+      return;
+    }
+
     let cancelled = false;
     // Drop the previous conversation's ticks immediately, so the rail never shows
     // one conversation's anchors while another is open.
-    setHistoryAnchors([]);
+    if (!cached) setHistoryAnchors([]);
 
     // `compact` is enough: ticks only need the preview text, not whole message
     // bodies, and a long history would otherwise pull a lot of unused content.
-    loadAllConversationMessagesPaged(conversationId, { contentMode: 'compact' })
-      .then((messages) => {
+    loadConversationAnchors(conversationId)
+      .then((anchors) => {
         if (cancelled || requestedIdRef.current !== conversationId) return;
-        setHistoryAnchors(buildMessageAnchors(messages));
+        setHistoryAnchors(anchors);
       })
       .catch(() => {
         // Best-effort: the rail still works off the in-memory list, it just starts
         // at whatever the chat area has paged in.
         if (cancelled || requestedIdRef.current !== conversationId) return;
-        setHistoryAnchors([]);
+        if (!cached) setHistoryAnchors([]);
       });
 
     return () => {
@@ -65,8 +151,34 @@ export const useConversationAnchors = (
 
   const liveAnchors = useMemo(() => buildMessageAnchors(liveMessages), [liveMessages]);
 
-  return useMemo(
-    () => (liveAnchors.length >= historyAnchors.length ? liveAnchors : historyAnchors),
-    [liveAnchors, historyAnchors]
-  );
+  const resolvedAnchors = useMemo(() => {
+    if (liveAnchors.length >= historyAnchors.length) {
+      return liveAnchors;
+    }
+
+    const liveById = new Map(liveAnchors.map((anchor) => [anchor.messageId, anchor]));
+    const merged = historyAnchors.map((anchor) => {
+      const live = liveById.get(anchor.messageId);
+      if (!live) return anchor;
+      liveById.delete(anchor.messageId);
+      return { ...anchor, ...live, index: anchor.index };
+    });
+    for (const anchor of liveAnchors) {
+      if (liveById.has(anchor.messageId)) merged.push(anchor);
+    }
+    const normalized: MessageAnchorItem[] = [];
+    for (let index = 0; index < merged.length; index++) {
+      const anchor = merged[index];
+      normalized.push(anchor.index === index + 1 ? anchor : { ...anchor, index: index + 1 });
+    }
+    return normalized;
+  }, [historyAnchors, liveAnchors]);
+
+  useEffect(() => {
+    if (conversationId && resolvedAnchors.length > 0 && cacheEpochRef.current === anchorCacheEpoch) {
+      writeCachedAnchors(conversationId, resolvedAnchors);
+    }
+  }, [conversationId, resolvedAnchors]);
+
+  return resolvedAnchors;
 };

--- a/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
@@ -15,8 +15,9 @@ import {
   preferTextMessageVersion,
   sanitizeAcpToolCallContent,
 } from '@/common/chat/chatLib';
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
 import { createContext } from '@renderer/utils/ui/createContext';
+import { addEventListener } from '@/renderer/utils/emitter';
 import {
   DEFAULT_MESSAGE_PAGE_LIMIT,
   loadConversationAnchorWindow,
@@ -47,6 +48,64 @@ const EMPTY_MESSAGE_PAGINATION_STATE: MessagePaginationState = {
 
 const [useMessagePaginationState, MessagePaginationProvider, useUpdateMessagePaginationState] =
   createContext<MessagePaginationState>(EMPTY_MESSAGE_PAGINATION_STATE);
+
+type CachedMessageList = {
+  messages: TMessage[];
+  pagination: MessagePaginationState;
+  cachedAt: number;
+};
+
+const MESSAGE_LIST_CACHE_MAX_ENTRIES = 12;
+const MESSAGE_LIST_CACHE_MAX_MESSAGES = 200;
+const MESSAGE_LIST_CACHE_FRESH_MS = 30_000;
+const messageListCache = new Map<string, CachedMessageList>();
+const messageListRequests = new Map<string, symbol>();
+let messageListCacheEpoch = 0;
+
+const readCachedMessageList = (conversationId: string): CachedMessageList | undefined => {
+  const cached = messageListCache.get(conversationId);
+  if (!cached) return undefined;
+  messageListCache.delete(conversationId);
+  messageListCache.set(conversationId, cached);
+  return cached;
+};
+
+const writeCachedMessageList = (
+  conversationId: string,
+  messages: TMessage[],
+  pagination: MessagePaginationState
+): void => {
+  if (messages.length > MESSAGE_LIST_CACHE_MAX_MESSAGES) {
+    messageListCache.delete(conversationId);
+    return;
+  }
+  messageListCache.delete(conversationId);
+  messageListCache.set(conversationId, {
+    messages,
+    pagination: {
+      ...pagination,
+      isLoadingBefore: false,
+      isLoadingAnchor: false,
+    },
+    cachedAt: Date.now(),
+  });
+  while (messageListCache.size > MESSAGE_LIST_CACHE_MAX_ENTRIES) {
+    const oldestKey = messageListCache.keys().next().value;
+    if (typeof oldestKey !== 'string') break;
+    messageListCache.delete(oldestKey);
+  }
+};
+
+export const clearMessageListCache = (): void => {
+  messageListCacheEpoch++;
+  messageListCache.clear();
+  messageListRequests.clear();
+};
+
+const deleteConversationMessageCache = (conversationId: string): void => {
+  messageListCache.delete(conversationId);
+  messageListRequests.delete(conversationId);
+};
 
 const beforeUpdateMessageListStack: Array<(list: TMessage[]) => TMessage[]> = [];
 
@@ -929,43 +988,94 @@ export const useLoadAnchorMessageWindow = (conversationId?: string) => {
 
 export const useMessageLstCache = (key: string) => {
   const update = useUpdateMessageList();
-  const list = useMessageList();
+  const messageList = useMessageList();
   const setLoading = useUpdateMessageListLoading();
+  const pagination = useMessagePaginationState();
   const setPagination = useUpdateMessagePaginationState();
+  const hydratedConversationRef = useRef('');
+  const cacheEpochRef = useRef(messageListCacheEpoch);
+  const cacheConversationRef = useRef(key);
+  if (cacheConversationRef.current !== key) {
+    cacheConversationRef.current = key;
+    cacheEpochRef.current = messageListCacheEpoch;
+  }
   // Mirrors the current list into a ref so the turnCompleted handler below
   // can inspect it synchronously without re-subscribing to the WS event on
   // every list change (useState's functional updater runs asynchronously,
   // so update((list) => ...) can't be used for a synchronous read here).
-  const listRef = useRef(list);
+  const listRef = useRef(messageList);
   useEffect(() => {
-    listRef.current = list;
-  }, [list]);
-  const loadMessages = useCallback(async (): Promise<TMessage[]> => {
-    const result = await loadLatestConversationMessages(key, {
-      limit: DEFAULT_MESSAGE_PAGE_LIMIT,
-      contentMode: 'compact',
+    listRef.current = messageList;
+  }, [messageList]);
+  useEffect(() => {
+    const removeAuthListener = addEventListener('auth.cacheCleared', clearMessageListCache);
+    const removeDeletionListener = addEventListener('conversation.deleted', (conversationId) => {
+      deleteConversationMessageCache(conversationId);
+      if (conversationId === key) hydratedConversationRef.current = '';
     });
-    const messages = result?.items?.map(normalizeDbMessage);
-    if (messages && Array.isArray(messages)) {
-      update((currentList) => mergeLoadedPageWithCurrent(key, messages, currentList));
-      setPagination({
-        oldestCursor: result.oldest_cursor ?? undefined,
-        newestCursor: result.newest_cursor ?? undefined,
-        hasMoreBefore: result.has_more_before,
-        hasMoreAfter: result.has_more_after,
-        isLoadingBefore: false,
-        isLoadingAnchor: false,
+    return () => {
+      removeAuthListener();
+      removeDeletionListener();
+    };
+  }, [key]);
+  const loadMessages = useCallback(async (): Promise<TMessage[]> => {
+    const requestToken = Symbol(key);
+    messageListRequests.set(key, requestToken);
+    try {
+      const result = await loadLatestConversationMessages(key, {
+        limit: DEFAULT_MESSAGE_PAGE_LIMIT,
+        contentMode: 'compact',
       });
-      return messages;
+      if (messageListRequests.get(key) !== requestToken) return [];
+      const messages = result?.items?.map(normalizeDbMessage);
+      if (messages && Array.isArray(messages)) {
+        const nextPagination = {
+          oldestCursor: result.oldest_cursor ?? undefined,
+          newestCursor: result.newest_cursor ?? undefined,
+          hasMoreBefore: result.has_more_before,
+          hasMoreAfter: result.has_more_after,
+          isLoadingBefore: false,
+          isLoadingAnchor: false,
+        } satisfies MessagePaginationState;
+        update((currentList) => {
+          const nextList = mergeLoadedPageWithCurrent(key, messages, currentList);
+          writeCachedMessageList(key, nextList, nextPagination);
+          return nextList;
+        });
+        setPagination(nextPagination);
+        hydratedConversationRef.current = key;
+        return messages;
+      }
+      return [];
+    } finally {
+      if (messageListRequests.get(key) === requestToken) messageListRequests.delete(key);
     }
-    return [];
   }, [key, setPagination, update]);
+
+  useLayoutEffect(() => {
+    if (!key) return;
+    const cached = readCachedMessageList(key);
+    if (!cached) {
+      hydratedConversationRef.current = '';
+      return;
+    }
+    hydratedConversationRef.current = key;
+    update(cached.messages);
+    setPagination(cached.pagination);
+    setLoading(false);
+  }, [key, setLoading, setPagination, update]);
 
   useEffect(() => {
     if (!key) return;
     let cancelled = false;
-    setLoading(true);
-    setPagination({ ...EMPTY_MESSAGE_PAGINATION_STATE });
+    const cached = readCachedMessageList(key);
+    if (cached && Date.now() - cached.cachedAt <= MESSAGE_LIST_CACHE_FRESH_MS) {
+      return;
+    }
+    if (!cached) {
+      setLoading(true);
+      setPagination({ ...EMPTY_MESSAGE_PAGINATION_STATE });
+    }
     void loadMessages()
       .catch((error) => {
         console.error('[useMessageLstCache] Failed to load messages from database:', error);
@@ -979,6 +1089,13 @@ export const useMessageLstCache = (key: string) => {
       cancelled = true;
     };
   }, [key, loadMessages, setLoading, setPagination]);
+
+  useEffect(() => {
+    if (!key || hydratedConversationRef.current !== key || cacheEpochRef.current !== messageListCacheEpoch) return;
+    const cached = readCachedMessageList(key);
+    if (messageList.length === 0 && cached && cached.messages.length > 0) return;
+    writeCachedMessageList(key, messageList, pagination);
+  }, [key, messageList, pagination]);
 
   useEffect(() => {
     if (!key) {

--- a/packages/desktop/src/renderer/utils/emitter.ts
+++ b/packages/desktop/src/renderer/utils/emitter.ts
@@ -34,6 +34,7 @@ interface EventTypes {
   'codex.selected.file.clear': void;
   'codex.workspace.refresh': void;
   'chat.history.refresh': void;
+  'auth.cacheCleared': void;
   // 会话删除事件 / Conversation deletion event
   'conversation.deleted': [string]; // conversation_id
   // 预览面板事件 / Preview panel events

--- a/tests/unit/renderer/conversation/useConversationAnchors.dom.test.tsx
+++ b/tests/unit/renderer/conversation/useConversationAnchors.dom.test.tsx
@@ -5,8 +5,9 @@
  */
 
 import type { TMessage } from '@/common/chat/chatLib';
+import { emitter } from '@/renderer/utils/emitter';
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const loadAllConversationMessagesPaged = vi.fn();
 
@@ -14,7 +15,7 @@ vi.mock('@/renderer/utils/chat/messagePagination', () => ({
   loadAllConversationMessagesPaged: (...args: unknown[]) => loadAllConversationMessagesPaged(...args),
 }));
 
-const { useConversationAnchors } =
+const { clearConversationAnchorCache, useConversationAnchors } =
   await import('@/renderer/pages/conversation/Messages/anchorRail/useConversationAnchors');
 
 /** Builds one user/assistant turn pair. */
@@ -45,6 +46,11 @@ const history = (count: number) => Array.from({ length: count }, (_, i) => turn(
 describe('useConversationAnchors', () => {
   beforeEach(() => {
     loadAllConversationMessagesPaged.mockReset();
+    clearConversationAnchorCache();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('covers the whole history even when the chat area has only paged in the tail', async () => {
@@ -66,6 +72,94 @@ describe('useConversationAnchors', () => {
 
     await waitFor(() => expect(loadAllConversationMessagesPaged).toHaveBeenCalled());
     expect(loadAllConversationMessagesPaged).toHaveBeenCalledWith('c1', { contentMode: 'compact' });
+  });
+
+  it('reuses cached full-history anchors when reopening a conversation', async () => {
+    loadAllConversationMessagesPaged.mockResolvedValue(history(30));
+    const first = renderHook(() => useConversationAnchors('c1', history(2)));
+    await waitFor(() => expect(first.result.current).toHaveLength(30));
+    first.unmount();
+    loadAllConversationMessagesPaged.mockClear();
+
+    const second = renderHook(() => useConversationAnchors('c1', history(2)));
+
+    expect(second.result.current).toHaveLength(30);
+    expect(loadAllConversationMessagesPaged).not.toHaveBeenCalled();
+  });
+
+  it('shows stale cached anchors while refreshing them in the background', async () => {
+    let now = 0;
+    vi.spyOn(Date, 'now').mockImplementation(() => now);
+    loadAllConversationMessagesPaged.mockResolvedValue(history(10));
+    const first = renderHook(() => useConversationAnchors('c1', history(2)));
+    await waitFor(() => expect(first.result.current).toHaveLength(10));
+    first.unmount();
+    now = 30_001;
+    loadAllConversationMessagesPaged.mockResolvedValue(history(12));
+    loadAllConversationMessagesPaged.mockClear();
+
+    const second = renderHook(() => useConversationAnchors('c1', history(2)));
+
+    expect(second.result.current).toHaveLength(10);
+    await waitFor(() => expect(second.result.current).toHaveLength(12));
+    expect(loadAllConversationMessagesPaged).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops cached anchors when authentication cache is cleared', async () => {
+    loadAllConversationMessagesPaged.mockResolvedValue(history(10));
+    const first = renderHook(() => useConversationAnchors('c1', history(2)));
+    await waitFor(() => expect(first.result.current).toHaveLength(10));
+    act(() => emitter.emit('auth.cacheCleared'));
+    first.unmount();
+    loadAllConversationMessagesPaged.mockClear();
+
+    renderHook(() => useConversationAnchors('c1', history(2)));
+
+    await waitFor(() => expect(loadAllConversationMessagesPaged).toHaveBeenCalledTimes(1));
+  });
+
+  it('does not repopulate the cache from a request invalidated by authentication reset', async () => {
+    let resolveFirst: ((messages: TMessage[]) => void) | undefined;
+    loadAllConversationMessagesPaged.mockImplementation(
+      () => new Promise<TMessage[]>((resolve) => (resolveFirst = resolve))
+    );
+    const first = renderHook(() => useConversationAnchors('c1', history(2)));
+    act(() => emitter.emit('auth.cacheCleared'));
+    await act(async () => resolveFirst?.(history(10)));
+    first.unmount();
+    loadAllConversationMessagesPaged.mockResolvedValue(history(3));
+    loadAllConversationMessagesPaged.mockClear();
+
+    renderHook(() => useConversationAnchors('c1', history(2)));
+
+    await waitFor(() => expect(loadAllConversationMessagesPaged).toHaveBeenCalledTimes(1));
+  });
+
+  it('drops cached anchors when the conversation is deleted', async () => {
+    loadAllConversationMessagesPaged.mockResolvedValue(history(10));
+    const first = renderHook(() => useConversationAnchors('c1', history(2)));
+    await waitFor(() => expect(first.result.current).toHaveLength(10));
+    act(() => emitter.emit('conversation.deleted', 'c1'));
+    first.unmount();
+    loadAllConversationMessagesPaged.mockClear();
+
+    renderHook(() => useConversationAnchors('c1', history(2)));
+
+    await waitFor(() => expect(loadAllConversationMessagesPaged).toHaveBeenCalledTimes(1));
+  });
+
+  it('keeps cached anchors when a different conversation is deleted', async () => {
+    loadAllConversationMessagesPaged.mockResolvedValue(history(10));
+    const first = renderHook(() => useConversationAnchors('c1', history(2)));
+    await waitFor(() => expect(first.result.current).toHaveLength(10));
+    act(() => emitter.emit('conversation.deleted', 'c2'));
+    first.unmount();
+    loadAllConversationMessagesPaged.mockClear();
+
+    const second = renderHook(() => useConversationAnchors('c1', history(2)));
+
+    expect(second.result.current).toHaveLength(10);
+    expect(loadAllConversationMessagesPaged).not.toHaveBeenCalled();
   });
 
   it('lets newly sent messages extend the rail without re-reading history', async () => {

--- a/tests/unit/renderer/messageMerging.dom.test.tsx
+++ b/tests/unit/renderer/messageMerging.dom.test.tsx
@@ -8,16 +8,19 @@ import React, { type PropsWithChildren } from 'react';
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ipcBridge } from '@/common';
+import { emitter } from '@/renderer/utils/emitter';
 import type { IMessageAcpToolCall, IMessageText, IMessageThinking } from '@/common/chat/chatLib';
 import {
   MessageListLoadingProvider,
   MessageListProvider,
   MessagePaginationProvider,
+  clearMessageListCache,
   useAddOrUpdateMessage,
   useMessageLstCache,
   useMessageList,
   useReplaceWithAnchorWindow,
 } from '@/renderer/pages/conversation/Messages/hooks';
+import { useAutoScroll } from '@/renderer/pages/conversation/Messages/useAutoScroll';
 
 vi.mock('@/common', () => ({
   ipcBridge: {
@@ -144,6 +147,7 @@ async function flushMessageQueue(): Promise<void> {
 describe('message merging', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    clearMessageListCache();
   });
 
   afterEach(() => {
@@ -280,6 +284,317 @@ describe('message merging', () => {
       limit: 50,
       content_mode: 'compact',
     });
+  });
+
+  it('restores a fresh message page without requesting it again after remount', async () => {
+    const invoke = vi.mocked(ipcBridge.database.getConversationMessages.invoke);
+    invoke.mockResolvedValue({
+      items: [createTextMessage('cached-agent', 'cached response')],
+      oldest_cursor: 'oldest',
+      newest_cursor: 'newest',
+      has_more_before: true,
+      has_more_after: false,
+    });
+
+    function useCacheAndListHarness() {
+      useMessageLstCache(CONVERSATION_ID);
+      return { messages: useMessageList() };
+    }
+
+    const first = renderHook(() => useCacheAndListHarness(), { wrapper: CacheWrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(first.result.current.messages).toHaveLength(1);
+    first.unmount();
+    invoke.mockClear();
+
+    const second = renderHook(() => useCacheAndListHarness(), { wrapper: CacheWrapper });
+
+    expect(second.result.current.messages).toHaveLength(1);
+    expect((second.result.current.messages[0] as IMessageText).content.content).toBe('cached response');
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('opens a cached conversation at the latest message without requesting the page again', async () => {
+    const invoke = vi.mocked(ipcBridge.database.getConversationMessages.invoke);
+    invoke.mockResolvedValue({
+      items: [createTextMessage('cached-agent', 'cached response')],
+      oldest_cursor: null,
+      newest_cursor: null,
+      has_more_before: false,
+      has_more_after: false,
+    });
+
+    function useCacheAndScrollHarness() {
+      useMessageLstCache(CONVERSATION_ID);
+      const messages = useMessageList();
+      return {
+        messages,
+        autoScroll: useAutoScroll({ messages, itemCount: messages.length }),
+      };
+    }
+
+    const first = renderHook(() => useCacheAndScrollHarness(), { wrapper: CacheWrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    first.unmount();
+    invoke.mockClear();
+
+    const scroller = document.createElement('div');
+    Object.defineProperties(scroller, {
+      scrollTop: { configurable: true, writable: true, value: 120 },
+      scrollHeight: { configurable: true, writable: true, value: 1_000 },
+      clientHeight: { configurable: true, writable: true, value: 400 },
+    });
+    const scrollTo = vi.fn(({ top }: ScrollToOptions) => {
+      if (typeof top === 'number') scroller.scrollTop = top;
+    });
+    scroller.scrollTo = scrollTo;
+    const content = document.createElement('div');
+    const second = renderHook(() => useCacheAndScrollHarness(), { wrapper: CacheWrapper });
+
+    act(() => {
+      second.result.current.autoScroll.handleScrollerRef(scroller);
+      second.result.current.autoScroll.handleContentRef(content);
+    });
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(second.result.current.messages).toHaveLength(1);
+    expect(invoke).not.toHaveBeenCalled();
+    expect(scrollTo).toHaveBeenCalledWith({ top: 600, behavior: 'auto' });
+  });
+
+  it('shows a stale cached page immediately while revalidating it in the background', async () => {
+    const invoke = vi.mocked(ipcBridge.database.getConversationMessages.invoke);
+    invoke.mockResolvedValue({
+      items: [createTextMessage('cached-agent', 'old response')],
+      oldest_cursor: null,
+      newest_cursor: null,
+      has_more_before: false,
+      has_more_after: false,
+    });
+
+    function useCacheAndListHarness() {
+      useMessageLstCache(CONVERSATION_ID);
+      return { messages: useMessageList() };
+    }
+
+    const first = renderHook(() => useCacheAndListHarness(), { wrapper: CacheWrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    first.unmount();
+    vi.advanceTimersByTime(30_001);
+    invoke.mockResolvedValue({
+      items: [createTextMessage('cached-agent', 'new response')],
+      oldest_cursor: null,
+      newest_cursor: null,
+      has_more_before: false,
+      has_more_after: false,
+    });
+    invoke.mockClear();
+
+    const second = renderHook(() => useCacheAndListHarness(), { wrapper: CacheWrapper });
+    expect((second.result.current.messages[0] as IMessageText).content.content).toBe('old response');
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect((second.result.current.messages[0] as IMessageText).content.content).toBe('new response');
+  });
+
+  it('does not restore message data after the authentication cache is cleared', async () => {
+    const invoke = vi.mocked(ipcBridge.database.getConversationMessages.invoke);
+    invoke.mockResolvedValue({
+      items: [createTextMessage('cached-agent', 'private response')],
+      oldest_cursor: null,
+      newest_cursor: null,
+      has_more_before: false,
+      has_more_after: false,
+    });
+
+    function useCacheAndListHarness() {
+      useMessageLstCache(CONVERSATION_ID);
+      return { messages: useMessageList() };
+    }
+
+    const first = renderHook(() => useCacheAndListHarness(), { wrapper: CacheWrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => emitter.emit('auth.cacheCleared'));
+    first.unmount();
+    invoke.mockClear();
+
+    renderHook(() => useCacheAndListHarness(), { wrapper: CacheWrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache a response that completes after authentication cache is cleared', async () => {
+    const invoke = vi.mocked(ipcBridge.database.getConversationMessages.invoke);
+    let resolveFirst:
+      | ((value: {
+          items: IMessageText[];
+          oldest_cursor: null;
+          newest_cursor: null;
+          has_more_before: false;
+          has_more_after: false;
+        }) => void)
+      | undefined;
+    invoke.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        })
+    );
+
+    function useCacheAndListHarness() {
+      useMessageLstCache(CONVERSATION_ID);
+      return { messages: useMessageList() };
+    }
+
+    const first = renderHook(() => useCacheAndListHarness(), { wrapper: CacheWrapper });
+    act(() => emitter.emit('auth.cacheCleared'));
+    await act(async () => {
+      resolveFirst?.({
+        items: [createTextMessage('private-agent', 'private response')],
+        oldest_cursor: null,
+        newest_cursor: null,
+        has_more_before: false,
+        has_more_after: false,
+      });
+      await Promise.resolve();
+    });
+    expect(first.result.current.messages).toEqual([]);
+    first.unmount();
+    invoke.mockResolvedValue({
+      items: [],
+      oldest_cursor: null,
+      newest_cursor: null,
+      has_more_before: false,
+      has_more_after: false,
+    });
+    invoke.mockClear();
+
+    renderHook(() => useCacheAndListHarness(), { wrapper: CacheWrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops cached messages when the conversation is deleted', async () => {
+    const invoke = vi.mocked(ipcBridge.database.getConversationMessages.invoke);
+    invoke.mockResolvedValue({
+      items: [createTextMessage('cached-agent', 'deleted response')],
+      oldest_cursor: null,
+      newest_cursor: null,
+      has_more_before: false,
+      has_more_after: false,
+    });
+
+    function useCacheAndListHarness() {
+      useMessageLstCache(CONVERSATION_ID);
+      return { messages: useMessageList() };
+    }
+
+    const first = renderHook(() => useCacheAndListHarness(), { wrapper: CacheWrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => emitter.emit('conversation.deleted', CONVERSATION_ID));
+    first.unmount();
+    invoke.mockClear();
+
+    renderHook(() => useCacheAndListHarness(), { wrapper: CacheWrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps cached messages when a different conversation is deleted', async () => {
+    const invoke = vi.mocked(ipcBridge.database.getConversationMessages.invoke);
+    invoke.mockResolvedValue({
+      items: [createTextMessage('cached-agent', 'cached response')],
+      oldest_cursor: null,
+      newest_cursor: null,
+      has_more_before: false,
+      has_more_after: false,
+    });
+
+    function useCacheAndListHarness() {
+      useMessageLstCache(CONVERSATION_ID);
+      return { messages: useMessageList() };
+    }
+
+    const first = renderHook(() => useCacheAndListHarness(), { wrapper: CacheWrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    act(() => emitter.emit('conversation.deleted', 'conversation-2'));
+    first.unmount();
+    invoke.mockClear();
+
+    const second = renderHook(() => useCacheAndListHarness(), { wrapper: CacheWrapper });
+
+    expect(second.result.current.messages).toHaveLength(1);
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('evicts an older cached page when the in-memory list grows beyond the cache limit', async () => {
+    const invoke = vi.mocked(ipcBridge.database.getConversationMessages.invoke);
+    invoke.mockResolvedValue({
+      items: [createTextMessage('cached-agent', 'old response')],
+      oldest_cursor: null,
+      newest_cursor: null,
+      has_more_before: false,
+      has_more_after: false,
+    });
+
+    function useCacheAndListHarness() {
+      useMessageLstCache(CONVERSATION_ID);
+      return { messages: useMessageList() };
+    }
+
+    const first = renderHook(() => useCacheAndListHarness(), { wrapper: CacheWrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    first.unmount();
+    vi.advanceTimersByTime(30_001);
+    invoke.mockResolvedValue({
+      items: Array.from({ length: 201 }, (_, index) => createTextMessage(`large-${index}`, `response ${index}`)),
+      oldest_cursor: null,
+      newest_cursor: null,
+      has_more_before: false,
+      has_more_after: false,
+    });
+
+    const second = renderHook(() => useCacheAndListHarness(), { wrapper: CacheWrapper });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(second.result.current.messages).toHaveLength(202);
+    second.unmount();
+    invoke.mockImplementation(() => new Promise(() => {}));
+    invoke.mockClear();
+
+    const third = renderHook(() => useCacheAndListHarness(), { wrapper: CacheWrapper });
+
+    expect(third.result.current.messages).toEqual([]);
+    expect(invoke).toHaveBeenCalledTimes(1);
   });
 
   it('flips a pending user message to finish when message.statusChanged arrives for it', async () => {


### PR DESCRIPTION
# Pull Request

## Description

Reopening a conversation remounts its message providers. That discarded the latest message page and the full-history anchor list, so navigating away and back immediately repeated both the latest-page IPC read and every paginated anchor-history read.

This change keeps bounded renderer-side LRU caches across those remounts:

- cache up to 12 message lists, with a 200-message cap per entry
- cache up to 20 full-history anchor lists and deduplicate concurrent anchor reads
- serve entries immediately for 30 seconds, then keep showing them while revalidating in the background
- invalidate cached data and in-flight writes on authentication reset or conversation deletion
- merge live anchors into cached history so newly sent messages remain visible

The result is an immediate fresh-cache reopen without another message-page request or full-history anchor scan. A combined DOM regression test also verifies that an immediately restored list still opens at the latest message, preserving the initial auto-follow behavior introduced by #3042.

## Related Issues

- Follow-up to #3848
- Related to #2196

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [x] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format, for example `perf(scope): subject` (English)

Both cache consumers address the same conversation-remount cost and share the same freshness and security invalidation boundary. The independent sidebar row memoization is intentionally excluded into a separate PR.

## Local Checks (Rule 3)

- [x] `bun run format` — changed files formatted; full `bun run format:check` passes
- [x] `bun run lint` — 0 errors (existing warnings only)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 4,747 passed, 5 skipped
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no new user-facing text)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

Not applicable; this change has no visual surface.

## Additional Context

- Focused cache, anchor, and auto-scroll verification: 40 tests passed.
- Full coverage command passed: 4,747 tests passed; repository-wide line coverage is currently 54.48%.
- The combined regression test proves a fresh cached remount does not request the message page again and still scrolls an old position to the latest message.

---

**Thank you for contributing to AionUi!**
