### PR TITLE
perf(sidebar): memoize conversation rows

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/ConversationRow.tsx
@@ -339,4 +339,4 @@ const ConversationRow: React.FC<ConversationRowProps> = (props) => {
   );
 };
 
-export default ConversationRow;
+export default React.memo(ConversationRow);

--- a/tests/unit/renderer/conversation/ConversationRowManualUnread.dom.test.tsx
+++ b/tests/unit/renderer/conversation/ConversationRowManualUnread.dom.test.tsx
@@ -13,9 +13,10 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }));
 
-vi.mock('@/renderer/hooks/agent/usePresetAssistantInfo', () => ({
-  usePresetAssistantInfo: () => ({ info: null }),
+const { usePresetAssistantInfo } = vi.hoisted(() => ({
+  usePresetAssistantInfo: vi.fn(() => ({ info: null })),
 }));
+vi.mock('@/renderer/hooks/agent/usePresetAssistantInfo', () => ({ usePresetAssistantInfo }));
 
 vi.mock('@/renderer/hooks/context/LayoutContext', () => ({
   useLayoutContext: () => ({ isMobile: false }),
@@ -68,7 +69,7 @@ const makeProps = (overrides: Partial<ConversationRowProps> = {}): ConversationR
   onMenuVisibleChange: vi.fn(),
   onEditStart: vi.fn(),
   onCreateCronTask: vi.fn(),
-  onDelete: vi.fn(),
+  onArchive: vi.fn(),
   onTogglePin: vi.fn(),
   onToggleManualUnread: vi.fn(),
   getJobStatus: () => 'none',
@@ -76,6 +77,16 @@ const makeProps = (overrides: Partial<ConversationRowProps> = {}): ConversationR
 });
 
 describe('conversation mark-as-unread menu item', () => {
+  it('does not rerender when every row prop is unchanged', () => {
+    const props = makeProps();
+    const { rerender } = render(<ConversationRow {...props} />);
+    const renderCount = usePresetAssistantInfo.mock.calls.length;
+
+    rerender(<ConversationRow {...props} />);
+
+    expect(usePresetAssistantInfo).toHaveBeenCalledTimes(renderCount);
+  });
+
   it('offers "Mark as unread" when the conversation is not manually unread', async () => {
     render(<ConversationRow {...makeProps({ isManualUnread: false })} />);
 


### PR DESCRIPTION
# Pull Request

## Description

`GroupedHistory` rebuilds row props whenever sidebar-level state changes, such as the selected conversation or the visible row menu. Most conversations keep the same shallow prop values, but an un-memoized `ConversationRow` still rerenders every row.

Wrap `ConversationRow` with `React.memo` so rows with unchanged props keep their existing render. The parent already supplies stable callbacks and conversation objects, while rows whose selected, unread, generating, checked, or menu state changes continue to rerender normally.

The regression test rerenders a row with the same props and verifies its component hook is not called again. The touched test fixture is also aligned with the current `onArchive` prop contract.

## Related Issues

- None

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [x] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format, for example `perf(scope): subject` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — changed files formatted; full `bun run format:check` passes
- [x] `bun run lint` — 0 errors (existing warnings only)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 4,734 passed, 5 skipped
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (no new user-facing text)

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

Not applicable; this change has no visual surface.

## Additional Context

- Focused `ConversationRow` DOM tests: 5 passed.
- Full coverage command passed: 4,734 tests passed; repository-wide line coverage is currently 54.33%.

---

**Thank you for contributing to AionUi!**
