### PR TITLE
fix(webui): stop bridge websocket reconnect storm on repeated failures

### DIFF
--- a/packages/desktop/src/common/adapter/browser.ts
+++ b/packages/desktop/src/common/adapter/browser.ts
@@ -79,10 +79,19 @@ if (win.electronAPI) {
 
   type QueuedMessage = { name: string; data: unknown };
 
+  const BASE_RECONNECT_DELAY = 500;
+  const MAX_RECONNECT_DELAY = 8000;
+  // A connection must hold this long before the backoff is considered recovered.
+  // A server that accepts the upgrade and drops it right away (rejected auth,
+  // backend restarting) still fires `open`, so resetting the delay there alone
+  // would keep the backoff pinned at its minimum forever.
+  const STABLE_CONNECTION_MS = 5000;
+
   let socket: WebSocket | null = null;
   let emitterRef: { emit: (name: string, data: unknown) => void } | null = null;
   let reconnectTimer: number | null = null;
-  let reconnectDelay = 500;
+  let reconnectDelay = BASE_RECONNECT_DELAY;
+  let connectedAt = 0;
   let shouldReconnect = true; // Flag to control reconnection
 
   const messageQueue: QueuedMessage[] = [];
@@ -109,7 +118,7 @@ if (win.electronAPI) {
 
     reconnectTimer = window.setTimeout(() => {
       reconnectTimer = null;
-      reconnectDelay = Math.min(reconnectDelay * 2, 8000);
+      reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY);
       connect();
     }, reconnectDelay);
   };
@@ -134,7 +143,7 @@ if (win.electronAPI) {
     const currentSocket = socket;
 
     currentSocket.addEventListener('open', () => {
-      reconnectDelay = 500;
+      connectedAt = Date.now();
       flushQueue();
     });
 
@@ -212,6 +221,14 @@ if (win.electronAPI) {
         socket = null;
       }
 
+      // Only credit the backoff if the connection actually held for a while.
+      // Otherwise an accept-then-immediately-drop server keeps the delay at its
+      // minimum and the client hammers it forever.
+      if (connectedAt !== 0 && Date.now() - connectedAt >= STABLE_CONNECTION_MS) {
+        reconnectDelay = BASE_RECONNECT_DELAY;
+      }
+      connectedAt = 0;
+
       scheduleReconnect();
     });
 
@@ -222,6 +239,20 @@ if (win.electronAPI) {
 
   // 4.确保在发送/订阅前已经发起连接
   const ensureSocket = () => {
+    // 认证已终止时不得重连，否则 emit 会绕过上面的“停止重连”逻辑
+    // A terminal auth error deliberately stops reconnection; emit() must not restart it.
+    if (!shouldReconnect) {
+      return;
+    }
+
+    // 已有退避重连在排队时不要立即重拨，否则退避形同虚设
+    // A backoff reconnect is already queued — let it run. Dialling here instead
+    // would tie the reconnect rate to how often the app emits bridge events
+    // rather than to the backoff, turning a failing connection into a storm.
+    if (reconnectTimer !== null) {
+      return;
+    }
+
     if (!socket || socket.readyState === WebSocket.CLOSED || socket.readyState === WebSocket.CLOSING) {
       connect();
     }
@@ -257,7 +288,11 @@ if (win.electronAPI) {
   // Expose reconnection control for login flow
   win.__websocketReconnect = () => {
     shouldReconnect = true;
-    reconnectDelay = 500;
+    reconnectDelay = BASE_RECONNECT_DELAY;
+    if (reconnectTimer !== null) {
+      window.clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
     connect();
   };
 }

--- a/tests/unit/renderer/webuiWebSocketReconnect.dom.test.ts
+++ b/tests/unit/renderer/webuiWebSocketReconnect.dom.test.ts
@@ -1,0 +1,226 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression tests for the WebUI browser bridge socket.
+ *
+ * The browser adapter re-dials on demand so a login can immediately get a
+ * cookie-bearing connection. That on-demand path used to ignore both the
+ * pending backoff timer and the terminal-auth stop flag, so a WebUI whose
+ * connection kept failing reconnected once per bridge emit instead of on the
+ * backoff schedule.
+ */
+
+const CLOSED = 3;
+
+type SocketListener = (event: unknown) => void;
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  static instances: FakeWebSocket[] = [];
+
+  readyState = FakeWebSocket.CONNECTING;
+  sent: string[] = [];
+
+  private readonly listeners = new Map<string, SocketListener[]>();
+
+  constructor(public readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: SocketListener): void {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(listener);
+    this.listeners.set(type, existing);
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload);
+  }
+
+  close(): void {
+    if (this.readyState === FakeWebSocket.CLOSED) {
+      return;
+    }
+    this.readyState = FakeWebSocket.CLOSED;
+    this.dispatch('close', { code: 1006 });
+  }
+
+  /** Server accepts the upgrade. */
+  acceptUpgrade(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.dispatch('open', {});
+  }
+
+  /** Server pushes a bridge payload. */
+  deliver(payload: unknown): void {
+    this.dispatch('message', { data: JSON.stringify(payload) });
+  }
+
+  private dispatch(type: string, event: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+}
+
+const loadBrowserAdapter = async () => {
+  FakeWebSocket.instances = [];
+  vi.resetModules();
+
+  const win = window as unknown as Record<string, unknown>;
+  delete win.electronAPI;
+  delete win.__bridgeEmitter;
+  delete win.__websocketReconnect;
+
+  vi.stubGlobal('WebSocket', FakeWebSocket);
+
+  const { bridge } = await import('@/common/platform/bridge');
+  await import('@/common/adapter/browser');
+
+  return { bridge };
+};
+
+const latestSocket = (): FakeWebSocket => {
+  const socket = FakeWebSocket.instances.at(-1);
+  if (!socket) {
+    throw new Error('no socket was created');
+  }
+  return socket;
+};
+
+/** Drop the live socket, then assert the next dial lands exactly on `delay`. */
+const expectReconnectAt = async (delay: number, socketsSoFar: number): Promise<void> => {
+  latestSocket().acceptUpgrade();
+  latestSocket().close();
+
+  await vi.advanceTimersByTimeAsync(delay - 1);
+  expect(FakeWebSocket.instances).toHaveLength(socketsSoFar);
+
+  await vi.advanceTimersByTimeAsync(1);
+  expect(FakeWebSocket.instances).toHaveLength(socketsSoFar + 1);
+};
+
+describe('WebUI browser bridge socket', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('connects once on load', async () => {
+    await loadBrowserAdapter();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(latestSocket().url).toMatch(/\/ws$/);
+  });
+
+  it('does not re-dial on every emit while a backoff reconnect is pending', async () => {
+    const { bridge } = await loadBrowserAdapter();
+
+    latestSocket().acceptUpgrade();
+    latestSocket().close();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    // The app keeps talking to a dead socket. Each emit used to call connect()
+    // directly, so the reconnect rate tracked the emit rate, not the backoff.
+    for (let i = 0; i < 25; i += 1) {
+      bridge.emit(`probe-${i}`, {});
+    }
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    // Only the scheduled retry opens the next socket.
+    await vi.advanceTimersByTimeAsync(500);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
+  it('queues messages emitted while disconnected and flushes them on reconnect', async () => {
+    const { bridge } = await loadBrowserAdapter();
+
+    latestSocket().acceptUpgrade();
+    latestSocket().close();
+
+    bridge.emit('queued-event', { value: 7 });
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(500);
+    const reconnected = latestSocket();
+    reconnected.acceptUpgrade();
+
+    expect(reconnected.sent).toHaveLength(1);
+    expect(JSON.parse(reconnected.sent[0])).toEqual({ name: 'queued-event', data: { value: 7 } });
+  });
+
+  it('backs off when the server accepts the upgrade and drops it immediately', async () => {
+    await loadBrowserAdapter();
+
+    // A backend that rejects auth still completes the WebSocket handshake, so
+    // `open` fires on every attempt. The delay must keep growing regardless.
+    await expectReconnectAt(500, 1);
+    await expectReconnectAt(1000, 2);
+    await expectReconnectAt(2000, 3);
+    await expectReconnectAt(4000, 4);
+  });
+
+  it('resets the backoff once a connection has held', async () => {
+    await loadBrowserAdapter();
+
+    latestSocket().acceptUpgrade();
+    latestSocket().close();
+    await vi.advanceTimersByTimeAsync(500);
+
+    // Second attempt stays up long enough to count as recovered.
+    latestSocket().acceptUpgrade();
+    await vi.advanceTimersByTimeAsync(5000);
+    latestSocket().close();
+
+    const before = FakeWebSocket.instances.length;
+    await vi.advanceTimersByTimeAsync(500);
+    expect(FakeWebSocket.instances).toHaveLength(before + 1);
+  });
+
+  it('stops reconnecting after a terminal auth error, including on later emits', async () => {
+    const { bridge } = await loadBrowserAdapter();
+
+    latestSocket().acceptUpgrade();
+    latestSocket().deliver({ name: 'realtime.error', data: { code: 'REALTIME_AUTH_EXPIRED' } });
+
+    expect(latestSocket().readyState).toBe(CLOSED);
+    const afterAuthFailure = FakeWebSocket.instances.length;
+
+    // Emitting must not quietly resurrect the connection the auth handler just
+    // shut down, otherwise "stopping reconnection" never actually stops.
+    for (let i = 0; i < 10; i += 1) {
+      bridge.emit(`probe-${i}`, {});
+    }
+    await vi.advanceTimersByTimeAsync(30000);
+
+    expect(FakeWebSocket.instances).toHaveLength(afterAuthFailure);
+  });
+
+  it('reconnects immediately when the login flow asks it to', async () => {
+    await loadBrowserAdapter();
+
+    latestSocket().acceptUpgrade();
+    latestSocket().deliver({ name: 'realtime.error', data: { code: 'REALTIME_AUTH_EXPIRED' } });
+    const afterAuthFailure = FakeWebSocket.instances.length;
+
+    const reconnect = (window as unknown as { __websocketReconnect?: () => void }).__websocketReconnect;
+    expect(reconnect).toBeTypeOf('function');
+    reconnect?.();
+
+    expect(FakeWebSocket.instances).toHaveLength(afterAuthFailure + 1);
+  });
+});

--- a/tests/unit/renderer/webuiWebSocketReconnect.dom.test.ts
+++ b/tests/unit/renderer/webuiWebSocketReconnect.dom.test.ts
@@ -223,4 +223,25 @@ describe('WebUI browser bridge socket', () => {
 
     expect(FakeWebSocket.instances).toHaveLength(afterAuthFailure + 1);
   });
+
+  it('cancels a pending backoff retry when the login flow reconnects', async () => {
+    await loadBrowserAdapter();
+
+    // Burn one retry so the next one is queued a full second out, then leave a
+    // retry pending — this is the state a user is in when they sign in while
+    // the socket is still failing.
+    await expectReconnectAt(500, 1);
+    latestSocket().acceptUpgrade();
+    latestSocket().close();
+
+    const beforeLogin = FakeWebSocket.instances.length;
+    (window as unknown as { __websocketReconnect?: () => void }).__websocketReconnect?.();
+
+    // Login dials straight away instead of waiting out the backoff.
+    expect(FakeWebSocket.instances).toHaveLength(beforeLogin + 1);
+
+    // The superseded timer must not fire a second, duplicate dial afterwards.
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(FakeWebSocket.instances).toHaveLength(beforeLogin + 1);
+  });
 });


### PR DESCRIPTION
# Pull Request

## Description

The WebUI browser bridge reconnects its WebSocket on demand so that a login can immediately get a cookie-bearing connection. That on-demand path bypassed the backoff, which turns any persistent connection failure into a reconnect storm.

Three related defects in `packages/desktop/src/common/adapter/browser.ts`, all on the same code path:

1. **`ensureSocket()` bypassed the backoff.** It called `connect()` directly whenever the socket was `CLOSED`/`CLOSING`, and it is invoked from `emit()` — i.e. on *every* bridge event. With a pending `reconnectTimer` sitting unused, the reconnect rate tracked how often the app emitted rather than the 500 ms→8 s schedule.

2. **`ensureSocket()` ignored `shouldReconnect`.** After `isRealtimeAuthTerminalError()` sets `shouldReconnect = false`, clears the timer and closes the socket, the very next `emit()` re-dialled anyway — so "stopping reconnection" never actually stopped.

3. **The backoff reset on `open`.** A server that completes the WebSocket handshake and then drops the connection (rejected auth, backend restarting) still fires `open`, so `reconnectDelay` snapped back to 500 ms on every attempt and never grew.

Together these mean a WebUI whose connection keeps failing reconnects roughly once a second, forever. Because a reconnect also triggers a full data revalidation, the page appears to be constantly reloading and becomes unusable.

### Changes

- `ensureSocket()` returns early when reconnection is disabled or a retry is already queued.
- `reconnectDelay` only resets after a connection has held for `STABLE_CONNECTION_MS` (5 s), tracked via `connectedAt` on `open` and evaluated on `close`.
- `__websocketReconnect()` clears any pending timer before dialling, so the login flow still reconnects instantly.
- Extracted `BASE_RECONNECT_DELAY` / `MAX_RECONNECT_DELAY` so the two previously duplicated `500` literals and the `8000` cap stay in sync.

Message queueing is unchanged: events emitted while disconnected still land in `messageQueue` and flush on the next `open`. There is a test covering that so the fix cannot silently start dropping events.

## Related Issues

Contributing cause of #4155. It does **not** close that issue — the primary defect there (a paired browser's Core session is minted with a 24 h TTL and never renewed) lives in code that is not part of this repository. This PR fixes the part that is here: the reconnect storm that turns that auth failure into an unusable, seemingly-reloading page.

- Related to #4155

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

The three changes share one root cause and one code path — reconnect scheduling in the browser bridge. Splitting them would leave the storm in place: guarding `ensureSocket()` alone still lets an accept-then-drop server hammer at the 500 ms floor, and fixing only the backoff reset still lets `emit()` skip the timer.

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no new warnings from the changed files (0 errors; the 4 pre-existing warnings in `browser.ts` are unused catch params in untouched code)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 4822 passed, 5 skipped, 0 failed (508 files)
- [x] i18n validated — N/A, no `src/renderer/`, `locales/` or `src/common/config/i18n/` changes
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — N/A, no user-facing text

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

Found on macOS 15.6 with a phone paired over LAN to the desktop WebUI, against a backend rejecting the browser's expired session — the exact `accept upgrade, then drop` case in defect 3. Backend logs showed `path=/ws status=101` about once per second alongside a full `/api/*` burst on each reconnect.

New test file `tests/unit/renderer/webuiWebSocketReconnect.dom.test.ts` (7 tests) drives the real module in jsdom with fake timers and a scripted `WebSocket` stub. Against the unpatched adapter **4 of the 7 fail**, so the tests demonstrably pin the regressions rather than just passing:

```
× does not re-dial on every emit while a backoff reconnect is pending
× queues messages emitted while disconnected and flushes them on reconnect
× backs off when the server accepts the upgrade and drops it immediately
× stops reconnecting after a terminal auth error, including on later emits
```

## Additional Context

Reconnect behaviour after the change, for a connection that keeps failing:

| | before | after |
|---|---|---|
| socket closes, app keeps emitting | one dial per emit (~1 Hz+) | one dial per backoff tick |
| server accepts upgrade then drops | 500 ms forever | 500 ms → 1 s → 2 s → 4 s → 8 s |
| terminal auth error, then an emit | reconnects anyway | stays down |
| login calls `__websocketReconnect()` | immediate | immediate (unchanged) |
| connection recovers and holds ≥5 s | delay already 500 ms | delay resets to 500 ms |
