### PR TITLE
fix(guid): stop turning "no model picked" into a silent pick

### DIFF
--- a/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
+++ b/packages/desktop/src/renderer/pages/guid/GuidPage.tsx
@@ -262,7 +262,6 @@ const GuidPage: React.FC = () => {
     selectedMode: agentSelection.selectedMode,
     selectedAcpModel: agentSelection.selectedAcpModel,
     selectedThoughtLevelValue: agentSelection.selectedThoughtLevelValue,
-    currentAcpCachedModelInfo: agentSelection.currentAcpCachedModelInfo,
     current_model: modelSelection.current_model,
 
     guidDisabledBuiltinSkills,

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidAssistantSelection.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidAssistantSelection.ts
@@ -252,11 +252,25 @@ export const useGuidAssistantSelection = ({
 
   const modelSelectionScopeRef = useRef<string | null>(null);
   useEffect(() => {
-    const runtimeModelId =
-      selectedAgentRuntimeModelInfo?.current_model_id || selectedAgentRuntimeModelInfo?.available_models[0]?.id;
-    const fallbackModelId =
-      runtimeModelId ||
-      (selectedAssistantModels.length > 0 ? resolveInitialAssistantModel(selectedAssistantModels) : null);
+    // A CLI agent's runtime catalog must NOT seed a selection. `current_model_id` there is
+    // whatever the LAST session of this agent wrote back — not this user's intent — and
+    // `available_models[0]` is the agent's own "Default" row, which for claude is a REAL
+    // choice (it pins the account default, overriding the user's ANTHROPIC_MODEL). Seeding
+    // either one turned "I have not picked a model" into a silent pick, so a fresh
+    // conversation could never start on the model `claude` itself would have used.
+    //
+    // `null` is the meaningful value: `useGuidSend` omits the model override entirely, and
+    // the agent then resolves it from the user's own config, exactly as its CLI does. The
+    // picker renders this as no checkmark + the generic "default model" label, and once a
+    // session exists the backend reports the model it actually resolved to.
+    //
+    // Assistants backed by an API provider have no runtime catalog; they keep seeding from
+    // their own `models` list, which is a real per-assistant configuration.
+    const fallbackModelId = selectedAgentRuntimeModelInfo
+      ? null
+      : selectedAssistantModels.length > 0
+        ? resolveInitialAssistantModel(selectedAssistantModels)
+        : null;
     const availableModelIds = new Set(
       selectedAgentRuntimeModelInfo?.available_models.map((model) => model.id) ?? selectedAssistantModels
     );

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -16,7 +16,6 @@ import { type TFunction } from 'i18next';
 import type { NavigateFunction } from 'react-router-dom';
 import { mutate as swrMutate } from 'swr';
 import { getConversationCreateErrorMessage } from '@/renderer/pages/conversation/utils/conversationCreateError';
-import type { AcpModelInfo } from '../types';
 
 export type GuidSendDeps = {
   // Input state
@@ -35,7 +34,6 @@ export type GuidSendDeps = {
   selectedMode: string;
   selectedAcpModel: string | null;
   selectedThoughtLevelValue?: string;
-  currentAcpCachedModelInfo: AcpModelInfo | null;
   current_model: TProviderWithModel | undefined;
 
   guidDisabledBuiltinSkills: string[] | undefined;
@@ -83,7 +81,6 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     selectedMode,
     selectedAcpModel,
     selectedThoughtLevelValue,
-    currentAcpCachedModelInfo,
     current_model,
     guidDisabledBuiltinSkills,
     guidEnabledSkills,
@@ -152,11 +149,18 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     // Omitting it lets the agent start on its own default, which is what a user
     // who has not picked a model means. The cron dialog already gates the same
     // value this way (`resolvedBackend !== 'aionrs' → undefined`).
+    //
+    // The cached `current_model_id` is NOT a fallback for the same reason, and it
+    // used to defeat the very intent described above. It is whatever the LAST
+    // session of this agent wrote back, so an unpicked conversation inherited a
+    // stranger's choice: for claude that was usually its `default` row, which
+    // PINS the account default and overrides the user's own ANTHROPIC_MODEL — so
+    // the app ran a different model than `claude` in a terminal did, and the
+    // picker contradicted itself (the row promised one model, the session used
+    // another). Omit it: no pick means no override, and the agent resolves the
+    // model from the user's own config.
     const assistantOverrideModel =
-      selectedAcpModel ||
-      currentAcpCachedModelInfo?.current_model_id ||
-      (assistantBackend === 'aionrs' ? current_model?.use_model : undefined) ||
-      undefined;
+      selectedAcpModel || (assistantBackend === 'aionrs' ? current_model?.use_model : undefined) || undefined;
     const assistantOverrides = {
       model: assistantOverrideModel,
       permission: selectedMode || undefined,
@@ -286,7 +290,6 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
     selectedMode,
     selectedAcpModel,
     selectedThoughtLevelValue,
-    currentAcpCachedModelInfo,
     current_model,
     guidDisabledBuiltinSkills,
     guidEnabledSkills,

--- a/tests/unit/renderer/useGuidAgentSelection.dom.test.ts
+++ b/tests/unit/renderer/useGuidAgentSelection.dom.test.ts
@@ -268,7 +268,12 @@ describe('useGuidAssistantSelection', () => {
       expect(result.current.selectedAssistantId).toBe('custom-1781258588874-26ad');
     });
 
-    expect(result.current.selectedAcpModel).toBe('global.anthropic.claude-opus-4-8');
+    // The catalog is READ from the right agent, but it must NOT become a selection: its
+    // `current_model_id` is whatever the agent's last session wrote back, not this user's
+    // intent. Seeding it made every fresh conversation inherit a stranger's pick — for
+    // claude usually its `default` row, which pins the account default and overrides the
+    // user's own ANTHROPIC_MODEL, so the app ran a different model than the CLI did.
+    expect(result.current.selectedAcpModel).toBeNull();
     expect(result.current.currentAcpCachedModelInfo).toEqual({
       current_model_id: 'global.anthropic.claude-opus-4-8',
       current_model_label: 'Opus 4.8',
@@ -394,9 +399,12 @@ describe('useGuidAssistantSelection', () => {
       })
     );
 
+    // Nothing is picked until the user picks: the catalog's own `current_model_id` must
+    // not masquerade as a selection.
     await waitFor(() => {
-      expect(result.current.selectedAcpModel).toBe('default');
+      expect(result.current.selectedAssistantId).toBe('assistant-with-runtime-models');
     });
+    expect(result.current.selectedAcpModel).toBeNull();
 
     act(() => {
       result.current.setSelectedAcpModel('global.anthropic.claude-opus-4-8');
@@ -404,6 +412,7 @@ describe('useGuidAssistantSelection', () => {
 
     expect(result.current.selectedAcpModel).toBe('global.anthropic.claude-opus-4-8');
 
+    // A catalog refresh for the SAME assistant must not disturb the user's pick.
     mockManagedAgents = [buildManagedAgent()];
     rerender();
 

--- a/tests/unit/renderer/useGuidSend.dom.test.ts
+++ b/tests/unit/renderer/useGuidSend.dom.test.ts
@@ -56,7 +56,6 @@ const createDeps = (): GuidSendDeps => ({
   selectedAssistantBackend: 'claude',
   selectedMode: 'bypassPermissions',
   selectedAcpModel: 'claude-opus',
-  currentAcpCachedModelInfo: null,
   current_model: undefined,
   guidDisabledBuiltinSkills: undefined,
   guidEnabledSkills: undefined,
@@ -257,7 +256,6 @@ describe('useGuidSend', () => {
     const deps = createDeps();
     deps.selectedAssistantBackend = 'antigravity';
     deps.selectedAcpModel = null;
-    deps.currentAcpCachedModelInfo = null;
     deps.current_model = { id: 'p1', name: 'Gemini', use_model: 'gemini-3.1-pro-preview' } as never;
 
     const { result } = renderHook(() => useGuidSend(deps));
@@ -276,7 +274,6 @@ describe('useGuidSend', () => {
     const deps = createDeps();
     deps.selectedAssistantBackend = 'aionrs';
     deps.selectedAcpModel = null;
-    deps.currentAcpCachedModelInfo = null;
     deps.current_model = { id: 'p1', name: 'Gemini', use_model: 'gemini-3.1-pro-preview' } as never;
 
     const { result } = renderHook(() => useGuidSend(deps));
@@ -288,15 +285,16 @@ describe('useGuidSend', () => {
     expect(payload.assistant.conversation_overrides.model).toBe('gemini-3.1-pro-preview');
   });
 
-  it('prefers the agent catalog model once it has been probed', async () => {
-    // The path that makes this bug invisible after first use.
+  it('sends no model override for a CLI agent when the user has not picked one', async () => {
+    // The agent's own catalog is NOT a stand-in for the user's intent. It used to be
+    // substituted here, so an unpicked conversation inherited whatever the agent's LAST
+    // session had written back — for claude usually its `default` row, which pins the
+    // account default and overrides the user's own ANTHROPIC_MODEL. Omitting the override
+    // is what lets the agent resolve the model from the user's config, exactly as its CLI
+    // does; the aionrs provider model stays gated to aionrs.
     const deps = createDeps();
     deps.selectedAssistantBackend = 'antigravity';
     deps.selectedAcpModel = null;
-    deps.currentAcpCachedModelInfo = {
-      current_model_id: 'gemini-3.6-flash-low',
-      available_models: [{ id: 'gemini-3.6-flash-low', label: 'low' }],
-    } as never;
     deps.current_model = { id: 'p1', name: 'Gemini', use_model: 'gemini-3.1-pro-preview' } as never;
 
     const { result } = renderHook(() => useGuidSend(deps));
@@ -305,7 +303,24 @@ describe('useGuidSend', () => {
     });
 
     const payload = createConversationInvokeMock.mock.calls[0][0];
-    expect(payload.assistant.conversation_overrides.model).toBe('gemini-3.6-flash-low');
+    expect(payload.assistant.conversation_overrides.model).toBeUndefined();
+  });
+
+  it('sends the model the user actually picked for a CLI agent', async () => {
+    const deps = createDeps();
+    deps.selectedAssistantBackend = 'claude';
+    deps.selectedAcpModel = 'default';
+    deps.current_model = { id: 'p1', name: 'Gemini', use_model: 'gemini-3.1-pro-preview' } as never;
+
+    const { result } = renderHook(() => useGuidSend(deps));
+    await act(async () => {
+      await result.current.handleSend();
+    });
+
+    const payload = createConversationInvokeMock.mock.calls[0][0];
+    // `default` is a real row of claude's catalog, not a synonym for "unpicked": it must
+    // travel so the agent runs the account default the row advertises.
+    expect(payload.assistant.conversation_overrides.model).toBe('default');
   });
 
   it('does not create a conversation without assistant identity', async () => {


### PR DESCRIPTION
## Problem

A fresh conversation with a CLI agent could never start on the model the agent itself would have used. For `claude` this was visible as a self-contradiction: the picker showed `Default` selected, that row's own description named one model, and asking the conversation which model it was got a different answer.

## Root cause

"No model picked" was not representable end to end. Two layers substituted the agent's cached catalog state for the user's intent:

1. `useGuidAssistantSelection` seeded `selectedAcpModel` from the runtime catalog's `current_model_id`, falling back to `available_models[0]`.
2. `useGuidSend` then substituted that same `current_model_id` whenever the pick was still `null`.

`current_model_id` there is whatever the agent's **last session** wrote back — not this user's intent — so an unpicked conversation inherited a stranger's choice. And `available_models[0]` is the agent's own `Default` row, which for `claude` is a real choice that pins the account default and overrides the user's `ANTHROPIC_MODEL`. The net effect: the app ran a different model than the CLI did for the same configuration, and the row's description no longer matched what the session used.

Both layers already documented the correct intent — `useGuidSend`'s own comment says omitting the override "lets the agent start on its own default, which is what a user who has not picked a model means". The fallback defeated it.

## Changes

- `useGuidAssistantSelection`: a CLI agent's runtime catalog no longer seeds a selection. It still drops a pick the catalog no longer offers; it just never invents one.
- `useGuidSend`: the cached `current_model_id` is no longer a fallback, so `null` reaches the payload as "no override". Picking `default` explicitly still travels, because it is a real catalog row, not "unpicked".
- `currentAcpCachedModelInfo` is dropped from `useGuidSend`'s deps — substituting it was its only use.

Assistants backed by an API provider are untouched: they have no runtime catalog and keep seeding from their own `models` list, which is real per-assistant configuration. The scheduled-task dialog already represented "unpicked" correctly and needed no change.

## Tests

Three tests asserted the old substitution. They were rewritten rather than weakened, each keeping its original subject:

- "reads the runtime catalog from the right managed agent" now asserts the catalog is read *and* that it does not become a selection.
- "keeps a page model selection across catalog refreshes" now makes an actual user pick before refreshing, instead of relying on the seeding to fabricate one — a closer test of its own title.
- The send-path test is split into "no pick sends no override" and "an explicit pick is sent", the latter covering `default` specifically.

Full unit suite green (4730 passed), typecheck clean, lint warning count unchanged from the base branch, formatting clean.

## Manual validation

Verified in a development build against the real CLI, comparing the model the process reported running against what the conversation itself answered:

- With no pick, a new conversation started on the model the CLI resolves from the user's own configuration — the model that was previously unreachable from the app.
- Explicitly picking `Default` ran the account default the row advertises, so the picker and the session now agree.
- Explicitly picking alias rows and concrete rows each ran the corresponding model.
- The picker's list matches the CLI's `/model` list row for row and no longer changes depending on which model the last session happened to use.

## Cross-repo

Pairs with the AionCore change that carries the selection in-band and stops the `default` row being suppressed. Either side can ship first without breaking: this change alone sends no override, which older backends already treat as "no flag".
