### PR TITLE
fix(markdown): align table header with body rows

### DIFF
--- a/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
+++ b/packages/desktop/src/renderer/components/Markdown/ShadowView.tsx
@@ -239,6 +239,11 @@ export const createInitStyle = (
       border: 1px solid var(--bg-3);
       background-color: var(--bg-1);
       font-weight: bold;
+      /* Without this the UA default (text-align: center) applies and the header
+         row is centred while every body row is start-aligned. GFM alignment
+         markers (:---, :---:, ---:) still win: remark-gfm emits them as an
+         inline style, which outranks this rule. */
+      text-align: start;
     }
     td{
         padding: 8px;

--- a/packages/desktop/src/renderer/styles/markdown.css
+++ b/packages/desktop/src/renderer/styles/markdown.css
@@ -139,6 +139,11 @@
   border: 1px solid var(--bg-3);
   background-color: var(--bg-1);
   font-weight: bold;
+  /* Without this the UA default (text-align: center) applies and the header row
+     is centred while every body row is start-aligned. GFM alignment markers
+     (:---, :---:, ---:) still win: remark-gfm emits them as an inline style,
+     which outranks this rule. */
+  text-align: start;
 }
 .aionui-markdown :where(td) {
   padding: 8px;

--- a/tests/unit/renderer/markdownTableAlignment.dom.test.tsx
+++ b/tests/unit/renderer/markdownTableAlignment.dom.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression: markdown tables rendered with a centred header row above
+ * start-aligned body rows.
+ *
+ * Neither markdown surface declared `text-align` on `th`, so the UA default
+ * (`th { text-align: center }`) applied to the header while `td` fell through to
+ * `start`. Every table written without GFM alignment markers — `|---|---|` — came
+ * out visually inconsistent.
+ *
+ * The fix adds `text-align: start` to `th` on both surfaces. It is only safe
+ * because remark-gfm emits explicit alignment as an **inline style**, which
+ * outranks any stylesheet rule; this file pins both halves of that argument:
+ *   1. the `text-align: start` default exists on the chat and preview surfaces
+ *   2. `:---` / `:---:` / `---:` still reach the DOM as inline styles, and a
+ *      table without markers emits none (so the CSS default is what applies)
+ *
+ * jsdom loads no stylesheets, so `getComputedStyle` cannot verify (1) — the CSS
+ * is parsed directly instead, the same approach `scmBadgeCss.test.ts` takes.
+ */
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { render } from '@testing-library/react';
+import React from 'react';
+import ReactMarkdown from 'react-markdown';
+import { describe, expect, it } from 'vitest';
+
+import { MARKDOWN_REMARK_PLUGINS } from '@renderer/components/Markdown/markdownComponents';
+import { createInitStyle } from '@renderer/components/Markdown/ShadowView';
+
+const PREVIEW_CSS_PATH = path.resolve(__dirname, '../../../packages/desktop/src/renderer/styles/markdown.css');
+
+/** Parse a stylesheet string through jsdom's CSSOM and return its top-level rules. */
+const parseRules = (css: string): CSSRule[] => {
+  const style = document.createElement('style');
+  style.textContent = css;
+  document.head.appendChild(style);
+  const rules = [...(style.sheet?.cssRules ?? [])];
+  style.remove();
+  return rules;
+};
+
+const selectorOf = (rule: CSSRule): string => (rule as CSSStyleRule).selectorText ?? '';
+
+/** Collapse whitespace so `:where(th)` matches regardless of authored spacing. */
+const normalize = (selector: string): string => selector.replace(/\s+/g, ' ').trim();
+
+/** jsdom reports nested rules with an explicit `&` prefix (`th{}` → `& th`). */
+const nestedSelectorOf = (rule: CSSRule): string => normalize(selectorOf(rule).replace(/^&\s*/, ''));
+
+describe('chat surface (ShadowView) table header alignment', () => {
+  it('declares text-align: start on th so the header matches the body rows', () => {
+    const style = createInitStyle('light');
+    document.head.appendChild(style);
+    const rules = [...(style.sheet?.cssRules ?? [])];
+    style.remove();
+
+    const table = rules.find((rule) => selectorOf(rule) === 'table') as CSSStyleRule | undefined;
+    expect(table, 'the shadow stylesheet must still carry a `table` rule').toBeDefined();
+
+    const nested = [...(table?.cssRules ?? [])] as CSSStyleRule[];
+    const th = nested.find((rule) => nestedSelectorOf(rule) === 'th');
+    const td = nested.find((rule) => nestedSelectorOf(rule) === 'td');
+
+    expect(th, 'the nested `th` rule must exist').toBeDefined();
+    expect(th?.style.getPropertyValue('text-align')).toBe('start');
+    // `td` deliberately stays untouched: its UA default is already `start`.
+    expect(td?.style.getPropertyValue('text-align')).toBe('');
+  });
+});
+
+describe('preview surface (markdown.css) table header alignment', () => {
+  it('declares text-align: start on th so the header matches the body rows', () => {
+    const rules = parseRules(readFileSync(PREVIEW_CSS_PATH, 'utf8'));
+
+    const th = rules.find((rule) => normalize(selectorOf(rule)) === '.aionui-markdown :where(th)') as
+      | CSSStyleRule
+      | undefined;
+
+    expect(th, 'markdown.css must still carry a `.aionui-markdown :where(th)` rule').toBeDefined();
+    expect(th?.style.getPropertyValue('text-align')).toBe('start');
+  });
+});
+
+describe('GFM alignment markers survive the new default', () => {
+  const renderTable = (md: string) => {
+    const { container } = render(<ReactMarkdown remarkPlugins={MARKDOWN_REMARK_PLUGINS}>{md}</ReactMarkdown>);
+    return container;
+  };
+
+  it('emits inline text-align for :--- / :---: / ---: (inline style outranks the CSS default)', () => {
+    const container = renderTable(['| A | B | C |', '|:--|:-:|--:|', '| a | b | c |'].join('\n'));
+
+    const headers = [...container.querySelectorAll('th')].map((cell) => cell.style.textAlign);
+    const cells = [...container.querySelectorAll('td')].map((cell) => cell.style.textAlign);
+
+    expect(headers).toEqual(['left', 'center', 'right']);
+    expect(cells).toEqual(['left', 'center', 'right']);
+  });
+
+  it('emits no inline text-align without markers, leaving the CSS default in charge', () => {
+    const container = renderTable(['| A | B |', '|---|---|', '| a | b |'].join('\n'));
+
+    const headers = [...container.querySelectorAll('th')].map((cell) => cell.style.textAlign);
+    expect(headers).toEqual(['', '']);
+  });
+});


### PR DESCRIPTION
## Description

Markdown tables written without GFM alignment markers (`|---|---|`) rendered with a **centred header row above left-aligned body rows**.

Neither markdown surface declared `text-align` on `th`, so the UA default (`th { text-align: center }`) applied while `td` fell through to `start`. This PR adds `text-align: start` to `th` on both surfaces:

- chat — `packages/desktop/src/renderer/components/Markdown/ShadowView.tsx` (nested `table > th`)
- preview — `packages/desktop/src/renderer/styles/markdown.css` (`.aionui-markdown :where(th)`)

Explicit alignment is unaffected: remark-gfm emits `:---` / `:---:` / `---:` as an **inline style**, which outranks a stylesheet rule. That is the property the fix rests on, so the new test pins it directly.

## Related Issues

- Closes #4166

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [ ] `bunx vitest run` — tests pass <!-- ran the markdown-related suites (35 tests, all green), not the full suite; CI covers the rest -->
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — N/A, CSS only

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

Verified by rendering the reported table through the exact chat-surface CSS in a browser, before and after the change, plus a mutation check: removing the two `text-align: start` declarations makes the new tests fail.

## Additional Context

New test: `tests/unit/renderer/markdownTableAlignment.dom.test.tsx`

1. the chat shadow stylesheet declares `text-align: start` on the nested `th` (and leaves `td` alone)
2. `markdown.css` declares it on `.aionui-markdown :where(th)`
3. `:--- / :---: / ---:` still reach the DOM as inline `text-align` on both `th` and `td`
4. a table with no markers emits no inline `text-align`, so the CSS default is what applies