### PR TITLE
fix(conversation): make empty conversation title clickable to rename

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/components/ChatTitleEditor.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/components/ChatTitleEditor.tsx
@@ -19,7 +19,7 @@ type ChatTitleEditorProps = {
   leading?: React.ReactNode;
 };
 
-// Inline title display with double-click-to-edit rename support
+// Inline title display with click-to-edit rename support
 const ChatTitleEditor: React.FC<ChatTitleEditorProps> = ({
   editingTitle,
   titleDraft,
@@ -35,6 +35,19 @@ const ChatTitleEditor: React.FC<ChatTitleEditorProps> = ({
 }) => {
   const { t } = useTranslation();
 
+  // Conversations started from an empty input are persisted with an empty name,
+  // so the title renders as nothing. Without a placeholder the header looks
+  // blank and the click-to-rename region collapses to zero height, leaving no
+  // way to name the conversation. The placeholder is display-only — the rename
+  // draft still starts from the stored (empty) name.
+  const isTitleBlank = typeof title === 'string' && title.trim() === '';
+  const displayTitle = isTitleBlank ? t('conversation.historySearch.untitled') : title;
+
+  const startEditing = () => {
+    if (!canRenameTitle) return;
+    setEditingTitle(true);
+  };
+
   return (
     <div
       className={classNames(
@@ -46,8 +59,8 @@ const ChatTitleEditor: React.FC<ChatTitleEditorProps> = ({
       style={{ width: '100%', maxWidth: `${titleAreaMaxWidth}px` }}
     >
       {leading && <div className='shrink-0 flex items-center ps-8px'>{leading}</div>}
-      <div className='min-w-0 flex-1 px-8px py-5px'>
-        {editingTitle && canRenameTitle ? (
+      {editingTitle && canRenameTitle ? (
+        <div className='min-w-0 flex-1 px-8px py-5px'>
           <Input
             autoFocus
             value={titleDraft}
@@ -77,31 +90,42 @@ const ChatTitleEditor: React.FC<ChatTitleEditorProps> = ({
             placeholder={t('conversation.history.renamePlaceholder')}
             size='default'
           />
-        ) : (
+        </div>
+      ) : (
+        // The whole padded region is the rename trigger: an empty title leaves
+        // the text span with no box to hit, and the padding alone is only 10px
+        // tall. `min-h-24px` sits below the natural height of a rendered title
+        // (~29px), so it never affects layout — it only guarantees a usable hit
+        // area if the title text is ever absent.
+        <div
+          data-testid='chat-title-editor-trigger'
+          role={canRenameTitle ? 'button' : undefined}
+          tabIndex={canRenameTitle ? 0 : undefined}
+          className={classNames(
+            'min-w-0 flex-1 px-8px py-5px min-h-24px',
+            canRenameTitle && 'cursor-text focus:outline-none'
+          )}
+          onClick={startEditing}
+          onKeyDown={(event) => {
+            if (!canRenameTitle) return;
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              startEditing();
+            }
+          }}
+        >
           <span
-            role={canRenameTitle ? 'button' : undefined}
-            tabIndex={canRenameTitle ? 0 : undefined}
             className={classNames(
-              'block min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-16px font-bold text-t-primary transition-colors duration-150',
+              'block min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-16px font-bold transition-colors duration-150',
+              isTitleBlank ? 'text-t-tertiary' : 'text-t-primary',
               canRenameTitle &&
-                'cursor-text group-hover:text-[rgb(var(--primary-6))] group-focus-within:text-[rgb(var(--primary-6))] focus:outline-none'
+                'group-hover:text-[rgb(var(--primary-6))] group-focus-within:text-[rgb(var(--primary-6))]'
             )}
-            onClick={() => {
-              if (!canRenameTitle) return;
-              setEditingTitle(true);
-            }}
-            onKeyDown={(event) => {
-              if (!canRenameTitle) return;
-              if (event.key === 'Enter' || event.key === ' ') {
-                event.preventDefault();
-                setEditingTitle(true);
-              }
-            }}
           >
-            {title}
+            {displayTitle}
           </span>
-        )}
-      </div>
+        </div>
+      )}
       {!editingTitle && (
         <div className='w-0 flex items-center overflow-hidden opacity-0 transition-all duration-180 group-hover:w-40px group-hover:opacity-100 group-focus-within:w-40px group-focus-within:opacity-100'>
           <span className='h-16px w-1px shrink-0 rounded-full bg-[color:color-mix(in_srgb,var(--color-text-4)_44%,transparent)]' />

--- a/tests/unit/conversation/ChatTitleEditor.dom.test.tsx
+++ b/tests/unit/conversation/ChatTitleEditor.dom.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+// The minimap pulls conversation messages over the IPC bridge; the title editor
+// behaviour under test does not depend on it.
+vi.mock('@/renderer/pages/conversation/components/ConversationTitleMinimap', () => ({
+  default: () => null,
+}));
+
+import ChatTitleEditor from '@/renderer/pages/conversation/components/ChatTitleEditor';
+
+const renderEditor = (overrides: Partial<React.ComponentProps<typeof ChatTitleEditor>> = {}) => {
+  const setEditingTitle = vi.fn();
+  const props: React.ComponentProps<typeof ChatTitleEditor> = {
+    editingTitle: false,
+    titleDraft: '',
+    setTitleDraft: vi.fn(),
+    setEditingTitle,
+    renameLoading: false,
+    canRenameTitle: true,
+    submitTitleRename: vi.fn().mockResolvedValue(undefined),
+    titleAreaMaxWidth: 400,
+    title: '',
+    conversation_id: 'conv-1',
+    ...overrides,
+  };
+  render(<ChatTitleEditor {...props} />);
+  return { setEditingTitle };
+};
+
+describe('ChatTitleEditor with an empty conversation title', () => {
+  it('shows the untitled placeholder so the header is not blank', () => {
+    renderEditor();
+    expect(screen.getByText('conversation.historySearch.untitled')).toBeInTheDocument();
+  });
+
+  it('enters edit mode when the title region is clicked', () => {
+    const { setEditingTitle } = renderEditor();
+    fireEvent.click(screen.getByTestId('chat-title-editor-trigger'));
+    expect(setEditingTitle).toHaveBeenCalledWith(true);
+  });
+
+  it('stays read-only when rename is unavailable', () => {
+    const { setEditingTitle } = renderEditor({ canRenameTitle: false });
+    fireEvent.click(screen.getByTestId('chat-title-editor-trigger'));
+    expect(setEditingTitle).not.toHaveBeenCalled();
+  });
+});
+
+describe('ChatTitleEditor with a named conversation', () => {
+  it('renders the real title instead of the untitled placeholder', () => {
+    renderEditor({ title: '每日 AI 论文简报' });
+    expect(screen.getByText('每日 AI 论文简报')).toBeInTheDocument();
+    expect(screen.queryByText('conversation.historySearch.untitled')).not.toBeInTheDocument();
+  });
+
+  it('enters edit mode when the title region is clicked', () => {
+    const { setEditingTitle } = renderEditor({ title: '每日 AI 论文简报' });
+    fireEvent.click(screen.getByTestId('chat-title-editor-trigger'));
+    expect(setEditingTitle).toHaveBeenCalledWith(true);
+  });
+});


### PR DESCRIPTION
## Description

A conversation started from an empty input is persisted with an empty `name`, so the header title rendered nothing — and clicking that blank title area did not open the inline rename editor, leaving no way to ever name the conversation.

Root cause: the click-to-rename handler was attached to the title `<span>` itself. With an empty title that span is an empty block box, so it collapses to **zero height** and there is no hit area. The hover highlight that users see belongs to the padded wrapper around it, which had no handler — so every click landed on a non-interactive element. `canRenameTitle` was already `true` in this state (the stored name is `''`, a string), so the capability was never the problem; the geometry was.

Changes in `ChatTitleEditor`:

- Move the click / keyboard handler onto the padded title region so the whole hovered area is the rename trigger, independent of whether the title has text. It sits on that inner region (not the outer group) so the leading agent icon and the minimap button keep their own behaviour without needing `stopPropagation`.
- Add `min-h-24px` as an inert floor: it is below the natural height of a rendered title (~29px), so it never affects layout — it only guarantees a usable hit area if the title text is ever absent again.
- Render the existing `conversation.historySearch.untitled` placeholder in muted text (`text-t-tertiary`) when the stored name is blank, keeping `16px/bold` so nothing shifts once a real title lands. The placeholder is display-only: the rename draft still starts from the stored empty name, so nothing new is persisted and search cannot match the placeholder text.
- Split the editing branch into its own wrapper so the rename `<Input>` is no longer nested inside a `role="button"` element.
- Fix a stale comment that described the interaction as double-click.

Deliberately out of scope: the sidebar row and the search result list. The sidebar has no functional gap (the row opens the conversation, rename lives in the `⋯` menu regardless of the name), and a grey placeholder in a dense list of real titles reads as content rather than as a placeholder — a blank row is less misleading there. The search popover already renders the same untitled fallback.

## Related Issues

None.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (911 pre-existing warnings, 0 errors)
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (493 files, 4734 tests, 0 failures)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — no new keys, the existing `conversation.historySearch.untitled` is reused
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

Verified in a running build: an empty-title conversation now shows the muted placeholder, clicking the title area opens the inline editor, and renaming persists.

Header geometry was measured from screenshots (title-box fill height normalised against the macOS traffic-light button, whose logical size is constant), because an earlier iteration of this change used a wrong `min-height` and visibly inflated the header:

| State | Normalised box height |
| --- | --- |
| Before this PR · named title | 2.76 |
| After this PR · named title | 2.75 |
| After this PR · empty title (placeholder) | 2.75 |
| Before this PR · empty title | 2.13 |

So a named title keeps its exact previous height, and an empty title now matches it instead of being ~7px shorter — which also removes the header height jump that happened the moment a generated title arrived.

## Tests

New `tests/unit/conversation/ChatTitleEditor.dom.test.tsx` (written before the fix, failing first):

- empty title renders the untitled placeholder
- clicking the title region enters edit mode with an empty title
- clicking does nothing when rename is unavailable (`canRenameTitle: false`)
- a real title is not replaced by the placeholder
- clicking the title region still enters edit mode for a named conversation
