### PR TITLE
feat(auth): silently refresh WebUI session on 401

### DIFF
--- a/packages/desktop/src/common/adapter/browser.ts
+++ b/packages/desktop/src/common/adapter/browser.ts
@@ -6,6 +6,7 @@
 
 import { bridge } from '@/common/platform/bridge';
 import { WEBUI_DEFAULT_PORT } from '@/common/config/constants';
+import { refreshSession } from './sessionRefresh';
 import type { ElectronBridgeAPI } from '@/common/types/platform/electron';
 
 interface CustomWindow extends Window {
@@ -114,6 +115,22 @@ if (win.electronAPI) {
     }, reconnectDelay);
   };
 
+  // 跳转到登录页（已在登录页则跳过，防止无限刷新循环）
+  // Redirect to the login page (skipped when already there to avoid a reload loop).
+  const redirectToLogin = () => {
+    if (window.location.pathname === '/login' || window.location.hash.includes('/login')) {
+      return;
+    }
+
+    // 短暂延迟以便展示 UI 反馈；用 hash 导航留在 SPA 内（HashRouter），
+    // 避免整页刷新落到空 hash 造成白屏
+    // Short delay to surface any UI feedback; hash navigation stays within the SPA
+    // (HashRouter) instead of a full reload that would land on an empty hash.
+    setTimeout(() => {
+      window.location.hash = '/login';
+    }, 1000);
+  };
+
   // 3.建立 WebSocket 连接（或复用已有的 OPEN/CONNECTING 状态）
   const connect = () => {
     if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING)) {
@@ -159,36 +176,33 @@ if (win.electronAPI) {
           return;
         }
 
-        // 处理认证过期 - 停止重连并跳转到登录页
-        // Handle auth expiration - stop reconnecting and redirect to login
+        // 处理认证过期 - 先静默续期，成功则重连，失败才跳转登录页
+        // Handle auth expiration - try a silent refresh first; reconnect on success,
+        // and only fall back to the login page when the refresh token is also dead.
         if (isRealtimeAuthTerminalError(payload)) {
-          console.warn('[WebSocket] Authentication expired, stopping reconnection');
-          shouldReconnect = false;
+          console.warn('[WebSocket] Authentication expired, attempting silent refresh');
 
-          // 清除所有待执行的重连定时器
-          // Clear any pending reconnection timer
+          // 续期期间暂停自动重连，避免拿着失效 Cookie 空转（#4124 的重连风暴）
+          // Pause auto-reconnect while refreshing so the dead cookie can't loop
+          // (the #4124 reconnect storm).
+          shouldReconnect = false;
           if (reconnectTimer !== null) {
             window.clearTimeout(reconnectTimer);
             reconnectTimer = null;
           }
-
-          // 关闭 socket 并跳转到登录页
-          // Close the socket and redirect to login page
           socket?.close();
 
-          // 已在登录页则不再重定向，防止无限刷新循环
-          // Skip redirect if already on login page to prevent infinite reload loop
-          if (window.location.pathname === '/login' || window.location.hash.includes('/login')) {
-            return;
-          }
-
-          // 短暂延迟后跳转到登录页，以便显示 UI 反馈
-          // Redirect to login page after a short delay to show any UI feedback
-          // Use hash navigation to stay within the SPA (HashRouter), avoiding a full
-          // page reload that would land on an empty hash and cause a blank screen.
-          setTimeout(() => {
-            window.location.hash = '/login';
-          }, 1000);
+          void refreshSession().then((refreshed) => {
+            if (refreshed) {
+              // 新 Cookie 已就位，重连即可携带
+              // Fresh cookie is in place — the reconnect carries it.
+              shouldReconnect = true;
+              reconnectDelay = 500;
+              connect();
+              return;
+            }
+            redirectToLogin();
+          });
 
           return;
         }

--- a/packages/desktop/src/common/adapter/httpBridge.ts
+++ b/packages/desktop/src/common/adapter/httpBridge.ts
@@ -6,6 +6,8 @@
  * so existing renderer code works without changes.
  */
 
+import { refreshSession, WS_CLOSE_POLICY_VIOLATION } from './sessionRefresh';
+
 // ---------------------------------------------------------------------------
 // Base URL
 // ---------------------------------------------------------------------------
@@ -172,13 +174,55 @@ function redactForLog(value: unknown, depth = 0): unknown {
   );
 }
 
+const REFRESH_ENDPOINT = '/api/auth/refresh';
+
+/**
+ * Paths where a 401 is a genuine credential decision rather than an expired
+ * session — refreshing and replaying them would be recursive or nonsensical.
+ */
+function isAuthEndpoint(path: string): boolean {
+  return path.startsWith(REFRESH_ENDPOINT) || path === '/login' || path === '/logout';
+}
+
+/**
+ * Resolve the Core CSRF double-submit token for the current context.
+ *
+ * The open-source WebUI removed its CSRF layer with the legacy webserver (M6);
+ * a double-submit scheme is slated to return in M7. Until then this is a stub
+ * that reports "no token available", so the shared session-refresh primitive
+ * (`sessionRefresh.ts`) attaches no `x-csrf-token` header and the backend —
+ * which enforces no CSRF check here — accepts the request unchanged.
+ *
+ * It exists as the single seam every state-changing request would call for its
+ * token, so restoring CSRF in M7 (and the aionpro superset, whose backend does
+ * enforce the double-submit check) only swaps this body — no caller changes.
+ *
+ * Returns '' — always, for now.
+ */
+export function resolveCoreCsrfToken(): string {
+  return '';
+}
+
+function sendHttpRequest(
+  method: string,
+  path: string,
+  headers: Record<string, string>,
+  body?: unknown
+): Promise<Response> {
+  const url = `${getBaseUrl()}${path}`;
+  return fetch(url, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
 export async function httpRequest<T>(
   method: string,
   path: string,
   body?: unknown,
   options?: HttpRequestOptions
 ): Promise<T> {
-  const url = `${getBaseUrl()}${path}`;
   const headers: Record<string, string> = {};
 
   if (body !== undefined) {
@@ -194,11 +238,20 @@ export async function httpRequest<T>(
     body !== undefined ? JSON.stringify(redactForLog(body)).slice(0, 500) : '(no body)'
   );
 
-  const response = await fetch(url, {
-    method,
-    headers,
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
+  let response = await sendHttpRequest(method, path, headers, body);
+
+  // Expired access cookie → 401. Attempt one silent session refresh, then replay
+  // the original request — the WebUI half of the #4124 fix. refreshSession() is a
+  // no-op outside browser mode and single-flights concurrent 401s into one POST.
+  // The auth endpoints themselves are skipped to avoid recursion.
+  if (response.status === 401 && !isAuthEndpoint(path)) {
+    console.debug(`[httpBridge] ${method} ${path} → 401, attempting session refresh`);
+    const refreshed = await refreshSession();
+    if (refreshed) {
+      console.debug(`[httpBridge] session refreshed, replaying ${method} ${path}`);
+      response = await sendHttpRequest(method, path, headers, body);
+    }
+  }
 
   if (!response.ok) {
     // Response body can only be consumed once — read as text, then try JSON
@@ -396,6 +449,14 @@ function ensureWs(): void {
   current.addEventListener('close', (e) => {
     console.debug('[ensureWs] CLOSED code=' + e.code + ' reason=' + e.reason);
     if (ws === current) ws = null;
+    if (e.code === WS_CLOSE_POLICY_VIOLATION) {
+      // Auth policy violation (expired/missing session). Blindly reconnecting with
+      // the same dead cookie is the #4124 loop — refresh once and only reconnect if
+      // it succeeds. On failure the realtime stream stays down until re-auth;
+      // browser.ts's bridge socket drives the /login redirect.
+      void handleWsAuthClose();
+      return;
+    }
     scheduleWsReconnect();
   });
 
@@ -432,6 +493,19 @@ function scheduleWsReconnect(): void {
     wsReconnectTimer = null;
     ensureWs();
   }, delay);
+}
+
+/**
+ * Handle a realtime socket closed for auth policy violation (code 1008): attempt
+ * one shared session refresh, then reconnect only if the session was renewed.
+ * A failed refresh means the session is truly dead — we stop rather than loop.
+ */
+async function handleWsAuthClose(): Promise<void> {
+  const refreshed = await refreshSession();
+  if (refreshed) {
+    wsReconnectAttempt = 0;
+    ensureWs();
+  }
 }
 
 /**

--- a/packages/desktop/src/common/adapter/sessionRefresh.ts
+++ b/packages/desktop/src/common/adapter/sessionRefresh.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * WebUI browser-mode session refresh.
+ *
+ * The desktop app runs the backend in local mode (no tokens), but the remote
+ * WebUI (phone browser) authenticates with a short-lived access cookie plus a
+ * long-lived refresh cookie (HttpOnly, `Path=/api/auth/refresh`). When the access
+ * cookie expires the backend answers API calls with `401` and closes realtime
+ * sockets with code `1008` (`REALTIME_AUTH_EXPIRED`). Before the #4124 fix the
+ * client had no refresh step, so it either surfaced the 401 or blindly
+ * reconnected the socket with the same dead cookie — an unthrottled loop that
+ * ended in a hard kick to `/login`.
+ *
+ * `refreshSession()` performs the missing step: `POST /api/auth/refresh`, which
+ * the browser answers by attaching the HttpOnly refresh cookie. On success the
+ * backend `Set-Cookie`s a fresh access + refresh pair, so the caller can replay
+ * the failed request / reconnect the socket transparently. On failure the refresh
+ * cookie is also dead and the session is genuinely over.
+ *
+ * Concurrency: one expired access cookie fails many in-flight API calls and both
+ * realtime sockets at the same instant. A module-level single-flight collapses
+ * them into ONE POST, mirroring the backend `RefreshCoalescer` and staying under
+ * the refresh endpoint's rate limiter. Callers that lose the race await the same
+ * in-flight result.
+ *
+ * This module has no import-time side effects, so both `httpBridge.ts` and
+ * `browser.ts` can share it without bootstrapping each other's WebSocket.
+ */
+
+import { resolveCoreCsrfToken } from './httpBridge';
+
+/** WebSocket close code the backend uses for auth policy violations (RFC 6455 §7.4.1). */
+export const WS_CLOSE_POLICY_VIOLATION = 1008;
+
+const REFRESH_ENDPOINT = '/api/auth/refresh';
+
+/**
+ * WebUI browser mode = a real DOM with no Electron preload port. Only here do
+ * cookie-based sessions (and thus refresh) exist; the desktop renderer talks to
+ * a local-mode backend that needs no tokens. Kept in sync with the identical
+ * check in `httpBridge.ts` (duplicated rather than imported to avoid coupling the
+ * refresh primitive to the HTTP bridge).
+ */
+function isWebUiBrowserMode(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof document !== 'undefined' &&
+    !(window as { __backendPort?: number }).__backendPort
+  );
+}
+
+let inFlight: Promise<boolean> | null = null;
+
+/**
+ * Attempt a single silent session refresh. Concurrent callers share one POST.
+ *
+ * Resolves `true` when the session was renewed (fresh cookies now set), `false`
+ * when the refresh token is missing/expired or the request failed. Never throws —
+ * callers branch on the boolean and fall back to their existing failure handling.
+ */
+export function refreshSession(): Promise<boolean> {
+  if (!isWebUiBrowserMode()) {
+    // Desktop/local mode has no refreshable cookie session.
+    return Promise.resolve(false);
+  }
+  if (inFlight) {
+    return inFlight;
+  }
+  inFlight = performRefresh().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+async function performRefresh(): Promise<boolean> {
+  try {
+    // Attach the CSRF double-submit header when a token is available. The
+    // open-source WebUI has no CSRF layer yet (M6 removed it, M7 restores it), so
+    // resolveCoreCsrfToken() returns '' and no header is sent; the aionpro superset
+    // resolves a real token here and its backend enforces the check. The matching
+    // cookie, when one exists, rides `credentials: 'include'`.
+    const headers: Record<string, string> = {};
+    const csrfToken = resolveCoreCsrfToken();
+    if (csrfToken) {
+      headers['x-csrf-token'] = csrfToken;
+    }
+    const response = await fetch(REFRESH_ENDPOINT, {
+      method: 'POST',
+      // Same-origin request: the browser attaches the HttpOnly refresh cookie
+      // (scoped to Path=/api/auth/refresh). No body is needed — the backend reads
+      // the cookie and only falls back to a body token for legacy native clients.
+      credentials: 'include',
+      headers,
+    });
+    return response.ok;
+  } catch {
+    // Network failure — treat as "not refreshed" so callers keep their existing
+    // failure handling rather than assuming a live session.
+    return false;
+  }
+}

--- a/packages/desktop/src/renderer/hooks/context/AuthContext.tsx
+++ b/packages/desktop/src/renderer/hooks/context/AuthContext.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { PREVIEW_SCOPE_KEY_PREFIX } from '@/renderer/pages/conversation/Preview/context/previewScope';
+import { refreshSession } from '@/common/adapter/sessionRefresh';
 // M6: CSRF removed with legacy webserver — stub functions for compatibility, re-implement in M7
 const withCsrfToken = <T extends Record<string, unknown>>(data: T): T => data;
 const hasValidCsrfToken = (): boolean => true;
@@ -85,11 +86,26 @@ function clearAuthCache(): void {
 
 async function fetchCurrentUser(signal?: AbortSignal): Promise<AuthUser | null> {
   try {
-    const response = await fetch(AUTH_USER_ENDPOINT, {
+    let response = await fetch(AUTH_USER_ENDPOINT, {
       method: 'GET',
       credentials: 'include',
       signal,
     });
+
+    // The access cookie may have expired — attempt one silent session refresh
+    // and re-check before concluding the user is unauthenticated. Without this
+    // the status poll would kick a refreshable session to /login (#4124).
+    // refreshSession() single-flights with the httpBridge refresh path.
+    if (response.status === 401) {
+      const refreshed = await refreshSession();
+      if (refreshed) {
+        response = await fetch(AUTH_USER_ENDPOINT, {
+          method: 'GET',
+          credentials: 'include',
+          signal,
+        });
+      }
+    }
 
     if (!response.ok) {
       return null;

--- a/tests/unit/adapter/httpBridgeRefresh.dom.test.ts
+++ b/tests/unit/adapter/httpBridgeRefresh.dom.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { httpRequest } from '@/common/adapter/httpBridge';
+
+type WindowWithPort = { __backendPort?: number };
+
+/** Minimal `Response`-like stub covering the fields `httpRequest` reads. */
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: (name: string) => (name.toLowerCase() === 'content-type' ? 'application/json' : null) },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function errorResponse(status: number, body: unknown) {
+  return {
+    ok: false,
+    status,
+    headers: { get: () => null },
+    text: async () => JSON.stringify(body),
+  };
+}
+
+describe('httpRequest 401 → refresh → replay (WebUI #4124 fix)', () => {
+  beforeEach(() => {
+    // Browser mode so getBaseUrl() === '' and refresh is active.
+    delete (window as WindowWithPort).__backendPort;
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (window as WindowWithPort).__backendPort;
+  });
+
+  it('refreshes once and replays the original request on 401, returning unwrapped data', async () => {
+    let dataCalls = 0;
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/auth/refresh') return { ok: true };
+      dataCalls += 1;
+      if (dataCalls === 1) return errorResponse(401, { code: 'UNAUTHORIZED', error: 'expired' });
+      return jsonResponse(200, { data: { value: 42 } });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(httpRequest('GET', '/api/data')).resolves.toEqual({ value: 42 });
+
+    // original 401 + refresh + replay = 3 calls
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls.map((c) => c[0])).toEqual(['/api/data', '/api/auth/refresh', '/api/data']);
+  });
+
+  it('throws the original 401 when the refresh also fails (no infinite retry)', async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url === '/api/auth/refresh') return { ok: false, status: 401 };
+      return errorResponse(401, { code: 'UNAUTHORIZED', error: 'expired' });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(httpRequest('GET', '/api/data')).rejects.toMatchObject({
+      name: 'BackendHttpError',
+      status: 401,
+      code: 'UNAUTHORIZED',
+    });
+
+    // original 401 + one refresh attempt, then give up (no replay)
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not refresh when the first response succeeds', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { data: { ok: true } }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(httpRequest('GET', '/api/data')).resolves.toEqual({ ok: true });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/auth/refresh', expect.anything());
+  });
+
+  it('does not recurse when the refresh endpoint itself returns 401', async () => {
+    const fetchMock = vi.fn(async () => errorResponse(401, { code: 'UNAUTHORIZED', error: 'expired' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(httpRequest('POST', '/api/auth/refresh')).rejects.toMatchObject({
+      name: 'BackendHttpError',
+      status: 401,
+    });
+
+    // Called exactly once — the auth endpoint is exempt from refresh-replay.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/adapter/sessionRefresh.dom.test.ts
+++ b/tests/unit/adapter/sessionRefresh.dom.test.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2025 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { refreshSession } from '@/common/adapter/sessionRefresh';
+
+type WindowWithPort = { __backendPort?: number };
+
+describe('refreshSession (WebUI session refresh)', () => {
+  beforeEach(() => {
+    // Browser mode: real DOM (jsdom) with no Electron preload port.
+    delete (window as WindowWithPort).__backendPort;
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete (window as WindowWithPort).__backendPort;
+  });
+
+  it('POSTs /api/auth/refresh (cookie-borne, no body) and resolves true on success', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(refreshSession()).resolves.toBe(true);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/auth/refresh');
+    expect(init).toMatchObject({ method: 'POST', credentials: 'include' });
+    // No body — the browser attaches the HttpOnly refresh cookie.
+    expect(init.body).toBeUndefined();
+  });
+
+  it('sends no x-csrf-token header (open-source WebUI has no CSRF layer — M6 removed, M7 restores)', async () => {
+    // resolveCoreCsrfToken() is a stub returning '' here, so the shared refresh
+    // primitive attaches no CSRF header. The aionpro superset resolves a real
+    // token and asserts the header is present instead.
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(refreshSession()).resolves.toBe(true);
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.headers ?? {}).not.toHaveProperty('x-csrf-token');
+  });
+
+  it('resolves false when the refresh token is also expired (non-ok response)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 401 }));
+    await expect(refreshSession()).resolves.toBe(false);
+  });
+
+  it('resolves false (never throws) on network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+    await expect(refreshSession()).resolves.toBe(false);
+  });
+
+  it('single-flights concurrent callers into one POST, then refreshes anew afterwards', async () => {
+    let resolveFetch: (value: { ok: boolean }) => void = () => {};
+    const pending = new Promise<{ ok: boolean }>((resolve) => {
+      resolveFetch = resolve;
+    });
+    const fetchMock = vi.fn().mockReturnValueOnce(pending).mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const first = refreshSession();
+    const second = refreshSession();
+    // Both callers share the same in-flight request.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resolveFetch({ ok: true });
+    await expect(first).resolves.toBe(true);
+    await expect(second).resolves.toBe(true);
+
+    // In-flight promise cleared after settling — a later call refreshes again.
+    await expect(refreshSession()).resolves.toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('is a no-op (no fetch) outside WebUI browser mode', async () => {
+    (window as WindowWithPort).__backendPort = 13400;
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(refreshSession()).resolves.toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/common-adapter/browserRealtimeError.test.ts
+++ b/tests/unit/common-adapter/browserRealtimeError.test.ts
@@ -149,23 +149,28 @@ describe('browser WebSocket realtime error handling', () => {
   it.each([
     { name: 'realtime.error', data: { code: 'REALTIME_AUTH_MISSING', message: 'Missing auth', recoverable: false } },
     { name: 'realtime.error', data: { code: 'REALTIME_AUTH_EXPIRED', message: 'Expired auth', recoverable: false } },
-  ])('treats $name auth payload as terminal and redirects to login', async (payload) => {
+  ])('treats $name auth payload as terminal and redirects to login when refresh fails', async (payload) => {
     const { adapter, location, socket } = await loadBrowserAdapter();
     const emit = vi.fn();
     adapter.on({ emit });
 
     socket.dispatchMessage(payload);
 
+    // The socket is closed synchronously; the redirect now lives behind a silent
+    // refresh attempt. In this node env `document` is absent, so refreshSession()
+    // short-circuits to false and we fall through to the login redirect — but the
+    // scheduling happens on a microtask, so timers must advance asynchronously to
+    // let that promise settle first.
     expect(socket.close).toHaveBeenCalledTimes(1);
     expect(emit).not.toHaveBeenCalled();
 
     socket.dispatchClose(1006);
     const socketCountAfterClose = FakeWebSocket.instances.length;
-    vi.advanceTimersByTime(8000);
+    await vi.advanceTimersByTimeAsync(8000);
 
     expect(FakeWebSocket.instances).toHaveLength(socketCountAfterClose);
 
-    vi.advanceTimersByTime(1000);
+    await vi.advanceTimersByTimeAsync(1000);
     expect(location.hash).toBe('/login');
   });
 


### PR DESCRIPTION
## Description

The remote WebUI (a phone browser) authenticates with a short-lived access cookie plus a long-lived HttpOnly refresh cookie. When the access cookie expired, the client had no refresh step — it either surfaced the 401 or blindly reconnected the realtime socket with the same dead cookie, an unthrottled loop (#4124) that ended in a hard kick to `/login`.

This adds a silent session-refresh step ahead of that failure:

- **`refreshSession()`** — `POST /api/auth/refresh` swaps in a fresh cookie pair, with a module-level single-flight that collapses concurrent 401s (and both WS paths) into one request, mirroring the backend coalescer and staying under the refresh rate limit. Browser-mode only; no import-time side effects.
- **httpBridge** — on a 401, refresh then replay the request once (still-failing replays throw as before); auth endpoints are skipped to avoid recursion. On WS close 1008, reconnect only after a successful refresh.
- **browser.ts** — realtime auth-terminal errors refresh first, reconnect on success, and only redirect to `/login` when the refresh cookie is also dead.
- **AuthContext** — the auth-status poll refreshes on 401 before concluding the session is dead, so a refreshable session is no longer kicked to `/login`.
- **CSRF seam** — `performRefresh` attaches an `x-csrf-token` double-submit header when a token is available, via a shared `resolveCoreCsrfToken()`. The open-source WebUI removed CSRF with the legacy webserver (M6, restored in M7), so the resolver stubs to `''` and no header is sent — behavior is unchanged here. It exists as the single source of truth the closed-source superset overlays with a real token.

## Related Issues

- Refs #4124

## Type of Change

- [x] `feat` — New feature (non-breaking change which adds functionality)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (4825 passed / 5 skipped)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — passed (AuthContext touched renderer; no new user-facing strings)
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — N/A, no user-facing text

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

**Live verification is still pending and has not been done in this PR.** Exercising the refresh path requires running aioncore in a non-`--local` identity mode (JWT is enforced only outside local mode) with a shortened access-token TTL so the access cookie actually expires within a session — the default 30-day TTL means a 401 never fires under normal local testing. The logic is covered by DOM unit tests (single-flight, browser-mode gating, refresh/replay, recursion guard, CSRF-header-absent, and the realtime auth-terminal redirect).

Native-client dual-token and proactive timed refresh are deferred to a follow-up (they need a backend LoginResponse change).
