### PR TITLE
fix(webui): stop realtime socket reconnect and refresh storm on dead session

### DIFF
--- a/packages/desktop/src/common/adapter/browser.ts
+++ b/packages/desktop/src/common/adapter/browser.ts
@@ -6,7 +6,7 @@
 
 import { bridge } from '@/common/platform/bridge';
 import { WEBUI_DEFAULT_PORT } from '@/common/config/constants';
-import { refreshSession } from './sessionRefresh';
+import { refreshSessionOutcome, resetSessionRefresh } from './sessionRefresh';
 import type { ElectronBridgeAPI } from '@/common/types/platform/electron';
 
 interface CustomWindow extends Window {
@@ -94,6 +94,11 @@ if (win.electronAPI) {
   let reconnectDelay = BASE_RECONNECT_DELAY;
   let connectedAt = 0;
   let shouldReconnect = true; // Flag to control reconnection
+  // Auth recovery runs on its own schedule: the socket stays down until a refresh
+  // succeeds, so it must not share the reconnect timer/backoff.
+  let authRecoveryTimer: number | null = null;
+  let authRecoveryDelay = BASE_RECONNECT_DELAY;
+  let authRecoveryPending = false;
 
   const messageQueue: QueuedMessage[] = [];
 
@@ -138,6 +143,69 @@ if (win.electronAPI) {
     setTimeout(() => {
       window.location.hash = '/login';
     }, 1000);
+  };
+
+  // 认证失效后的恢复：续期成功才重连；refresh 也失效才跳登录页；
+  // 无法判定时只重试续期，绝不拿着同一个失效 Cookie 重拨
+  // Recover from an auth failure. The backend has already said this session is
+  // not authenticated, so the socket must stay down until a refresh actually
+  // succeeds — re-dialling with the same dead cookie only earns the same close.
+  // Only the *refresh* is retried, and only when the failure was inconclusive.
+  const attemptAuthRecovery = (): Promise<void> => {
+    authRecoveryPending = true;
+    return refreshSessionOutcome().then((outcome) => {
+      authRecoveryPending = false;
+
+      if (outcome === 'refreshed') {
+        // 新 Cookie 已就位，按退避重连即可携带；不要重置 reconnectDelay，
+        // 否则「续期成功但服务端仍拒绝」会变成新的无节制循环
+        // Fresh cookie is in place — the reconnect carries it. Go through the
+        // backoff rather than dialling straight away, and leave reconnectDelay
+        // alone: a backend that keeps refusing even a freshly minted session would
+        // otherwise loop refresh -> dial -> close -> refresh unthrottled. The delay
+        // is credited back on `close` once a connection has actually held.
+        authRecoveryDelay = BASE_RECONNECT_DELAY;
+        shouldReconnect = true;
+        scheduleReconnect();
+        return;
+      }
+
+      if (outcome === 'expired') {
+        // refresh 凭证本身失效，只能重新登录
+        // The refresh credential itself is dead — only a fresh login helps.
+        redirectToLogin();
+        return;
+      }
+
+      // 离线 / 429 / 5xx：无法判定会话是否真的失效，按退避重试续期，
+      // 不要因为一次瞬时故障就把用户踢到登录页
+      // Offline / 429 / 5xx says nothing about the session, so retry the refresh
+      // on a backoff rather than signing the user out over a transient failure.
+      authRecoveryTimer = window.setTimeout(() => {
+        authRecoveryTimer = null;
+        void attemptAuthRecovery();
+      }, authRecoveryDelay);
+      authRecoveryDelay = Math.min(authRecoveryDelay * 2, MAX_RECONNECT_DELAY);
+    });
+  };
+
+  const recoverFromAuthFailure = () => {
+    // 续期期间暂停自动重连，避免拿着失效 Cookie 空转（#4124 的重连风暴）
+    // Pause auto-reconnect while refreshing so the dead cookie can't loop
+    // (the #4124 reconnect storm).
+    shouldReconnect = false;
+    if (reconnectTimer !== null) {
+      window.clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    socket?.close();
+
+    // 一次只跑一轮恢复：帧可能重复到达
+    // One recovery at a time — the terminal frame can arrive more than once.
+    if (authRecoveryPending || authRecoveryTimer !== null) {
+      return;
+    }
+    void attemptAuthRecovery();
   };
 
   // 3.建立 WebSocket 连接（或复用已有的 OPEN/CONNECTING 状态）
@@ -190,29 +258,7 @@ if (win.electronAPI) {
         // and only fall back to the login page when the refresh token is also dead.
         if (isRealtimeAuthTerminalError(payload)) {
           console.warn('[WebSocket] Authentication expired, attempting silent refresh');
-
-          // 续期期间暂停自动重连，避免拿着失效 Cookie 空转（#4124 的重连风暴）
-          // Pause auto-reconnect while refreshing so the dead cookie can't loop
-          // (the #4124 reconnect storm).
-          shouldReconnect = false;
-          if (reconnectTimer !== null) {
-            window.clearTimeout(reconnectTimer);
-            reconnectTimer = null;
-          }
-          socket?.close();
-
-          void refreshSession().then((refreshed) => {
-            if (refreshed) {
-              // 新 Cookie 已就位，重连即可携带
-              // Fresh cookie is in place — the reconnect carries it.
-              shouldReconnect = true;
-              reconnectDelay = 500;
-              connect();
-              return;
-            }
-            redirectToLogin();
-          });
-
+          recoverFromAuthFailure();
           return;
         }
 
@@ -229,7 +275,7 @@ if (win.electronAPI) {
       }
     });
 
-    currentSocket.addEventListener('close', (event: CloseEvent) => {
+    currentSocket.addEventListener('close', () => {
       // Only null the outer reference if it still points at this socket.
       if (socket === currentSocket) {
         socket = null;
@@ -301,6 +347,17 @@ if (win.electronAPI) {
 
   // Expose reconnection control for login flow
   win.__websocketReconnect = () => {
+    // 登录成功后清除上一个会话留下的续期闩锁与重试队列，
+    // 否则新 Cookie 也会被判定为失效
+    // A new session invalidates the previous one's expiry latch and any queued
+    // refresh retry; without this the fresh cookie would still be treated as
+    // unrefreshable.
+    resetSessionRefresh();
+    if (authRecoveryTimer !== null) {
+      window.clearTimeout(authRecoveryTimer);
+      authRecoveryTimer = null;
+    }
+    authRecoveryDelay = BASE_RECONNECT_DELAY;
     shouldReconnect = true;
     reconnectDelay = BASE_RECONNECT_DELAY;
     if (reconnectTimer !== null) {

--- a/packages/desktop/src/common/adapter/httpBridge.ts
+++ b/packages/desktop/src/common/adapter/httpBridge.ts
@@ -6,7 +6,7 @@
  * so existing renderer code works without changes.
  */
 
-import { refreshSession, WS_CLOSE_POLICY_VIOLATION } from './sessionRefresh';
+import { isSessionExpired, refreshSession, refreshSessionOutcome, WS_CLOSE_POLICY_VIOLATION } from './sessionRefresh';
 
 // ---------------------------------------------------------------------------
 // Base URL
@@ -401,6 +401,16 @@ let ws: WebSocket | null = null;
 let wsReconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let wsReconnectAttempt = 0;
 let wsHasOpened = false;
+/** Epoch ms of the last `open`, or 0 while disconnected. */
+let wsConnectedAt = 0;
+
+/**
+ * How long a connection must hold before the backoff is considered recovered.
+ * A backend that accepts the upgrade and drops it right away (rejected auth,
+ * restarting) still fires `open`, so crediting the backoff there alone would pin
+ * the delay at its floor forever — the realtime half of the #4155 storm.
+ */
+const WS_STABLE_CONNECTION_MS = 5_000;
 
 function dispatchWsEvent(eventName: string, payload: unknown): void {
   const handlers = wsListeners.get(eventName);
@@ -417,6 +427,21 @@ function dispatchWsEvent(eventName: string, payload: unknown): void {
 function ensureWs(): void {
   if (typeof window === 'undefined') {
     console.debug('[ensureWs] skipped: no window');
+    return;
+  }
+  // The session is dead and no refresh can revive it. Every dial would be closed
+  // 1008 again and every close would spend another refresh POST, so stay down
+  // until re-auth calls resetSessionRefresh().
+  if (isSessionExpired()) {
+    console.debug('[ensureWs] skipped: session expired, waiting for re-auth');
+    return;
+  }
+  // A backoff reconnect is already queued — let it run. ensureWs() is called from
+  // wsSend() and from every wsEmitter().on() subscription, so dialling here ties
+  // the reconnect rate to how busy the app is rather than to the backoff. That is
+  // the #4155 storm, fixed for the bridge socket in #4156.
+  if (wsReconnectTimer) {
+    console.debug('[ensureWs] skipped: reconnect already queued');
     return;
   }
   if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
@@ -440,7 +465,7 @@ function ensureWs(): void {
     console.debug('[ensureWs] CONNECTED');
     const isReconnect = wsHasOpened;
     wsHasOpened = true;
-    wsReconnectAttempt = 0;
+    wsConnectedAt = Date.now();
     if (isReconnect) {
       dispatchWsEvent(REALTIME_RECONNECTED_EVENT, { timestamp: Date.now() });
     }
@@ -449,11 +474,16 @@ function ensureWs(): void {
   current.addEventListener('close', (e) => {
     console.debug('[ensureWs] CLOSED code=' + e.code + ' reason=' + e.reason);
     if (ws === current) ws = null;
+    // Only credit the backoff when the connection actually held; see
+    // WS_STABLE_CONNECTION_MS.
+    if (wsConnectedAt !== 0 && Date.now() - wsConnectedAt >= WS_STABLE_CONNECTION_MS) {
+      wsReconnectAttempt = 0;
+    }
+    wsConnectedAt = 0;
     if (e.code === WS_CLOSE_POLICY_VIOLATION) {
       // Auth policy violation (expired/missing session). Blindly reconnecting with
-      // the same dead cookie is the #4124 loop — refresh once and only reconnect if
-      // it succeeds. On failure the realtime stream stays down until re-auth;
-      // browser.ts's bridge socket drives the /login redirect.
+      // the same dead cookie is the #4124 loop — refresh first and let the outcome
+      // decide whether to reconnect, wait, or stay down. See handleWsAuthClose().
       void handleWsAuthClose();
       return;
     }
@@ -497,15 +527,51 @@ function scheduleWsReconnect(): void {
 
 /**
  * Handle a realtime socket closed for auth policy violation (code 1008): attempt
- * one shared session refresh, then reconnect only if the session was renewed.
- * A failed refresh means the session is truly dead — we stop rather than loop.
+ * one shared session refresh, then recover according to *why* it ended.
+ *
+ * The distinction matters because both failures used to look identical here: a
+ * dead refresh token and a 503 from the refresh endpoint both stopped the stream,
+ * while the next wsSend() re-dialled anyway — refreshing again on the next close.
  */
 async function handleWsAuthClose(): Promise<void> {
-  const refreshed = await refreshSession();
-  if (refreshed) {
-    wsReconnectAttempt = 0;
-    ensureWs();
+  const outcome = await refreshSessionOutcome();
+
+  if (outcome === 'refreshed') {
+    // Reconnect on the backoff rather than dialling straight away, and leave
+    // wsReconnectAttempt alone. A backend that keeps refusing even a freshly
+    // minted session would otherwise loop refresh -> dial -> 1008 -> refresh with
+    // nothing throttling it. The counter is credited on `close` once a connection
+    // has actually held, so a healthy recovery still comes back at the 1s floor.
+    scheduleWsReconnect();
+    return;
   }
+
+  if (outcome === 'expired') {
+    // Truly over. refreshSessionOutcome() has latched, so ensureWs() is now a
+    // no-op until re-auth — no dial, no further refresh POST. browser.ts's bridge
+    // socket drives the /login redirect.
+    console.warn('[ensureWs] session expired; realtime stream stays down until re-auth');
+    return;
+  }
+
+  // Inconclusive (offline / 429 / 5xx): the session may still be fine, so keep
+  // the stream on its normal backoff instead of stranding it until the next send.
+  scheduleWsReconnect();
+}
+
+/**
+ * Resume the realtime stream after a successful re-auth: drop the backoff and
+ * dial immediately, rather than waiting for the next subscription to do it.
+ * Callers must clear the refresh latch (`resetSessionRefresh()`) first.
+ */
+export function resumeRealtime(): void {
+  wsReconnectAttempt = 0;
+  wsConnectedAt = 0;
+  if (wsReconnectTimer) {
+    clearTimeout(wsReconnectTimer);
+    wsReconnectTimer = null;
+  }
+  ensureWs();
 }
 
 /**

--- a/packages/desktop/src/common/adapter/sessionRefresh.ts
+++ b/packages/desktop/src/common/adapter/sessionRefresh.ts
@@ -19,14 +19,31 @@
  * `refreshSession()` performs the missing step: `POST /api/auth/refresh`, which
  * the browser answers by attaching the HttpOnly refresh cookie. On success the
  * backend `Set-Cookie`s a fresh access + refresh pair, so the caller can replay
- * the failed request / reconnect the socket transparently. On failure the refresh
- * cookie is also dead and the session is genuinely over.
+ * the failed request / reconnect the socket transparently.
+ *
+ * ## Why a failed refresh needs more than `false`
+ *
+ * A refresh fails for two very different reasons, and #4155 is what happens when
+ * they are conflated:
+ *
+ * - The refresh credential itself is dead (`401`/`403`), or was never issued —
+ *   a paired browser holds only an access cookie. Re-asking can never succeed,
+ *   so every subsequent `401` firing another POST is a storm against a
+ *   rate-limited endpoint. This latches: `expired` is returned without a request
+ *   until an explicit re-auth calls `resetSessionRefresh()`.
+ * - The refresh could not be reached or concluded (network error, `429`, `5xx`).
+ *   The session may well still be good, so kicking the user to `/login` would
+ *   destroy a live session over a transient blip. This backs off instead:
+ *   `unavailable` is returned without a request until the cooldown elapses.
+ *
+ * Callers that only need "can I replay now?" keep using the boolean
+ * `refreshSession()`; callers that must choose between *reconnect*, *re-auth*
+ * and *retry later* use `refreshSessionOutcome()`.
  *
  * Concurrency: one expired access cookie fails many in-flight API calls and both
  * realtime sockets at the same instant. A module-level single-flight collapses
- * them into ONE POST, mirroring the backend `RefreshCoalescer` and staying under
- * the refresh endpoint's rate limiter. Callers that lose the race await the same
- * in-flight result.
+ * them into ONE POST, mirroring the backend `RefreshCoalescer`. Callers that lose
+ * the race await the same in-flight result.
  *
  * This module has no import-time side effects, so both `httpBridge.ts` and
  * `browser.ts` can share it without bootstrapping each other's WebSocket.
@@ -37,7 +54,23 @@ import { resolveCoreCsrfToken } from './httpBridge';
 /** WebSocket close code the backend uses for auth policy violations (RFC 6455 §7.4.1). */
 export const WS_CLOSE_POLICY_VIOLATION = 1008;
 
+/**
+ * Why a refresh attempt ended, so callers can pick the right recovery.
+ *
+ * - `refreshed`   — fresh cookies are set; replay the request / reconnect now.
+ * - `expired`     — the refresh credential is dead or absent; only re-auth helps.
+ *                   Latched: further calls return this without issuing a request.
+ * - `unavailable` — inconclusive (offline, rate-limited, backend error, or no
+ *                   cookie session in this runtime at all). The session may still
+ *                   be valid — retry later, do not sign the user out.
+ */
+export type SessionRefreshOutcome = 'refreshed' | 'expired' | 'unavailable';
+
 const REFRESH_ENDPOINT = '/api/auth/refresh';
+
+/** First cooldown after an inconclusive refresh; doubles up to the cap. */
+const BASE_COOLDOWN_MS = 1_000;
+const MAX_COOLDOWN_MS = 30_000;
 
 /**
  * WebUI browser mode = a real DOM with no Electron preload port. Only here do
@@ -54,22 +87,51 @@ function isWebUiBrowserMode(): boolean {
   );
 }
 
-let inFlight: Promise<boolean> | null = null;
+let inFlight: Promise<SessionRefreshOutcome> | null = null;
+/** Set once the backend rejects the refresh credential itself. Cleared on re-auth. */
+let sessionExpired = false;
+/** Epoch ms before which an inconclusive refresh must not be retried. */
+let cooldownUntil = 0;
+let cooldownMs = BASE_COOLDOWN_MS;
 
 /**
- * Attempt a single silent session refresh. Concurrent callers share one POST.
- *
- * Resolves `true` when the session was renewed (fresh cookies now set), `false`
- * when the refresh token is missing/expired or the request failed. Never throws —
- * callers branch on the boolean and fall back to their existing failure handling.
+ * True once a refresh has come back `401`/`403` — the session cannot be revived
+ * without a fresh login. Reconnect loops consult this so they stop dialling a
+ * backend that will only close them again.
  */
-export function refreshSession(): Promise<boolean> {
+export function isSessionExpired(): boolean {
+  return sessionExpired;
+}
+
+/**
+ * Clear the expiry latch and the cooldown. Call after a successful re-auth so
+ * refresh, reconnects and replays resume for the new session.
+ */
+export function resetSessionRefresh(): void {
+  sessionExpired = false;
+  cooldownUntil = 0;
+  cooldownMs = BASE_COOLDOWN_MS;
+}
+
+/**
+ * Attempt a single silent session refresh, reporting *why* it ended.
+ * Concurrent callers share one POST; latched and cooling-down callers get an
+ * answer without any request at all.
+ */
+export function refreshSessionOutcome(): Promise<SessionRefreshOutcome> {
   if (!isWebUiBrowserMode()) {
-    // Desktop/local mode has no refreshable cookie session.
-    return Promise.resolve(false);
+    // Desktop/local mode has no refreshable cookie session — nothing failed, so
+    // this is not an `expired` verdict callers should sign the user out over.
+    return Promise.resolve('unavailable');
+  }
+  if (sessionExpired) {
+    return Promise.resolve('expired');
   }
   if (inFlight) {
     return inFlight;
+  }
+  if (Date.now() < cooldownUntil) {
+    return Promise.resolve('unavailable');
   }
   inFlight = performRefresh().finally(() => {
     inFlight = null;
@@ -77,7 +139,20 @@ export function refreshSession(): Promise<boolean> {
   return inFlight;
 }
 
-async function performRefresh(): Promise<boolean> {
+/**
+ * Attempt a single silent session refresh. Concurrent callers share one POST.
+ *
+ * Resolves `true` when the session was renewed (fresh cookies now set), `false`
+ * for every other outcome. Never throws — callers branch on the boolean and fall
+ * back to their existing failure handling. Use `refreshSessionOutcome()` when
+ * "expired" and "could not tell" need different handling.
+ */
+export async function refreshSession(): Promise<boolean> {
+  return (await refreshSessionOutcome()) === 'refreshed';
+}
+
+async function performRefresh(): Promise<SessionRefreshOutcome> {
+  let response: { ok: boolean; status?: number };
   try {
     // Attach the CSRF double-submit header when a token is available. The
     // open-source WebUI has no CSRF layer yet (M6 removed it, M7 restores it), so
@@ -89,7 +164,7 @@ async function performRefresh(): Promise<boolean> {
     if (csrfToken) {
       headers['x-csrf-token'] = csrfToken;
     }
-    const response = await fetch(REFRESH_ENDPOINT, {
+    response = await fetch(REFRESH_ENDPOINT, {
       method: 'POST',
       // Same-origin request: the browser attaches the HttpOnly refresh cookie
       // (scoped to Path=/api/auth/refresh). No body is needed — the backend reads
@@ -97,10 +172,30 @@ async function performRefresh(): Promise<boolean> {
       credentials: 'include',
       headers,
     });
-    return response.ok;
   } catch {
-    // Network failure — treat as "not refreshed" so callers keep their existing
-    // failure handling rather than assuming a live session.
-    return false;
+    // Offline / DNS / connection reset — says nothing about the session.
+    return enterCooldown();
   }
+
+  if (response.ok) {
+    resetSessionRefresh();
+    return 'refreshed';
+  }
+
+  // The backend actively rejected the refresh credential: it is dead or was
+  // never issued. Latch so the next 401 does not spend another POST on it.
+  if (response.status === 401 || response.status === 403) {
+    sessionExpired = true;
+    return 'expired';
+  }
+
+  // 429 / 5xx / anything else — inconclusive, so back off and try again later
+  // rather than concluding the session is over.
+  return enterCooldown();
+}
+
+function enterCooldown(): SessionRefreshOutcome {
+  cooldownUntil = Date.now() + cooldownMs;
+  cooldownMs = Math.min(cooldownMs * 2, MAX_COOLDOWN_MS);
+  return 'unavailable';
 }

--- a/packages/desktop/src/renderer/hooks/context/AuthContext.tsx
+++ b/packages/desktop/src/renderer/hooks/context/AuthContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { PREVIEW_SCOPE_KEY_PREFIX } from '@/renderer/pages/conversation/Preview/context/previewScope';
-import { refreshSession } from '@/common/adapter/sessionRefresh';
+import { resumeRealtime } from '@/common/adapter/httpBridge';
+import { refreshSession, resetSessionRefresh } from '@/common/adapter/sessionRefresh';
 // M6: CSRF removed with legacy webserver — stub functions for compatibility, re-implement in M7
 const withCsrfToken = <T extends Record<string, unknown>>(data: T): T => data;
 const hasValidCsrfToken = (): boolean => true;
@@ -238,10 +239,16 @@ export const AuthProvider: React.FC<React.PropsWithChildren> = ({ children }) =>
       setStatus('authenticated');
       setReady(true);
 
-      // Re-enable WebSocket reconnection after successful login (WebUI mode only)
+      // Re-enable WebSocket reconnection after successful login (WebUI mode only).
+      // The previous session may have latched the refresh primitive as expired and
+      // parked the realtime stream; clear the latch first, then resume both sockets
+      // so they dial with the fresh cookie instead of waiting for the next
+      // subscription to do it.
+      resetSessionRefresh();
       if (typeof window !== 'undefined' && (window as any).__websocketReconnect) {
         (window as any).__websocketReconnect();
       }
+      resumeRealtime();
 
       return { success: true };
     } catch (error) {

--- a/tests/integration/webui-session/browserHarness.ts
+++ b/tests/integration/webui-session/browserHarness.ts
@@ -1,0 +1,211 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Enough browser for the real WebUI adapters to run under Node.
+ *
+ * `httpBridge.ts`, `browser.ts` and `sessionRefresh.ts` are loaded unmodified —
+ * the point of the integration test is that the shipped client code is what gets
+ * exercised. They need four things Node does not provide:
+ *
+ *  1. `window.location`, so same-origin relative paths and the `ws://…/ws` URL
+ *     resolve against the web host under test.
+ *  2. `document`, which is how `sessionRefresh.ts` recognises WebUI browser mode.
+ *  3. A `fetch` that resolves relative URLs and keeps a cookie jar. Node's fetch
+ *     ignores `credentials: 'include'` entirely, and cookies are the subject of
+ *     this test, so the jar is not optional.
+ *  4. A `WebSocket` that attaches those cookies to the upgrade request. The
+ *     browser class has no header hook, so `ws` does the work.
+ *
+ * The jar deliberately does **not** expire anything. A paired browser holds its
+ * session cookie for 30 days while the token inside it dies after 24 hours, and
+ * keeps sending it — that is the bug. Validity is the server's call, decided
+ * against the stub's virtual clock.
+ *
+ * `window` and `document` are installed once and left in place for the whole
+ * file: `browser.ts` schedules reconnects on real timers and there is no way to
+ * shut it down from outside, so a timer can still fire after its test has ended.
+ * `dispose()` neutralises such a straggler by swapping in an inert `fetch` and
+ * `WebSocket` instead of deleting the globals it would crash on.
+ */
+
+import { WebSocket as WsClient } from 'ws';
+
+type StoredCookie = { value: string; path: string };
+
+export class CookieJar {
+  private readonly cookies = new Map<string, StoredCookie>();
+
+  /** Absorb `Set-Cookie` headers, honouring `Path` (and `Max-Age=0` deletions). */
+  absorb(setCookieHeaders: readonly string[]): void {
+    for (const header of setCookieHeaders) {
+      const [pair, ...attrs] = header.split(';');
+      const eq = pair.indexOf('=');
+      if (eq < 0) continue;
+      const name = pair.slice(0, eq).trim();
+      const value = pair.slice(eq + 1).trim();
+      let path = '/';
+      let deleted = false;
+      for (const attr of attrs) {
+        const [rawKey, rawValue] = attr.split('=');
+        const key = rawKey.trim().toLowerCase();
+        if (key === 'path' && rawValue) path = rawValue.trim();
+        if (key === 'max-age' && Number(rawValue) <= 0) deleted = true;
+      }
+      if (deleted) {
+        this.cookies.delete(name);
+        continue;
+      }
+      this.cookies.set(name, { value, path });
+    }
+  }
+
+  /**
+   * `Cookie` header for `requestPath`, or '' when nothing is in scope. Path
+   * scoping is load-bearing here: the refresh cookie lives at
+   * `Path=/api/auth/refresh`, so it must not ride along on ordinary `/api/*` calls.
+   */
+  headerFor(requestPath: string): string {
+    const parts: string[] = [];
+    for (const [name, cookie] of this.cookies) {
+      if (requestPath === cookie.path || requestPath.startsWith(cookie.path === '/' ? '/' : `${cookie.path}/`)) {
+        parts.push(`${name}=${cookie.value}`);
+      }
+    }
+    return parts.join('; ');
+  }
+
+  get(name: string): string | undefined {
+    return this.cookies.get(name)?.value;
+  }
+
+  names(): string[] {
+    return [...this.cookies.keys()];
+  }
+}
+
+export type BrowserHarness = {
+  jar: CookieJar;
+  origin: string;
+  /** Path of every request the client made, so client-side behaviour can be asserted too. */
+  clientRequests: string[];
+  /** How many WebSocket dials the client attempted. */
+  socketDials: () => number;
+  /** Current SPA route, i.e. `window.location.hash`. */
+  hash: () => string;
+  /**
+   * Make any straggling timer from this test's client a no-op and hang up every
+   * socket it opened. The adapters expose no shutdown, and `startStaticServer`'s
+   * `stop()` waits on live connections, so the harness has to close what it opened.
+   */
+  dispose: () => void;
+};
+
+type MutableGlobal = typeof globalThis & Record<string, unknown>;
+
+/** A socket that connects forever: no events, so no reconnect is ever scheduled. */
+class InertWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  readonly readyState = InertWebSocket.CONNECTING;
+  addEventListener(): void {}
+  removeEventListener(): void {}
+  send(): void {}
+  close(): void {}
+}
+
+const inertFetch = async (): Promise<Response> =>
+  new Response(JSON.stringify({ success: false }), {
+    status: 503,
+    headers: { 'content-type': 'application/json' },
+  });
+
+/**
+ * Install the browser globals for `origin`. Call before importing any adapter
+ * module — `browser.ts` connects at import time.
+ */
+export function installBrowserGlobals(origin: string): BrowserHarness {
+  const jar = new CookieJar();
+  const clientRequests: string[] = [];
+  const url = new URL(origin);
+  const g = globalThis as MutableGlobal;
+  const realFetch = (g.__harnessRealFetch as typeof fetch) ?? globalThis.fetch;
+  g.__harnessRealFetch = realFetch;
+  const opened: WsClient[] = [];
+  let dials = 0;
+
+  const location = {
+    protocol: url.protocol,
+    hostname: url.hostname,
+    host: url.host,
+    origin,
+    pathname: '/',
+    hash: '',
+  };
+
+  g.window = {
+    location,
+    setTimeout: setTimeout.bind(globalThis),
+    clearTimeout: clearTimeout.bind(globalThis),
+  };
+  // Presence is all `isWebUiBrowserMode()` checks for.
+  g.document = {};
+
+  g.fetch = async (input: unknown, init?: RequestInit): Promise<Response> => {
+    const target = new URL(String(input), origin);
+    clientRequests.push(target.pathname);
+    const headers = new Headers(init?.headers as HeadersInit | undefined);
+    const cookie = jar.headerFor(target.pathname);
+    if (cookie) headers.set('cookie', cookie);
+    const response = await realFetch(target, { ...init, headers, redirect: 'manual' });
+    jar.absorb(response.headers.getSetCookie());
+    return response;
+  };
+
+  /**
+   * `ws` already exposes the browser surface the adapters use — `addEventListener`,
+   * `readyState`, the static ready-state constants — so the only thing to add is
+   * the cookie header, which the browser API gives no way to set.
+   */
+  class HarnessWebSocket extends WsClient {
+    constructor(target: string) {
+      dials += 1;
+      super(target, { headers: { cookie: jar.headerFor(new URL(target).pathname) } });
+      opened.push(this);
+    }
+  }
+
+  g.WebSocket = HarnessWebSocket;
+
+  return {
+    jar,
+    origin,
+    clientRequests,
+    socketDials: () => dials,
+    hash: () => location.hash,
+    dispose: () => {
+      g.fetch = inertFetch;
+      g.WebSocket = InertWebSocket;
+      for (const socket of opened.splice(0)) {
+        socket.terminate();
+      }
+    },
+  };
+}
+
+/** Undo `installBrowserGlobals` entirely. Safe only once every client is idle. */
+export function removeBrowserGlobals(): void {
+  const g = globalThis as MutableGlobal;
+  delete g.window;
+  delete g.document;
+  if (g.__harnessRealFetch) {
+    g.fetch = g.__harnessRealFetch as typeof fetch;
+    delete g.__harnessRealFetch;
+  }
+  delete g.WebSocket;
+}

--- a/tests/integration/webui-session/coreStub.ts
+++ b/tests/integration/webui-session/coreStub.ts
@@ -1,0 +1,258 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A stub aioncore for the WebUI session-lifetime integration test.
+ *
+ * It exists to make #4155's "roughly 24 hours after pairing" reproducible in
+ * milliseconds. The trick is a **virtual clock**: cookies carry the real
+ * production lifetimes (24 h access, 30 d refresh/pairing) and validity is
+ * decided against `clock.now()`, which the test advances by hand. So
+ * `core.advance(HOURS_24)` is literally "a day later" as far as every token in
+ * the system is concerned, and costs no wall-clock time.
+ *
+ * Only the parts of Core the WebUI session path touches are implemented:
+ * login, the authenticated `/api/*` surface, `/api/auth/refresh`, and the `/ws`
+ * realtime stream. Tokens are `<id>.<expiryInVirtualMs>` rather than real JWTs —
+ * the only field this scenario turns on is `exp`.
+ */
+
+import http, { type IncomingMessage, type ServerResponse } from 'node:http';
+import type { AddressInfo, Socket } from 'node:net';
+import { WebSocketServer, type WebSocket as WsSocket } from 'ws';
+
+/** Production lifetimes, from the #4155 investigation. */
+export const HOUR_MS = 60 * 60 * 1000;
+export const ACCESS_TTL_MS = 24 * HOUR_MS;
+export const REFRESH_TTL_MS = 30 * 24 * HOUR_MS;
+
+/** Core's access cookie. Name as observed on the shipped build. */
+export const ACCESS_COOKIE = 'aionui-session';
+/**
+ * Core's refresh cookie. `Path=/api/auth/refresh` so it is *not* attached to
+ * ordinary `/api/*` calls — that scoping is load-bearing for this scenario, and
+ * the client's cookie jar honours it.
+ */
+export const REFRESH_COOKIE = 'aionui-refresh';
+
+/**
+ * How a session is minted at login.
+ *
+ * - `renewable` — access + refresh, the dual-token model added in
+ *   iOfficeAI/AionCore#926 and consumed by #4175.
+ * - `paired`    — access only. This is the #4155 shape: `createPairedSessionCookies()`
+ *   hands the browser a Core session JWT and nothing to renew it with, so the
+ *   refresh endpoint has no credential to accept.
+ */
+export type SessionMode = 'renewable' | 'paired';
+
+/** What the realtime stream does when it sees an expired access token. */
+export type RealtimeRejection =
+  /** Send a `realtime.error` frame, then close 1008. What the shipped backend does. */
+  | 'frame-then-close'
+  /** Close 1008 with no frame — the bare policy-violation case. */
+  | 'close-only';
+
+export type CoreStub = {
+  port: number;
+  /** Virtual clock. Every expiry check reads `now()`. */
+  now: () => number;
+  advance: (ms: number) => void;
+  /** Server-side request counters — the storm is measured here, not in the client. */
+  counts: {
+    api: number;
+    apiUnauthorized: number;
+    refresh: number;
+    refreshRejected: number;
+    wsUpgrade: number;
+  };
+  /** Cookie header of every `/api/*` request, so the test can prove what the proxy forwarded. */
+  apiCookieHeaders: string[];
+  setSessionMode: (mode: SessionMode) => void;
+  /** Force a status on `/api/auth/refresh` (e.g. 503) instead of evaluating the cookie. */
+  setRefreshStatus: (status: number | null) => void;
+  setRealtimeRejection: (mode: RealtimeRejection) => void;
+  /** Mint a session as if the browser had just logged in / been paired. */
+  issueSessionCookies: () => string[];
+  /** Hang up every live realtime client, so the proxy's splice tears down too. */
+  dropRealtimeClients: () => void;
+  close: () => Promise<void>;
+};
+
+function sendJson(res: ServerResponse, status: number, body: unknown, cookies?: string[]): void {
+  const headers: Record<string, string | string[]> = { 'content-type': 'application/json' };
+  if (cookies?.length) headers['set-cookie'] = cookies;
+  res.writeHead(status, headers);
+  res.end(JSON.stringify(body));
+}
+
+function parseCookies(header: string | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    out[part.slice(0, eq).trim()] = part.slice(eq + 1).trim();
+  }
+  return out;
+}
+
+export async function startCoreStub(): Promise<CoreStub> {
+  let virtualNow = Date.now();
+  let sessionMode: SessionMode = 'renewable';
+  let forcedRefreshStatus: number | null = null;
+  let realtimeRejection: RealtimeRejection = 'frame-then-close';
+  let tokenSeq = 0;
+
+  const counts: CoreStub['counts'] = {
+    api: 0,
+    apiUnauthorized: 0,
+    refresh: 0,
+    refreshRejected: 0,
+    wsUpgrade: 0,
+  };
+  const apiCookieHeaders: string[] = [];
+
+  const now = (): number => virtualNow;
+  const mintToken = (ttlMs: number): string => `t${++tokenSeq}.${now() + ttlMs}`;
+  const tokenIsValid = (token: string | undefined): boolean => {
+    if (!token) return false;
+    const expiresAt = Number(token.split('.')[1]);
+    return Number.isFinite(expiresAt) && expiresAt > now();
+  };
+
+  /**
+   * `Max-Age` deliberately outlives the token inside the cookie: a paired
+   * browser keeps *holding* its session cookie for 30 days while the JWT within
+   * it dies after 24 hours. That mismatch is the whole of #4155, so the harness
+   * has to reproduce it rather than let the browser drop the cookie.
+   */
+  const issueSessionCookies = (): string[] => {
+    const cookies = [
+      `${ACCESS_COOKIE}=${mintToken(ACCESS_TTL_MS)}; Path=/; HttpOnly; Max-Age=${REFRESH_TTL_MS / 1000}`,
+    ];
+    if (sessionMode === 'renewable') {
+      cookies.push(
+        `${REFRESH_COOKIE}=${mintToken(REFRESH_TTL_MS)}; Path=/api/auth/refresh; HttpOnly; Max-Age=${REFRESH_TTL_MS / 1000}`
+      );
+    }
+    return cookies;
+  };
+
+  const unauthorized = (res: ServerResponse): void => {
+    // Same envelope the real backend returns, including the message #4155
+    // singled out: a *present but expired* token, not a missing one.
+    sendJson(res, 401, { success: false, code: 'UNAUTHORIZED', error: 'Invalid or expired token' });
+  };
+
+  const server = http.createServer((req: IncomingMessage, res: ServerResponse) => {
+    const url = req.url ?? '/';
+    const cookies = parseCookies(req.headers.cookie);
+    const path = url.split('?')[0];
+
+    if (path === '/login' && req.method === 'POST') {
+      sendJson(res, 200, { success: true, user: { id: 'u1', username: 'paired' } }, issueSessionCookies());
+      return;
+    }
+
+    if (path === '/api/auth/refresh') {
+      counts.refresh += 1;
+      if (forcedRefreshStatus !== null) {
+        counts.refreshRejected += 1;
+        sendJson(res, forcedRefreshStatus, { success: false, error: 'refresh unavailable' });
+        return;
+      }
+      if (!tokenIsValid(cookies[REFRESH_COOKIE])) {
+        // No refresh credential (paired browser) or it has expired too.
+        counts.refreshRejected += 1;
+        unauthorized(res);
+        return;
+      }
+      sendJson(res, 200, { success: true }, issueSessionCookies());
+      return;
+    }
+
+    if (path.startsWith('/api/')) {
+      counts.api += 1;
+      apiCookieHeaders.push(req.headers.cookie ?? '');
+      if (!tokenIsValid(cookies[ACCESS_COOKIE])) {
+        counts.apiUnauthorized += 1;
+        unauthorized(res);
+        return;
+      }
+      if (path === '/api/auth/user') {
+        sendJson(res, 200, { success: true, user: { id: 'u1', username: 'paired' } });
+        return;
+      }
+      sendJson(res, 200, { success: true, data: { ok: true } });
+      return;
+    }
+
+    sendJson(res, 404, { success: false, error: 'not found' });
+  });
+
+  // `/ws` reaches the stub as a raw TCP splice from the web host, so this is a
+  // genuine upgrade over the proxy rather than an in-process shortcut.
+  const wss = new WebSocketServer({ noServer: true });
+  server.on('upgrade', (req: IncomingMessage, socket: Socket, head: Buffer) => {
+    if (!req.url?.startsWith('/ws')) {
+      socket.destroy();
+      return;
+    }
+    counts.wsUpgrade += 1;
+    const cookies = parseCookies(req.headers.cookie);
+    const authed = tokenIsValid(cookies[ACCESS_COOKIE]);
+    wss.handleUpgrade(req, socket, head, (ws: WsSocket) => {
+      if (authed) {
+        ws.send(JSON.stringify({ name: 'realtime.ready', data: { ok: true } }));
+        return;
+      }
+      // Accepted the upgrade, then refuses the stream — the `status=101` once a
+      // second that #4155's backend log shows.
+      if (realtimeRejection === 'frame-then-close') {
+        ws.send(
+          JSON.stringify({
+            name: 'realtime.error',
+            data: { code: 'REALTIME_AUTH_EXPIRED', message: 'Invalid or expired token', recoverable: false },
+          })
+        );
+      }
+      ws.close(1008, 'REALTIME_AUTH_EXPIRED');
+    });
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+
+  return {
+    port: (server.address() as AddressInfo).port,
+    now,
+    advance: (ms: number) => {
+      virtualNow += ms;
+    },
+    counts,
+    apiCookieHeaders,
+    setSessionMode: (mode: SessionMode) => {
+      sessionMode = mode;
+    },
+    setRefreshStatus: (status: number | null) => {
+      forcedRefreshStatus = status;
+    },
+    setRealtimeRejection: (mode: RealtimeRejection) => {
+      realtimeRejection = mode;
+    },
+    issueSessionCookies,
+    dropRealtimeClients: () => {
+      for (const client of wss.clients) {
+        client.terminate();
+      }
+    },
+    close: () =>
+      new Promise<void>((resolve) => {
+        wss.close();
+        server.close(() => resolve());
+      }),
+  };
+}

--- a/tests/integration/webuiSessionLifetime.test.ts
+++ b/tests/integration/webuiSessionLifetime.test.ts
@@ -1,0 +1,304 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * End-to-end reproduction of #4155: "a paired browser dies roughly 24 hours
+ * after pairing — endless 401 + WebSocket reconnect loop".
+ *
+ * Everything below the test is real: the shipped WebUI adapters
+ * (`httpBridge.ts`, `browser.ts`, `sessionRefresh.ts`) run unmodified, talking
+ * over real TCP through the real web host (`startStaticServer`, including its
+ * `/api/*` reverse proxy and its `/ws` splice) to a stub aioncore. Only Core
+ * itself is a stub, and only so its clock can be moved.
+ *
+ * **Fast-forward.** The stub carries the production lifetimes — a 24 h access
+ * token, a 30 d refresh/pairing cookie — and decides validity against a virtual
+ * clock. `core.advance(ACCESS_TTL_MS)` is therefore literally "the next day" for
+ * every token in the system and costs no wall-clock time. Client-side timers stay
+ * real, because real sockets and real HTTP need them; the waits the tests
+ * actually perform are all under two seconds.
+ *
+ * Each test pairs, jumps a day, then opens the WebUI **once** — the phone being
+ * picked up the next morning, which is the reproduction the issue describes.
+ * Two sockets come up on that load: the bridge socket (`browser.ts`) and the
+ * realtime stream (`httpBridge.ts`). Both are counted.
+ *
+ * The two outcomes asserted here are the two the issue named as acceptable:
+ *
+ *   > Either the session is transparently renewed and the WebUI keeps working,
+ *   > or […] the phone lands cleanly on the pairing screen.
+ *
+ * A session that can be renewed is renewed, invisibly (`renewable`). A session
+ * that cannot — the paired browser, handed a Core JWT and nothing to renew it
+ * with — gives up once, quietly, and routes to login (`paired`). Neither may
+ * loop, and "does not loop" is measured server-side in request counts rather
+ * than inferred from client state.
+ *
+ * ## Pointing this at the packaged web host
+ *
+ * The paired-browser session lifecycle itself lives in the packaged
+ * `@aionui/web-host`, not in this repository, so what runs here by default is the
+ * open-source static server with the pairing cookie shapes reproduced by hand.
+ * Set `AIONUI_WEBHOST_UNDER_TEST` to a module exporting `startStaticServer` to run
+ * the identical scenarios against a build that has the real pairing layer.
+ */
+
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  ACCESS_COOKIE,
+  ACCESS_TTL_MS,
+  REFRESH_COOKIE,
+  startCoreStub,
+  type CoreStub,
+  type SessionMode,
+} from './webui-session/coreStub';
+import { installBrowserGlobals, removeBrowserGlobals, type BrowserHarness } from './webui-session/browserHarness';
+import { startStaticServer, type StaticServerHandle } from '../../packages/web-host/src/static-server';
+
+const platformMock = vi.hoisted(() => ({ adapter: vi.fn() }));
+vi.mock('@/common/platform/bridge', () => ({ bridge: { adapter: platformMock.adapter } }));
+
+type BridgeAdapter = {
+  emit: (name: string, data: unknown) => void;
+  on: (emitter: { emit: (name: string, data: unknown) => void }) => void;
+};
+
+type RealtimeModule = typeof import('@/common/adapter/httpBridge');
+
+/** How long the client is driven while asserting that nothing storms. */
+const STORM_WINDOW_MS = 1200;
+/** A day, plus a minute so nothing turns on the boundary. */
+const ONE_DAY_LATER_MS = ACCESS_TTL_MS + 60_000;
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function resolveStartWebHost(): Promise<typeof startStaticServer> {
+  const override = process.env.AIONUI_WEBHOST_UNDER_TEST;
+  if (!override) return startStaticServer;
+  const mod = (await import(/* @vite-ignore */ override)) as { startStaticServer?: typeof startStaticServer };
+  if (!mod.startStaticServer) {
+    throw new Error(`AIONUI_WEBHOST_UNDER_TEST=${override} does not export startStaticServer`);
+  }
+  return mod.startStaticServer;
+}
+
+function makeStaticDir(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'aionui-webui-e2e-'));
+  writeFileSync(path.join(dir, 'index.html'), '<!doctype html><title>webui</title>');
+  return dir;
+}
+
+describe('WebUI session lifetime, 24h after pairing (#4155)', () => {
+  let core: CoreStub;
+  let host: StaticServerHandle;
+  let harness: BrowserHarness;
+
+  /** Boot Core + the web host, then pair: log in so the browser holds real cookies. */
+  async function pair(mode: SessionMode): Promise<void> {
+    core = await startCoreStub();
+    core.setSessionMode(mode);
+    const startWebHost = await resolveStartWebHost();
+    host = await startWebHost({ staticDir: makeStaticDir(), backendPort: core.port, port: 0 });
+    harness = installBrowserGlobals(host.localUrl);
+
+    const response = await globalThis.fetch('/login', { method: 'POST' });
+    expect(response.status).toBe(200);
+  }
+
+  /**
+   * Open the WebUI: a fresh copy of the client, as a page load gives. Module
+   * state (sockets, the refresh latch) starts clean; the cookie jar persists,
+   * exactly as a browser's would. Called at most once per test, so every request
+   * the stub sees belongs to exactly one client.
+   */
+  async function openWebUi(): Promise<{ realtime: RealtimeModule; bridgeAdapter: BridgeAdapter }> {
+    vi.resetModules();
+    platformMock.adapter.mockClear();
+    const realtime = await import('@/common/adapter/httpBridge');
+    await import('@/common/adapter/browser');
+    const bridgeAdapter = platformMock.adapter.mock.calls[0]?.[0] as BridgeAdapter | undefined;
+    if (!bridgeAdapter) throw new Error('browser adapter did not initialize');
+    bridgeAdapter.on({ emit: () => {} });
+    return { realtime, bridgeAdapter };
+  }
+
+  /**
+   * Drive the client the way the SPA does when every request fails: revalidate
+   * data, push realtime frames, re-subscribe. Before #4178 each of those
+   * re-dialled the realtime socket and spent another refresh POST.
+   */
+  async function driveClient(realtime: RealtimeModule, bridgeAdapter: BridgeAdapter, windowMs: number): Promise<void> {
+    const until = Date.now() + windowMs;
+    let round = 0;
+    while (Date.now() < until) {
+      round += 1;
+      // Sequential by design: the measurement is the rate a real client drives the
+      // adapters at, which parallelising would destroy.
+      // eslint-disable-next-line no-await-in-loop -- sequential by design
+      await realtime.httpRequest('GET', '/api/teams').catch(() => undefined);
+      realtime.wsSend('fs', { round });
+      realtime.wsEmitter(`scm-${round}`).on(() => {});
+      bridgeAdapter.emit(`probe-${round}`, {});
+      // eslint-disable-next-line no-await-in-loop -- sequential by design
+      await sleep(25);
+    }
+  }
+
+  beforeEach(() => {
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    // Order matters: hang up the client's sockets first, then the stub's, then
+    // close the listeners. `startStaticServer.stop()` waits on live connections,
+    // and Node's fetch keeps its HTTP connections alive, so the close is also
+    // bounded rather than trusted.
+    harness?.dispose();
+    core?.dropRealtimeClients();
+    await Promise.race([host?.stop() ?? Promise.resolve(), sleep(2000)]);
+    await core?.close();
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    removeBrowserGlobals();
+  });
+
+  it('works normally on the day it was paired', async () => {
+    await pair('paired');
+    const { realtime } = await openWebUi();
+
+    await expect(realtime.httpRequest('GET', '/api/teams')).resolves.toEqual({ ok: true });
+    realtime.wsEmitter('fs').on(() => {});
+    await sleep(300);
+
+    expect(core.counts.apiUnauthorized).toBe(0);
+    expect(core.counts.refresh).toBe(0);
+    // Bridge socket + realtime stream, both authenticated, both still up.
+    expect(core.counts.wsUpgrade).toBe(2);
+  });
+
+  it('renews a renewable session transparently a day later', async () => {
+    await pair('renewable');
+    expect(harness.jar.names()).toContain(REFRESH_COOKIE);
+    const accessOnPairingDay = harness.jar.get(ACCESS_COOKIE);
+
+    core.advance(ONE_DAY_LATER_MS);
+    const { realtime } = await openWebUi();
+
+    // The access token is dead, the refresh cookie is not. One silent refresh,
+    // then the original request is replayed — the caller never sees the 401.
+    await expect(realtime.httpRequest('GET', '/api/teams')).resolves.toEqual({ ok: true });
+    expect(core.counts.refreshRejected).toBe(0);
+    expect(harness.jar.get(ACCESS_COOKIE)).not.toBe(accessOnPairingDay);
+
+    await sleep(500);
+    // Renewed, so the WebUI keeps working: no logout, no pairing screen.
+    expect(harness.hash()).not.toContain('/login');
+    await expect(realtime.httpRequest('GET', '/api/teams')).resolves.toEqual({ ok: true });
+  });
+
+  it('gives up once and routes a paired browser to login a day later — no loop', async () => {
+    await pair('paired');
+    // A paired browser is handed a Core session and nothing to renew it with.
+    expect(harness.jar.names()).toContain(ACCESS_COOKIE);
+    expect(harness.jar.names()).not.toContain(REFRESH_COOKIE);
+
+    core.advance(ONE_DAY_LATER_MS);
+    const { realtime, bridgeAdapter } = await openWebUi();
+    await driveClient(realtime, bridgeAdapter, STORM_WINDOW_MS);
+    await sleep(400);
+
+    // The refresh endpoint has no credential to accept, so asking twice is
+    // asking forever. Exactly one POST, then the latch answers.
+    //
+    // Measured on this same window against the pre-#4178 adapters: 84 refresh
+    // POSTs and 43 `/ws` upgrades, i.e. ~52 and ~27 per second — #4155's
+    // "that full burst repeats every ~1 s", quantified.
+    expect(core.counts.refresh).toBe(1);
+    expect(core.counts.refreshRejected).toBe(1);
+
+    // Neither socket re-dials a backend that will only close it again. In fact
+    // one upgrade covers both: whichever socket asks first latches the session as
+    // expired, and the other never gets as far as dialling.
+    expect(core.counts.wsUpgrade).toBeLessThanOrEqual(3);
+
+    // #4155's "Expected Behavior": the phone lands cleanly on the pairing screen.
+    expect(harness.hash()).toContain('/login');
+  });
+
+  it('stays bounded when the stream is closed 1008 with no error frame', async () => {
+    await pair('paired');
+    // No `realtime.error` frame, just the policy-violation close. The bridge
+    // socket treats a bare 1008 as a generic drop by design and keeps retrying;
+    // what must hold is that the retry is on the backoff, not per emit.
+    core.setRealtimeRejection('close-only');
+
+    core.advance(ONE_DAY_LATER_MS);
+    const { realtime, bridgeAdapter } = await openWebUi();
+    await driveClient(realtime, bridgeAdapter, STORM_WINDOW_MS);
+    await sleep(400);
+
+    // The realtime socket does read 1008 as auth, so it refreshes once and latches.
+    expect(core.counts.refresh).toBe(1);
+    // The bridge socket keeps retrying, but on its 500ms→8s backoff: 3 dials over
+    // this window. Unpatched the same window produced 84 refresh POSTs and 45
+    // upgrades, because the retry rate tracked the emit rate instead.
+    expect(core.counts.wsUpgrade).toBeLessThanOrEqual(6);
+  });
+
+  it('keeps a renewable session alive across a transient refresh outage', async () => {
+    await pair('renewable');
+    core.advance(ONE_DAY_LATER_MS);
+    core.setRefreshStatus(503);
+    const { realtime } = await openWebUi();
+
+    await expect(realtime.httpRequest('GET', '/api/teams')).rejects.toMatchObject({ status: 401 });
+    const afterFirstFailure = core.counts.refresh;
+
+    // A 503 says nothing about the session, so the client must neither sign the
+    // user out nor hammer the endpoint. The cooldown collapses the burst — 11
+    // POSTs became 1.
+    for (let i = 0; i < 10; i++) {
+      // Concurrent calls would collapse into the refresh single-flight and prove
+      // nothing about the cooldown, so these go one at a time.
+      // eslint-disable-next-line no-await-in-loop -- sequential by design
+      await realtime.httpRequest('GET', '/api/teams').catch(() => undefined);
+    }
+    // Upper bound rather than equality: the cooldown is wall-clock, so on a slow
+    // runner the burst can straddle its expiry and legitimately spend a second
+    // POST. Unpatched the same burst spent 11, so this still discriminates.
+    expect(core.counts.refresh).toBeLessThanOrEqual(afterFirstFailure + 1);
+    expect(harness.hash()).not.toContain('/login');
+
+    // Endpoint comes back after the cooldown; the session was never lost.
+    core.setRefreshStatus(null);
+    await sleep(1100);
+    await expect(realtime.httpRequest('GET', '/api/teams')).resolves.toEqual({ ok: true });
+  });
+
+  it('forwards the browser session verbatim — the web host owns no session of its own', async () => {
+    await pair('paired');
+    core.advance(ONE_DAY_LATER_MS);
+    const { realtime } = await openWebUi();
+
+    const staleAccess = harness.jar.get(ACCESS_COOKIE);
+    await realtime.httpRequest('GET', '/api/teams').catch(() => undefined);
+
+    // Documents the open-source proxy's contract rather than a defect in it:
+    // `forwardToBackend()` copies `req.headers` through unchanged, so whatever
+    // the browser holds is what Core adjudicates. #4155's suggested fix 1 — the
+    // web host owning and renewing a Core session on the browser's behalf —
+    // would change this assertion, which is exactly when it should be revisited.
+    expect(core.apiCookieHeaders.at(-1)).toContain(`${ACCESS_COOKIE}=${staleAccess}`);
+    expect(core.counts.apiUnauthorized).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/adapter/realtimeSocketReconnect.dom.test.ts
+++ b/tests/unit/adapter/realtimeSocketReconnect.dom.test.ts
@@ -1,0 +1,249 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Regression tests for the WebUI *realtime* socket in `httpBridge.ts`.
+ *
+ * #4156 fixed reconnect scheduling on the *bridge* socket (`browser.ts`). The
+ * realtime socket is a second, independent WebSocket with its own scheduler, and
+ * it still had the same three defects — plus an unlatched refresh loop once the
+ * session is genuinely dead. These tests pin all four.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type SocketListener = (event: unknown) => void;
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  static instances: FakeWebSocket[] = [];
+
+  readyState: number = FakeWebSocket.CONNECTING;
+  sent: string[] = [];
+
+  private readonly listeners = new Map<string, SocketListener[]>();
+
+  constructor(public readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, listener: SocketListener): void {
+    const existing = this.listeners.get(type) ?? [];
+    existing.push(listener);
+    this.listeners.set(type, existing);
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload);
+  }
+
+  close(code = 1006): void {
+    if (this.readyState === FakeWebSocket.CLOSED) return;
+    this.readyState = FakeWebSocket.CLOSED;
+    this.dispatch('close', { code, reason: '' });
+  }
+
+  /** Server completes the upgrade handshake. */
+  acceptUpgrade(): void {
+    this.readyState = FakeWebSocket.OPEN;
+    this.dispatch('open', {});
+  }
+
+  private dispatch(type: string, event: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
+
+const latest = (): FakeWebSocket => {
+  const socket = FakeWebSocket.instances.at(-1);
+  if (!socket) throw new Error('no socket was created');
+  return socket;
+};
+
+/** Count of POSTs the refresh primitive made to the refresh endpoint. */
+const refreshCalls = (fetchMock: { mock: { calls: unknown[][] } }): number =>
+  fetchMock.mock.calls.filter((call) => call[0] === '/api/auth/refresh').length;
+
+type Bridge = typeof import('@/common/adapter/httpBridge');
+
+const loadBridge = async (fetchImpl: unknown): Promise<Bridge> => {
+  FakeWebSocket.instances = [];
+  vi.resetModules();
+  delete (window as { __backendPort?: number }).__backendPort;
+  vi.stubGlobal('WebSocket', FakeWebSocket);
+  vi.stubGlobal('fetch', fetchImpl);
+  return import('@/common/adapter/httpBridge');
+};
+
+/** Refresh endpoint answers `status`; every other call 200s. */
+const refreshResponder = (status: number) =>
+  vi.fn(async (url: string) => {
+    if (url === '/api/auth/refresh') return { ok: status >= 200 && status < 300, status };
+    return { ok: true, status: 200, headers: { get: () => null }, text: async () => '' };
+  });
+
+describe('WebUI realtime socket (httpBridge)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('dials once when the first subscriber attaches', async () => {
+    const bridge = await loadBridge(refreshResponder(200));
+    bridge.wsEmitter('fs').on(() => {});
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(latest().url).toMatch(/\/ws$/);
+  });
+
+  it('does not re-dial on every send while a backoff reconnect is pending', async () => {
+    const bridge = await loadBridge(refreshResponder(200));
+    bridge.wsEmitter('fs').on(() => {});
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    // Connection fails outright (no upgrade) — a reconnect is now queued.
+    latest().close();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    // The app keeps pushing frames and re-subscribing while the socket is down.
+    for (let i = 0; i < 10; i++) {
+      bridge.wsSend('fs', { seq: i });
+      bridge.wsEmitter('scm').on(() => {});
+    }
+
+    // The queued backoff owns the reconnect rate — not how often the app sends.
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
+  it('backs off when the server accepts the upgrade and drops it immediately', async () => {
+    const bridge = await loadBridge(refreshResponder(200));
+    bridge.wsEmitter('fs').on(() => {});
+
+    // 1st: accept-then-drop. Reconnect is due at 1s.
+    latest().acceptUpgrade();
+    latest().close();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    // 2nd: same. A handshake that never held must not credit the backoff, so
+    // the next attempt is due at 2s, not 1s again.
+    latest().acceptUpgrade();
+    latest().close();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(FakeWebSocket.instances).toHaveLength(3);
+  });
+
+  it('resets the backoff only after a connection has held', async () => {
+    const bridge = await loadBridge(refreshResponder(200));
+    bridge.wsEmitter('fs').on(() => {});
+
+    // Two accept-then-drop cycles grow the delay to 4s.
+    latest().acceptUpgrade();
+    latest().close();
+    await vi.advanceTimersByTimeAsync(1000);
+    latest().acceptUpgrade();
+    latest().close();
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(FakeWebSocket.instances).toHaveLength(3);
+
+    // This one holds past the stability window, so the delay is credited back to
+    // the 1s floor instead of continuing from 4s.
+    latest().acceptUpgrade();
+    await vi.advanceTimersByTimeAsync(5000);
+    latest().close();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(FakeWebSocket.instances).toHaveLength(4);
+  });
+
+  it('stops dialling and stops refreshing once the session is truly dead (1008 + 401 refresh)', async () => {
+    const fetchMock = refreshResponder(401);
+    const bridge = await loadBridge(fetchMock);
+    bridge.wsEmitter('fs').on(() => {});
+
+    // Backend accepts the upgrade, then closes it for auth policy violation.
+    latest().acceptUpgrade();
+    latest().close(1008);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(refreshCalls(fetchMock)).toBe(1);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+
+    // The app keeps sending and re-subscribing. Neither may resurrect the socket
+    // or fire another refresh POST — that pair is the #4155 storm.
+    for (let i = 0; i < 10; i++) {
+      bridge.wsSend('fs', { seq: i });
+      bridge.wsEmitter('scm').on(() => {});
+    }
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(refreshCalls(fetchMock)).toBe(1);
+  });
+
+  it('reconnects after a successful silent refresh (1008 + 200 refresh)', async () => {
+    const fetchMock = refreshResponder(200);
+    const bridge = await loadBridge(fetchMock);
+    bridge.wsEmitter('fs').on(() => {});
+
+    latest().acceptUpgrade();
+    latest().close(1008);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(refreshCalls(fetchMock)).toBe(1);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
+  it('still backs off when the backend refuses even a freshly refreshed session', async () => {
+    const fetchMock = refreshResponder(200);
+    const bridge = await loadBridge(fetchMock);
+    bridge.wsEmitter('fs').on(() => {});
+
+    // The refresh keeps succeeding but the backend keeps closing 1008. Without a
+    // backoff on this path that is refresh -> dial -> 1008 -> refresh at full
+    // speed — the same storm, just with a working refresh endpoint.
+    latest().acceptUpgrade();
+    latest().close(1008);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+
+    latest().acceptUpgrade();
+    latest().close(1008);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(FakeWebSocket.instances).toHaveLength(3);
+  });
+
+  it('keeps retrying on the backoff when the refresh endpoint is only transiently down (1008 + 503)', async () => {
+    const fetchMock = refreshResponder(503);
+    const bridge = await loadBridge(fetchMock);
+    bridge.wsEmitter('fs').on(() => {});
+
+    latest().acceptUpgrade();
+    latest().close(1008);
+    await vi.advanceTimersByTimeAsync(0);
+
+    // A 503 says nothing about the session, so the stream must not be stranded:
+    // it retries on the normal backoff without any send to prod it awake.
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+});

--- a/tests/unit/adapter/sessionRefresh.dom.test.ts
+++ b/tests/unit/adapter/sessionRefresh.dom.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { refreshSession } from '@/common/adapter/sessionRefresh';
+import { refreshSession, refreshSessionOutcome, resetSessionRefresh } from '@/common/adapter/sessionRefresh';
 
 type WindowWithPort = { __backendPort?: number };
 
@@ -13,11 +13,15 @@ describe('refreshSession (WebUI session refresh)', () => {
   beforeEach(() => {
     // Browser mode: real DOM (jsdom) with no Electron preload port.
     delete (window as WindowWithPort).__backendPort;
+    // The expiry latch and the retry cooldown are module-level state; clear them
+    // so tests do not inherit a previous test's verdict.
+    resetSessionRefresh();
     vi.restoreAllMocks();
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    resetSessionRefresh();
     delete (window as WindowWithPort).__backendPort;
   });
 
@@ -87,5 +91,81 @@ describe('refreshSession (WebUI session refresh)', () => {
 
     await expect(refreshSession()).resolves.toBe(false);
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('latches on 401 so repeated failures cost exactly one POST (#4155)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(refreshSessionOutcome()).resolves.toBe('expired');
+
+    // A dead refresh credential cannot become alive again. Every later 401 in the
+    // app must be answered from the latch, not with another POST — otherwise a
+    // revalidation burst turns into a storm against a rate-limited endpoint.
+    const repeats = await Promise.all(Array.from({ length: 20 }, () => refreshSessionOutcome()));
+    expect(repeats.every((outcome) => outcome === 'expired')).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats an inconclusive failure as retryable, not as a dead session', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 503 }));
+    await expect(refreshSessionOutcome()).resolves.toBe('unavailable');
+
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+    resetSessionRefresh();
+    await expect(refreshSessionOutcome()).resolves.toBe('unavailable');
+  });
+
+  it('backs off between inconclusive attempts instead of retrying on every 401', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(refreshSessionOutcome()).resolves.toBe('unavailable');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // Inside the cooldown the answer comes back without touching the network.
+      await expect(refreshSessionOutcome()).resolves.toBe('unavailable');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // Once it elapses the session gets another chance — this must not latch.
+      vi.setSystemTime(Date.now() + 1_001);
+      await expect(refreshSessionOutcome()).resolves.toBe('unavailable');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resumes refreshing after resetSessionRefresh() (re-auth)', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 401 }).mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(refreshSessionOutcome()).resolves.toBe('expired');
+    await expect(refreshSessionOutcome()).resolves.toBe('expired');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    resetSessionRefresh();
+    await expect(refreshSessionOutcome()).resolves.toBe('refreshed');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears a previous cooldown once a refresh succeeds', async () => {
+    vi.useFakeTimers();
+    try {
+      const fetchMock = vi.fn().mockResolvedValueOnce({ ok: false, status: 503 }).mockResolvedValue({ ok: true });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(refreshSessionOutcome()).resolves.toBe('unavailable');
+      vi.setSystemTime(Date.now() + 1_001);
+      await expect(refreshSessionOutcome()).resolves.toBe('refreshed');
+
+      // Back to the 1s floor: a later failure must not inherit the grown delay.
+      await expect(refreshSessionOutcome()).resolves.toBe('refreshed');
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/unit/common-adapter/browserRealtimeError.test.ts
+++ b/tests/unit/common-adapter/browserRealtimeError.test.ts
@@ -95,7 +95,7 @@ class FakeWebSocket {
   }
 }
 
-function setupBrowserGlobals() {
+function setupBrowserGlobals(refreshStatus: number) {
   const location: BrowserLocation = {
     protocol: 'http:',
     hostname: '127.0.0.1',
@@ -110,16 +110,26 @@ function setupBrowserGlobals() {
     clearTimeout: clearTimeout as unknown as Window['clearTimeout'],
   });
   vi.stubGlobal('WebSocket', FakeWebSocket as unknown as typeof WebSocket);
+  // `document` marks WebUI browser mode for the session-refresh primitive. Without
+  // it refreshSession() short-circuits and no refresh is ever attempted, so the
+  // auth-recovery paths below would never be exercised.
+  vi.stubGlobal('document', {});
+  const fetchMock = vi.fn(async () => ({ ok: refreshStatus >= 200 && refreshStatus < 300, status: refreshStatus }));
+  vi.stubGlobal('fetch', fetchMock);
 
-  return location;
+  return { location, fetchMock };
 }
 
-async function loadBrowserAdapter() {
+/**
+ * @param refreshStatus status the `/api/auth/refresh` endpoint answers with.
+ *   401 = the refresh credential is dead too (terminal), 503 = transient.
+ */
+async function loadBrowserAdapter(refreshStatus = 401) {
   vi.resetModules();
   FakeWebSocket.instances = [];
   platformMock.adapter.mockClear();
 
-  const location = setupBrowserGlobals();
+  const { location, fetchMock } = setupBrowserGlobals(refreshStatus);
 
   await import('@/common/adapter/browser');
 
@@ -130,7 +140,7 @@ async function loadBrowserAdapter() {
     throw new Error('browser adapter did not initialize');
   }
 
-  return { adapter, location, socket };
+  return { adapter, location, socket, fetchMock };
 }
 
 describe('browser WebSocket realtime error handling', () => {
@@ -157,10 +167,10 @@ describe('browser WebSocket realtime error handling', () => {
     socket.dispatchMessage(payload);
 
     // The socket is closed synchronously; the redirect now lives behind a silent
-    // refresh attempt. In this node env `document` is absent, so refreshSession()
-    // short-circuits to false and we fall through to the login redirect — but the
-    // scheduling happens on a microtask, so timers must advance asynchronously to
-    // let that promise settle first.
+    // refresh attempt, which here answers 401 — the refresh credential is dead
+    // too, so the session is genuinely over and the login redirect is correct.
+    // The scheduling happens on a microtask, so timers must advance
+    // asynchronously to let that promise settle first.
     expect(socket.close).toHaveBeenCalledTimes(1);
     expect(emit).not.toHaveBeenCalled();
 
@@ -172,6 +182,30 @@ describe('browser WebSocket realtime error handling', () => {
 
     await vi.advanceTimersByTimeAsync(1000);
     expect(location.hash).toBe('/login');
+  });
+
+  it('does not redirect when the refresh endpoint is only transiently unavailable', async () => {
+    const { adapter, location, socket, fetchMock } = await loadBrowserAdapter(503);
+    const emit = vi.fn();
+    adapter.on({ emit });
+
+    socket.dispatchMessage({
+      name: 'realtime.error',
+      data: { code: 'REALTIME_AUTH_EXPIRED', message: 'Expired auth', recoverable: false },
+    });
+
+    expect(socket.close).toHaveBeenCalledTimes(1);
+    socket.dispatchClose(1006);
+    const socketCountAfterClose = FakeWebSocket.instances.length;
+    await vi.advanceTimersByTimeAsync(30000);
+
+    // A 503 says nothing about the session. Kicking the user to /login over one
+    // would destroy a session that is very likely still good; re-dialling with the
+    // cookie the backend just rejected would only earn the same close. So: neither.
+    expect(location.hash).toBe('');
+    expect(FakeWebSocket.instances).toHaveLength(socketCountAfterClose);
+    // Only the refresh is retried, on its own backoff.
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
   });
 
   it('emits non-auth realtime errors without closing or redirecting', async () => {

--- a/tests/unit/renderer/AuthContextRealtimeRecovery.test.ts
+++ b/tests/unit/renderer/AuthContextRealtimeRecovery.test.ts
@@ -1,0 +1,261 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The login flow is the only code allowed to wake a session whose refresh
+ * credential has been latched as expired. Keep this test on the real adapter
+ * path: the sockets go through the static-server proxy to the Core stub, while
+ * AuthProvider is mounted in a small JSDOM document.
+ */
+
+import { JSDOM } from 'jsdom';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { cleanup, render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ACCESS_TTL_MS, startCoreStub, type CoreStub } from '../../integration/webui-session/coreStub';
+import {
+  installBrowserGlobals,
+  removeBrowserGlobals,
+  type BrowserHarness,
+} from '../../integration/webui-session/browserHarness';
+import { startStaticServer, type StaticServerHandle } from '../../../packages/web-host/src/static-server';
+
+const ONE_DAY_LATER_MS = ACCESS_TTL_MS + 60_000;
+const WAIT_TIMEOUT_MS = 8_000;
+const STORM_WINDOW_MS = 1_200;
+
+type Login = (params: { username: string; password: string; remember?: boolean }) => Promise<{ success: boolean }>;
+
+type AuthSnapshot = {
+  login: Login;
+  status: string;
+};
+
+type BridgeAdapter = {
+  emit: (name: string, data: unknown) => void;
+  on: (emitter: { emit: (name: string, data: unknown) => void }) => void;
+};
+
+const platformMock = vi.hoisted(() => ({
+  adapter: vi.fn((config: { on: (emitter: { emit: (name: string, data: unknown) => void }) => void }) => {
+    config.on({ emit: () => {} });
+  }),
+}));
+vi.mock('@/common/platform/bridge', () => ({ bridge: { adapter: platformMock.adapter } }));
+
+type DomGlobals = {
+  dom: JSDOM;
+  previous: Map<string, PropertyDescriptor | undefined>;
+};
+
+const DOM_GLOBAL_NAMES = [
+  'window',
+  'document',
+  'navigator',
+  'HTMLElement',
+  'Node',
+  'Event',
+  'MessageEvent',
+  'localStorage',
+] as const;
+
+function installDomGlobals(origin: string): DomGlobals {
+  const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: origin });
+  const previous = new Map<string, PropertyDescriptor | undefined>();
+  const values: Record<string, unknown> = {
+    window: dom.window,
+    document: dom.window.document,
+    navigator: dom.window.navigator,
+    HTMLElement: dom.window.HTMLElement,
+    Node: dom.window.Node,
+    Event: dom.window.Event,
+    MessageEvent: dom.window.MessageEvent,
+    localStorage: dom.window.localStorage,
+  };
+
+  for (const name of DOM_GLOBAL_NAMES) {
+    previous.set(name, Object.getOwnPropertyDescriptor(globalThis, name));
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      enumerable: true,
+      writable: true,
+      value: values[name],
+    });
+  }
+
+  return { dom, previous };
+}
+
+function restoreDomGlobals({ dom, previous }: DomGlobals): void {
+  dom.window.close();
+  for (const name of DOM_GLOBAL_NAMES) {
+    const descriptor = previous.get(name);
+    if (descriptor) {
+      Object.defineProperty(globalThis, name, descriptor);
+    } else {
+      delete (globalThis as Record<string, unknown>)[name];
+    }
+  }
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+function makeStaticDir(): string {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'aionui-auth-recovery-'));
+  writeFileSync(path.join(dir, 'index.html'), '<!doctype html><title>webui</title>');
+  return dir;
+}
+
+describe('AuthProvider realtime recovery', () => {
+  let core: CoreStub;
+  let host: StaticServerHandle;
+  let harness: BrowserHarness;
+  let domGlobals: DomGlobals;
+
+  beforeEach(() => {
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    cleanup();
+    vi.unstubAllGlobals();
+    harness?.dispose();
+    core?.dropRealtimeClients();
+    await Promise.race([host?.stop() ?? Promise.resolve(), sleep(2000)]);
+    await core?.close();
+    vi.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    if (domGlobals) restoreDomGlobals(domGlobals);
+    removeBrowserGlobals();
+  });
+
+  it('wakes both parked realtime sockets through the real login flow', { timeout: 40_000 }, async () => {
+    core = await startCoreStub();
+    core.setSessionMode('paired');
+    host = await startStaticServer({
+      staticDir: makeStaticDir(),
+      backendPort: core.port,
+      port: 0,
+    });
+
+    // Install the cookie-aware fetch and WebSocket first; then replace only the
+    // fake window/document with a real JSDOM pair for React and AuthProvider.
+    harness = installBrowserGlobals(host.localUrl);
+    const harnessFetch = globalThis.fetch;
+    const harnessWebSocket = (globalThis as typeof globalThis & { WebSocket: unknown }).WebSocket;
+    domGlobals = installDomGlobals(host.localUrl);
+    Object.defineProperty(domGlobals.dom.window, 'fetch', {
+      configurable: true,
+      value: harnessFetch,
+    });
+    Object.defineProperty(domGlobals.dom.window, 'WebSocket', {
+      configurable: true,
+      value: harnessWebSocket,
+    });
+    vi.stubGlobal('fetch', harnessFetch);
+    Object.defineProperty(globalThis, 'WebSocket', {
+      configurable: true,
+      writable: true,
+      value: harnessWebSocket,
+    });
+    vi.stubGlobal('WebSocket', harnessWebSocket);
+    expect(globalThis.WebSocket).toBeDefined();
+    window.location.hash = '/login';
+
+    const response = await globalThis.fetch('/login', { method: 'POST' });
+    expect(response.status).toBe(200);
+    core.advance(ONE_DAY_LATER_MS);
+
+    vi.resetModules();
+    platformMock.adapter.mockClear();
+    const realtime = await import('@/common/adapter/httpBridge');
+    const { AuthProvider, useAuth } = await import('@/renderer/hooks/context/AuthContext');
+    const { isSessionExpired } = await import('@/common/adapter/sessionRefresh');
+    let realtimeReconnected = 0;
+    realtime.wsEmitter('realtime.reconnected').on(() => {
+      realtimeReconnected += 1;
+    });
+    await import('@/common/adapter/browser');
+
+    const bridgeAdapter = platformMock.adapter.mock.calls[0]?.[0] as BridgeAdapter | undefined;
+    if (!bridgeAdapter) throw new Error('browser adapter did not initialize');
+    let bridgeReady = 0;
+    bridgeAdapter.on({
+      emit: (name) => {
+        if (name === 'realtime.ready') bridgeReady += 1;
+      },
+    });
+
+    let auth: AuthSnapshot | undefined;
+    const Probe: React.FC = () => {
+      const value = useAuth();
+      auth = { login: value.login, status: value.status };
+      return null;
+    };
+
+    render(React.createElement(AuthProvider, null, React.createElement(Probe)));
+
+    // The stale session is rejected over both sockets and through the auth
+    // user probe. The shared refresh call must latch once, leaving both sockets
+    // parked until a fresh login clears that latch.
+    await waitFor(() => expect(core.counts.refresh).toBe(1), { timeout: WAIT_TIMEOUT_MS });
+    await waitFor(() => expect(isSessionExpired()).toBe(true), { timeout: WAIT_TIMEOUT_MS });
+    await waitFor(() => expect(core.counts.wsUpgrade).toBe(2), { timeout: WAIT_TIMEOUT_MS });
+
+    const parkedRefreshes = core.counts.refresh;
+    const driveClient = async (windowMs: number): Promise<void> => {
+      const until = Date.now() + windowMs;
+      let round = 0;
+      while (Date.now() < until) {
+        round += 1;
+        // Exercise the same entry points that previously re-dialled parked
+        // sockets on every application update.
+        // eslint-disable-next-line no-await-in-loop -- sequential by design
+        await realtime.httpRequest('GET', '/api/teams').catch(() => undefined);
+        realtime.wsSend('fs', { round });
+        realtime.wsEmitter(`recovery-${round}`).on(() => {});
+        bridgeAdapter.emit(`recovery-${round}`, {});
+        // eslint-disable-next-line no-await-in-loop -- sequential by design
+        await sleep(25);
+      }
+    };
+
+    await driveClient(STORM_WINDOW_MS);
+    const parkedUnauthorized = core.counts.apiUnauthorized;
+    expect(core.counts.wsUpgrade).toBe(2);
+    expect(core.counts.refresh).toBe(parkedRefreshes);
+    expect(core.counts.refreshRejected).toBe(1);
+
+    await waitFor(() => expect(auth?.status).toBe('unauthenticated'), { timeout: WAIT_TIMEOUT_MS });
+    const result = await auth?.login({ username: 'paired', password: 'password' });
+    expect(result?.success).toBe(true);
+    expect(isSessionExpired()).toBe(false);
+
+    // AuthProvider calls both recovery entry points. One new upgrade is the
+    // browser bridge socket; the other is the httpBridge realtime stream.
+    await waitFor(() => expect(realtimeReconnected).toBeGreaterThanOrEqual(1), {
+      timeout: WAIT_TIMEOUT_MS,
+    });
+    await waitFor(() => expect(bridgeReady).toBeGreaterThanOrEqual(1), {
+      timeout: WAIT_TIMEOUT_MS,
+    });
+    await waitFor(() => expect(auth?.status).toBe('authenticated'), { timeout: WAIT_TIMEOUT_MS });
+    await driveClient(STORM_WINDOW_MS);
+    await expect(realtime.httpRequest('GET', '/api/teams')).resolves.toEqual({ ok: true });
+    expect(core.counts.apiUnauthorized).toBe(parkedUnauthorized);
+    expect(core.counts.wsUpgrade).toBe(4);
+    expect(core.counts.refresh).toBe(parkedRefreshes);
+    expect(core.counts.refreshRejected).toBe(1);
+    expect(isSessionExpired()).toBe(false);
+  });
+});

--- a/tests/unit/renderer/webuiWebSocketReconnect.dom.test.ts
+++ b/tests/unit/renderer/webuiWebSocketReconnect.dom.test.ts
@@ -279,6 +279,43 @@ describe('WebUI browser bridge socket', () => {
     expect(FakeWebSocket.instances).toHaveLength(afterAuthFailure + 1);
   });
 
+  it('retries auth recovery after a transient refresh outage without opening a socket', async () => {
+    const fetchMock = stubRefresh(503);
+    await loadBrowserAdapter();
+
+    latestSocket().acceptUpgrade();
+    latestSocket().deliver({ name: 'realtime.error', data: { code: 'REALTIME_AUTH_EXPIRED' } });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1500);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  it('cancels a pending auth-recovery retry when the login flow reconnects', async () => {
+    const fetchMock = stubRefresh(503);
+    await loadBrowserAdapter();
+
+    latestSocket().acceptUpgrade();
+    latestSocket().deliver({ name: 'realtime.error', data: { code: 'REALTIME_AUTH_EXPIRED' } });
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The inconclusive refresh schedules its own retry, separate from the
+    // socket backoff. A successful login must cancel that retry as it wakes the
+    // socket immediately.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const beforeLogin = FakeWebSocket.instances.length;
+    (window as unknown as { __websocketReconnect?: () => void }).__websocketReconnect?.();
+
+    expect(FakeWebSocket.instances).toHaveLength(beforeLogin + 1);
+    await vi.advanceTimersByTimeAsync(8000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(FakeWebSocket.instances).toHaveLength(beforeLogin + 1);
+  });
+
   it('cancels a pending backoff retry when the login flow reconnects', async () => {
     await loadBrowserAdapter();
 

--- a/tests/unit/renderer/webuiWebSocketReconnect.dom.test.ts
+++ b/tests/unit/renderer/webuiWebSocketReconnect.dom.test.ts
@@ -47,12 +47,12 @@ class FakeWebSocket {
     this.sent.push(payload);
   }
 
-  close(): void {
+  close(code = 1006): void {
     if (this.readyState === FakeWebSocket.CLOSED) {
       return;
     }
     this.readyState = FakeWebSocket.CLOSED;
-    this.dispatch('close', { code: 1006 });
+    this.dispatch('close', { code });
   }
 
   /** Server accepts the upgrade. */
@@ -88,6 +88,13 @@ const loadBrowserAdapter = async () => {
   await import('@/common/adapter/browser');
 
   return { bridge };
+};
+
+/** Refresh endpoint answers `status`; nothing else is fetched by this adapter. */
+const stubRefresh = (status: number) => {
+  const fetchMock = vi.fn(async () => ({ ok: status >= 200 && status < 300, status }));
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
 };
 
 const latestSocket = (): FakeWebSocket => {
@@ -208,6 +215,54 @@ describe('WebUI browser bridge socket', () => {
     await vi.advanceTimersByTimeAsync(30000);
 
     expect(FakeWebSocket.instances).toHaveLength(afterAuthFailure);
+  });
+
+  it('reconnects on the backoff after a successful silent refresh', async () => {
+    const fetchMock = stubRefresh(200);
+    await loadBrowserAdapter();
+
+    latestSocket().acceptUpgrade();
+    latestSocket().deliver({ name: 'realtime.error', data: { code: 'REALTIME_AUTH_EXPIRED' } });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/auth/refresh', expect.objectContaining({ method: 'POST' }));
+    // Not an immediate re-dial: a backend that refuses even the refreshed session
+    // would otherwise loop refresh -> dial -> close -> refresh unthrottled.
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(500);
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
+  it('does not sign the user out when the refresh endpoint is only transiently down', async () => {
+    const fetchMock = stubRefresh(503);
+    await loadBrowserAdapter();
+    window.location.hash = '';
+
+    latestSocket().acceptUpgrade();
+    latestSocket().deliver({ name: 'realtime.error', data: { code: 'REALTIME_AUTH_EXPIRED' } });
+    await vi.advanceTimersByTimeAsync(0);
+
+    const afterAuthFailure = FakeWebSocket.instances.length;
+    await vi.advanceTimersByTimeAsync(30000);
+
+    // A 503 says nothing about the session: no /login kick, and no reconnect with
+    // the cookie the backend just rejected. Only the refresh is retried.
+    expect(window.location.hash).not.toContain('/login');
+    expect(FakeWebSocket.instances).toHaveLength(afterAuthFailure);
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('redirects to /login only once the refresh credential is dead too', async () => {
+    stubRefresh(401);
+    await loadBrowserAdapter();
+    window.location.hash = '';
+
+    latestSocket().acceptUpgrade();
+    latestSocket().deliver({ name: 'realtime.error', data: { code: 'REALTIME_AUTH_EXPIRED' } });
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(window.location.hash).toContain('/login');
   });
 
   it('reconnects immediately when the login flow asks it to', async () => {


### PR DESCRIPTION
# Pull Request

## Description

#4156 fixed reconnect scheduling on the WebUI **bridge** socket (`browser.ts`). The WebUI has a **second** WebSocket — the realtime stream in `httpBridge.ts` — with its own independent scheduler, and it still carries all three of the defects #4156 fixed, plus an unlatched refresh loop that arrived with the refresh path in #4175.

Together they reproduce #4155's symptom on the socket #4156 didn't touch: point the WebUI at a backend that refuses its session and it dials `/ws` and POSTs `/api/auth/refresh` continuously, forever.

### The defects

**1. `ensureWs()` bypasses the backoff** (`httpBridge.ts`). It dials whenever the socket isn't `OPEN`/`CONNECTING`, with a pending `wsReconnectTimer` sitting unused. It is called from `wsSend()` *and* from every `wsEmitter().on()` subscription, so the reconnect rate tracks how busy the app is rather than the 1 s→30 s schedule. This is exactly the `ensureSocket()` defect from #4156 — and it bites harder here, because #4155's failure mode is a full SWR revalidation on every reconnect, which re-subscribes every realtime consumer.

**2. The backoff resets on `open`** (`httpBridge.ts`). `wsReconnectAttempt = 0` ran in the `open` handler. A backend that completes the handshake and then drops the connection still fires `open`, so the delay snapped back to 1 s on every attempt. That accept-then-drop shape is precisely what #4155's log shows — `path=/ws status=101` about once a second.

**3. A dead session never latches** (`httpBridge.ts` + `sessionRefresh.ts`). `handleWsAuthClose()` returned silently when the refresh failed, setting no stop flag, so the next `wsSend()` re-dialled with the same dead cookie, earned another 1008, and fired another refresh POST. `refreshSession()` couldn't stop it either: its single-flight only collapses *concurrent* callers, so sequential 401s each spawn a fresh POST against a rate-limited endpoint. A paired browser that holds an access cookie but no refresh cookie hits this on every single 401.

**4. "Refresh failed" and "session is dead" were the same answer** (`sessionRefresh.ts`). `refreshSession()` returned `false` for a `401` on the refresh token, for a `503`, and for dropped Wi-Fi alike. `browser.ts` reads that `false` as "sign the user out", so one transient blip kicks a perfectly refreshable session to `/login` — and any latch built on that boolean would strand it there.

### Changes

`sessionRefresh.ts` — teach the primitive *why* a refresh ended:

- New `refreshSessionOutcome(): Promise<'refreshed' | 'expired' | 'unavailable'>`. `refreshSession()` keeps its exact boolean contract (`=== 'refreshed'`), so existing callers are untouched.
- `401`/`403` → `expired`, and it **latches**: later calls answer from the latch with no request at all. `isSessionExpired()` exposes it so reconnect loops can stop dialling.
- Network error / `429` / `5xx` → `unavailable` with a 1 s→30 s cooldown, so an inconclusive failure is retried rather than treated as a logout.
- `resetSessionRefresh()` clears both; called on successful re-auth.

`httpBridge.ts` — the realtime socket:

- `ensureWs()` returns early when the session has latched as expired or a reconnect is already queued.
- `wsConnectedAt` + `WS_STABLE_CONNECTION_MS` (5 s): the backoff is credited on `close`, only for a connection that actually held — not on `open`.
- `handleWsAuthClose()` branches on the outcome: reconnect on `refreshed`, stay down on `expired` (the latch makes `ensureWs()` a no-op — no dial, no further POST), back off on `unavailable`.
- New `resumeRealtime()` so a successful login resumes the stream immediately instead of waiting out a pending backoff.

`browser.ts` — the bridge socket:

- An `unavailable` refresh now retries **the refresh**, on its own backoff — the socket stays down. Re-dialling with a cookie the backend just rejected only earns the same close, so #4156's "a terminal auth error stops reconnection" invariant holds unchanged. `redirectToLogin()` fires only on `expired`.
- Restores `BASE_RECONNECT_DELAY` where #4175 had re-introduced a literal `500`.

Both sockets: a **successful** refresh now reconnects on the backoff rather than dialling immediately, and doesn't reset the delay. Otherwise a backend that keeps refusing even a freshly minted session becomes a new unthrottled `refresh → dial → close → refresh` loop. The delay is credited back on `close` once a connection has actually held, so a healthy recovery still returns to the floor.

`AuthContext.tsx` — clear the previous session's latch on successful login, then resume both sockets.

## Related Issues

- Related to #4155

Continues the in-repo half of #4155. It does **not** close it: the primary defect there — a paired browser's Core session minted once with no renewal, `/auth/status` not reflecting Core-session validity, and the proxy forwarding the browser's stale cookie — lives in the packaged web-host. `packages/web-host/src/static-server.ts` is still 285 lines with no auth, and `desktopPairing`, `createPairedSessionCookies`, `coreUserBridge`, `AuthSessionStore`, `aionui-webhost-session` and `scheduleSessionRenewal` still have zero hits in this repository.

What this PR does do is make the client side safe to wire that flow onto. Once a paired browser holds a refresh cookie, `refreshSessionOutcome()` returns `refreshed` and both sockets recover silently; until then it returns `expired` **once** and everything goes quiet, instead of looping.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

One root cause — *a session the backend refuses produces an unbounded reconnect + refresh loop* — on one code path: realtime reconnect scheduling and the session-refresh primitive that drives it. Splitting leaves the storm in place. Guarding `ensureWs()` alone still lets an accept-then-drop backend hammer at the 1 s floor; fixing only the backoff still lets `wsSend()` skip the timer; and fixing both still POSTs `/api/auth/refresh` on every close, because without the outcome split there is nothing to latch on. The `unavailable` branch is not a separate feature either — it is what makes the latch safe to add at all.

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes (`format:check` clean)
- [x] `bun run lint` — 0 errors, no new warnings
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — 4965 passed, 5 skipped, 0 failed (520 files)
- [x] i18n validated — `bun run i18n:types` reports types up to date and `node scripts/check-i18n.js` passes; no `locales/` or i18n-config changes
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — N/A, no user-facing text

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [x] Verified on Linux
- [x] I have performed a self-review of my own code

Found from the #4155 reproduction: a phone paired to the desktop WebUI over LAN, against a backend rejecting the browser's expired session. Checks and tests were run on Ubuntu 24.04 / Node 22.14 / bun 1.4.

### End to end: the 24-hour scenario, fast-forwarded

`tests/integration/webuiSessionLifetime.test.ts` (6 tests) reproduces the issue as reported rather than by proxy. Everything below the test is real — the shipped adapters run unmodified, over real TCP, through the real `startStaticServer` including its `/api/*` proxy and its `/ws` splice. Only aioncore is a stub, and only so its clock can be moved: it mints the production lifetimes (24 h access, 30 d refresh/pairing) and judges them against a virtual clock, so `core.advance(ACCESS_TTL_MS)` is genuinely "the next day" for every token in the system and costs no wall-clock time.

Each test pairs, jumps a day, and opens the WebUI once — the phone being picked up the next morning. The two outcomes the issue named as acceptable are the two asserted:

- **renewable session** → renewed silently, one refresh POST, no logout, no pairing screen.
- **paired session** (access cookie, nothing to renew it with) → gives up once and lands on the pairing screen.

"Does not loop" is measured server-side in request counts, not inferred from client state. Driving the client for ~1.6 s at T+24 h, against a paired browser:

| | before | after |
|---|---|---|
| `POST /api/auth/refresh` | 84 | 1 |
| `/ws` upgrades | 43 | 1 |

That is ~52 refresh POSTs and ~27 upgrades per second against a rate-limited endpoint — #4155's "that full burst repeats every ~1 s", quantified. After the fix one socket's refresh latches the session and the other never gets as far as dialling.

The harness takes the web host as a parameter: set `AIONUI_WEBHOST_UNDER_TEST` to a module exporting `startStaticServer` to run the identical scenarios against a build that has the real pairing layer. The open-source static server is the default, with the pairing cookie shapes reproduced by hand.

### Unit coverage

New test file `tests/unit/adapter/realtimeSocketReconnect.dom.test.ts` (8 tests) drives the real `httpBridge` module in jsdom with fake timers and a scripted `WebSocket` stub, plus 3 new tests in `webuiWebSocketReconnect.dom.test.ts`, 1 in `browserRealtimeError.test.ts` and 5 in `sessionRefresh.dom.test.ts`.

Against the unpatched adapter, **8 of the 26 tests in the three socket test files fail** — so they pin the regressions rather than just passing:

```
× does not re-dial on every send while a backoff reconnect is pending
× backs off when the server accepts the upgrade and drops it immediately
× stops dialling and stops refreshing once the session is truly dead (1008 + 401 refresh)
× still backs off when the backend refuses even a freshly refreshed session
× keeps retrying on the backoff when the refresh endpoint is only transiently down (1008 + 503)
× reconnects on the backoff after a successful silent refresh
× does not sign the user out when the refresh endpoint is only transiently down
× does not redirect when the refresh endpoint is only transiently unavailable
```

The 5 new `sessionRefresh` tests cover APIs this PR adds, so they cannot be run against the unpatched module. The integration suite uses no new API and fails 3 of 6 unpatched.

### Notes on the existing tests that changed

No existing assertion was weakened, and one existing invariant deliberately shaped the design:

- **`browserRealtimeError.test.ts` — "does not redirect to login from close code 1008 without an auth error event"** is unchanged and still passes. I had initially made a bare `1008` close on the bridge socket run the auth recovery; that test says 1008 is a generic policy violation and the `realtime.error` frame is this socket's designated auth signal, so I dropped it. (The realtime socket keeps the `1008` handling #4175 gave it — that one has no such frame.)
- **`browserRealtimeError.test.ts` — "…redirects to login when refresh fails"** now stubs `document` and a `401` refresh response. Its own comment said it was relying on `document` being absent in the node env so `refreshSession()` would short-circuit, i.e. it never exercised a refresh response at all. It now drives a genuine dead-refresh 401, and a sibling case asserts a `503` does *not* redirect. The redirect assertion itself is unchanged.
- **`sessionRefresh.dom.test.ts` and `webuiWebSocketReconnect.dom.test.ts`** gained a `resetSessionRefresh()` in `beforeEach`/`afterEach`. The latch and the cooldown are module-level state, so without it one test's verdict leaks into the next.

## Additional Context

Realtime socket behaviour for a connection that keeps failing:

| | before | after |
|---|---|---|
| socket down, app keeps sending / subscribing | one dial per send or subscribe | one dial per backoff tick |
| backend accepts upgrade then drops | 1 s forever | 1 s → 2 s → 4 s … → 30 s |
| 1008 close, refresh returns 401 | re-dial + another refresh POST on the next send, forever | one POST, then silent until re-auth |
| 1008 close, refresh returns 503 | stream stranded until a send re-dials it | retried on the backoff |
| 1008 close, refresh succeeds but backend still refuses | immediate re-dial, backoff reset | backed off |
| transient refresh failure on the bridge socket | hard redirect to `/login` | refresh retried, session kept |
| login after a dead session | waits for the next subscription | both sockets resume immediately |
