### PR TITLE
chore: bump version to 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [2.2.0](https://github.com/iOfficeAI/AionUi/compare/v2.1.61...v2.2.0) (2026-08-28)
+
+### Desktop
+
+#### Features
+
+- **auth:** silently refresh WebUI session on 401 (#4175)
+
+#### Bug Fixes
+
+- **webui:** stop bridge websocket reconnect storm on repeated failures (#4156)
+
+### Core ([v0.2.0](https://github.com/iOfficeAI/AionCore/releases/tag/v0.2.0))
+
+#### ⚠ BREAKING CHANGES
+
+- **skills:** deliver skills through an AionUi-owned view instead of the workspace (#938)
+
+#### Features
+
+- **auth:** dual-token refresh with singleflight (#926)
+- **skills:** deliver skills through an AionUi-owned view instead of the workspace (#938)
+
+---
+
 ## [2.1.61](https://github.com/iOfficeAI/AionUi/compare/v2.1.60...v2.1.61) (2026-08-25)
 
 ### Desktop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.1.61",
+  "version": "2.2.0",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",
@@ -261,7 +261,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aioncoreVersion": "v0.1.72",
+  "aioncoreVersion": "v0.2.0",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
## [2.2.0](https://github.com/iOfficeAI/AionUi/compare/v2.1.61...v2.2.0) (2026-08-28)

### Desktop

#### Features

- **auth:** silently refresh WebUI session on 401 (#4175)

#### Bug Fixes

- **webui:** stop bridge websocket reconnect storm on repeated failures (#4156)

### Core ([v0.2.0](https://github.com/iOfficeAI/AionCore/releases/tag/v0.2.0))

#### ⚠ BREAKING CHANGES

- **skills:** deliver skills through an AionUi-owned view instead of the workspace (#938)

#### Features

- **auth:** dual-token refresh with singleflight (#926)
- **skills:** deliver skills through an AionUi-owned view instead of the workspace (#938)