### PR TITLE
fix(chat): preserve text around stray think-close after a complete block

### DIFF
--- a/packages/desktop/src/renderer/utils/chat/thinkTagFilter.ts
+++ b/packages/desktop/src/renderer/utils/chat/thinkTagFilter.ts
@@ -15,6 +15,31 @@
  * @param content - The content to filter
  * @returns Filtered content without think tags
  */
+/**
+ * Complete think/thinking block, matched innermost-first so nested blocks are
+ * fully removed (a single non-greedy pass would stop at the inner close and
+ * leave the outer content behind).
+ */
+const COMPLETE_THINK_BLOCK_RE = /<\s*think\s*>((?:(?!<\s*think\s*>|<\s*thinking\s*>)[\s\S])*?)<\s*\/\s*think\s*>/gi;
+const COMPLETE_THINKING_BLOCK_RE =
+  /<\s*thinking\s*>((?:(?!<\s*think\s*>|<\s*thinking\s*>)[\s\S])*?)<\s*\/\s*thinking\s*>/gi;
+
+/** Strip every complete think/thinking block, innermost first, until none remain. */
+function stripCompleteThinkBlocks(content: string): string {
+  let result = content;
+  let previous: string;
+  do {
+    previous = result;
+    result = result.replace(COMPLETE_THINK_BLOCK_RE, '').replace(COMPLETE_THINKING_BLOCK_RE, '');
+  } while (result !== previous);
+  return result;
+}
+
+/** Whether the content contains at least one complete, balanced think/thinking block. */
+function hasCompleteThinkBlock(content: string): boolean {
+  return Boolean(content.match(COMPLETE_THINK_BLOCK_RE)?.length || content.match(COMPLETE_THINKING_BLOCK_RE)?.length);
+}
+
 export function stripThinkTags(content: string): string {
   if (!content || typeof content !== 'string') {
     return content;
@@ -24,17 +49,28 @@ export function stripThinkTags(content: string): string {
     return content;
   }
 
+  // Step 1 & 2: Remove complete think/thinking blocks (with optional spaces in
+  // tags), innermost first so nested blocks are fully consumed and cannot leak
+  // content into the MiniMax strip below.
+  const hadCompleteBlock = hasCompleteThinkBlock(content);
+  let result = stripCompleteThinkBlocks(content);
+
+  // The MiniMax strip below deletes everything up to the FIRST orphaned closing
+  // tag. That is only safe when the message carries no complete block: a stray
+  // close after a balanced think block is just a leftover tag, and the content
+  // before it is legitimate text that must survive (Step 4 already removes the
+  // orphaned tag itself while preserving surrounding content).
+  if (!hadCompleteBlock) {
+    // Step 3: Handle MiniMax-style format: content before the FIRST orphaned
+    // closing tag. Models like MiniMax M2.5 omit the opening tag and output
+    // "thinking content...\n close\nreply".
+    result = result.replace(/^[\s\S]*?<\s*\/\s*think(?:ing)?\s*>/i, '');
+  }
+
   return (
-    content
-      // Step 1: Remove complete <think>...</think> blocks (with optional spaces in tags)
-      .replace(/<\s*think\s*>([\s\S]*?)<\s*\/\s*think\s*>/gi, '')
-      // Step 2: Remove complete <thinking>...</thinking> blocks (with optional spaces in tags)
-      .replace(/<\s*thinking\s*>([\s\S]*?)<\s*\/\s*thinking\s*>/gi, '')
-      // Step 3: Handle MiniMax-style format: content before the FIRST orphaned </think>
-      // Models like MiniMax M2.5 omit the opening tag: "thinking content...\n</think>\nresponse"
-      .replace(/^[\s\S]*?<\s*\/\s*think(?:ing)?\s*>/i, '')
+    result
       // Step 4: Remove any remaining orphaned closing tags (just the tags, preserve surrounding content)
-      // When text gets concatenated across tool calls, there may be additional </think> tags
+      // When text gets concatenated across tool calls, there may be additional closing tags
       .replace(/<\s*\/\s*think(?:ing)?\s*>/gi, '')
       // Step 5: Remove any remaining orphaned opening tags
       .replace(/<\s*think(?:ing)?\s*>/gi, '')

--- a/tests/unit/renderer/utils/thinkTagFilter.test.ts
+++ b/tests/unit/renderer/utils/thinkTagFilter.test.ts
@@ -28,6 +28,18 @@ describe('thinkTagFilter', () => {
       const input = '<think>outer<think>inner</think>outer</think>Text';
       expect(stripThinkTags(input)).toBe('Text');
     });
+    it('preserves content before an orphaned close when a complete block exists', () => {
+      // A complete <thinking> block plus a stray trailing close. The legacy
+      // MiniMax strip deleted everything up to the FIRST orphaned close, which
+      // wrongly ate the legitimate "START" and "MIDDLE" text.
+      const input = 'START <thinking>secret</thinking> MIDDLE </thinking> END';
+      expect(stripThinkTags(input)).toBe('START  MIDDLE  END');
+    });
+
+    it('preserves content after an orphaned close in the middle of the text', () => {
+      const input = 'head </thinking>tail';
+      expect(stripThinkTags(input)).toBe('tail');
+    });
 
     it('removes orphaned opening tags but preserves following text', () => {
       const input = 'Text<think>incomplete';


### PR DESCRIPTION
## Description

`stripThinkTags` (used by `MessageText`, `autoTitle`, `getLastAssistantText` and `turnCopy` to clean AI replies before rendering) had a destructive bug: its MiniMax step deleted **everything up to the first orphaned closing think tag**, even when the message contained a complete `<thinking>…</thinking>` block plus a stray trailing close.

Example: `START <thinking>secret</thinking> MIDDLE </thinking> END` was stripped to `" END"`, silently losing the legitimate `START` and `MIDDLE` text from the rendered message. That combination (a balanced block followed by a leftover close tag from concatenated tool-call output) is exactly the case Step 4 was documented to handle by removing "just the tags".

This fix:
1. Removes complete think/thinking blocks innermost-first in a loop, so nested blocks are fully consumed.
2. Applies the aggressive MiniMax leading-content strip **only** when no complete block was present; otherwise the orphaned close is removed by Step 4 while surrounding content is preserved.

## Related Issues

No existing issue tracked this; discovered during code review of `thinkTagFilter.ts`.

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)
- [ ] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass
- [ ] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`) — only if `src/renderer/`, `locales/`, or `src/common/config/i18n/` changed; N/A otherwise
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings)

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Screenshots

N/A (pure string-processing change, covered by unit tests).

## Additional Context

- Regression tests added in `tests/unit/renderer/utils/thinkTagFilter.test.ts` for both the "complete block + stray close" and the standalone-orphan-close cases.
- Verified the bug and the fix directly: the old implementation returned `" END"` for the input above, the new one returns `"START  MIDDLE  END"`.
- Note: `bunx tsc --noEmit` locally reports one pre-existing error (`Cannot find module 'mermaid'`) that also occurs on a clean checkout of `main` — it is an environment/dependency issue unrelated to this change.
