### PR TITLE
feat(notification): name the conversation in turn-completed notifications

### DIFF
--- a/packages/desktop/src/renderer/hooks/system/notification/browserNotificationCore.ts
+++ b/packages/desktop/src/renderer/hooks/system/notification/browserNotificationCore.ts
@@ -29,6 +29,24 @@ export const shouldShowNotification = (gate: NotificationGate): boolean =>
   gate.settingEnabled &&
   gate.documentHidden;
 
+/**
+ * Max length of a conversation name embedded in a turn-completed notification.
+ * The name sits at the front of the body, so anything longer is truncated with
+ * a trailing ellipsis (keep the beginning, where the title's meaning is). Kept
+ * as a constant so it is easy to tune in one place.
+ */
+export const CONVERSATION_NAME_MAX_LENGTH = 20;
+
+/**
+ * Trim a conversation name and cap it at `maxLength`, appending an ellipsis when
+ * it overflows. Keeps the leading characters (front-loaded titles read best).
+ */
+export const truncateConversationName = (name: string, maxLength: number = CONVERSATION_NAME_MAX_LENGTH): string => {
+  const trimmed = name.trim();
+  if (trimmed.length <= maxLength) return trimmed;
+  return `${trimmed.slice(0, maxLength)}…`;
+};
+
 export type NotificationKind = 'confirmation' | 'turnCompleted';
 
 export type NotificationPayload = {
@@ -47,7 +65,12 @@ export type BrowserNotificationDeps = {
    */
   shouldShow: () => boolean;
   show: (payload: NotificationPayload) => void;
-  bodyFor: (kind: NotificationKind) => string;
+  /**
+   * Build the notification body for a given kind. `conversationId` is provided
+   * so the turn-completed body can name the originating conversation; the
+   * confirmation body ignores it.
+   */
+  bodyFor: (kind: NotificationKind, conversationId?: string) => string;
 };
 
 /**
@@ -77,7 +100,11 @@ export const createBrowserNotificationController = (deps: BrowserNotificationDep
 
     if (PERMISSION_TYPES.has(message.type)) {
       if (!deps.shouldShow()) return;
-      deps.show({ body: deps.bodyFor('confirmation'), conversationId: message.conversation_id, kind: 'confirmation' });
+      deps.show({
+        body: deps.bodyFor('confirmation', message.conversation_id),
+        conversationId: message.conversation_id,
+        kind: 'confirmation',
+      });
       return;
     }
 
@@ -86,7 +113,7 @@ export const createBrowserNotificationController = (deps: BrowserNotificationDep
       if (!deps.shouldShow()) return;
       lastNotifiedTurnId = message.turn_id ?? null;
       deps.show({
-        body: deps.bodyFor('turnCompleted'),
+        body: deps.bodyFor('turnCompleted', message.conversation_id),
         conversationId: message.conversation_id,
         kind: 'turnCompleted',
       });

--- a/packages/desktop/src/renderer/hooks/system/notification/useBrowserNotification.ts
+++ b/packages/desktop/src/renderer/hooks/system/notification/useBrowserNotification.ts
@@ -10,9 +10,11 @@ import { useTranslation } from 'react-i18next';
 import { ipcBridge } from '@/common';
 import { configService } from '@/common/config/configService';
 import { isElectronDesktop } from '@/renderer/utils/platform';
+import { getSnapshotConversationName } from '@/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync';
 import {
   createBrowserNotificationController,
   shouldShowNotification,
+  truncateConversationName,
   type NotificationPermissionState,
 } from './browserNotificationCore';
 
@@ -48,10 +50,13 @@ export const useBrowserNotification = (): void => {
           settingEnabled: configService.get('system.notificationEnabled') !== false,
           documentHidden: document.hidden,
         }),
-      bodyFor: (kind) =>
-        kind === 'confirmation'
-          ? t('settings.browserNotification.bodyConfirmation')
-          : t('settings.browserNotification.bodyTurnCompleted'),
+      bodyFor: (kind, conversationId) => {
+        if (kind === 'confirmation') return t('settings.browserNotification.bodyConfirmation');
+        const name = conversationId ? getSnapshotConversationName(conversationId) : undefined;
+        return name
+          ? t('settings.browserNotification.bodyTurnCompletedNamed', { name: truncateConversationName(name) })
+          : t('settings.browserNotification.bodyTurnCompleted');
+      },
       show: ({ body, conversationId }) => {
         try {
           const notification = new Notification('AionUi', { body });

--- a/packages/desktop/src/renderer/hooks/system/notification/useDesktopTurnNotification.ts
+++ b/packages/desktop/src/renderer/hooks/system/notification/useDesktopTurnNotification.ts
@@ -9,7 +9,8 @@ import { useTranslation } from 'react-i18next';
 import { ipcBridge } from '@/common';
 import { configService } from '@/common/config/configService';
 import { isElectronDesktop } from '@/renderer/utils/platform';
-import { createBrowserNotificationController } from './browserNotificationCore';
+import { getSnapshotConversationName } from '@/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync';
+import { createBrowserNotificationController, truncateConversationName } from './browserNotificationCore';
 
 /**
  * Desktop-only: fire a native system notification when an agent turn finishes.
@@ -37,10 +38,13 @@ export const useDesktopTurnNotification = (): void => {
       // Cheap renderer-side gate; the main process still re-checks the setting
       // and the window-focus condition before showing anything.
       shouldShow: () => configService.get('system.notificationEnabled') !== false,
-      bodyFor: (kind) =>
-        kind === 'confirmation'
-          ? t('settings.browserNotification.bodyConfirmation')
-          : t('settings.browserNotification.bodyTurnCompleted'),
+      bodyFor: (kind, conversationId) => {
+        if (kind === 'confirmation') return t('settings.browserNotification.bodyConfirmation');
+        const name = conversationId ? getSnapshotConversationName(conversationId) : undefined;
+        return name
+          ? t('settings.browserNotification.bodyTurnCompletedNamed', { name: truncateConversationName(name) })
+          : t('settings.browserNotification.bodyTurnCompleted');
+      },
       show: ({ body, conversationId, kind }) => {
         // This issue scopes desktop notifications to turn completion only.
         if (kind !== 'turnCompleted') return;

--- a/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts
+++ b/packages/desktop/src/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync.ts
@@ -221,6 +221,19 @@ export const setConversationProjectMapForTest = (entries: Array<[string, string 
   projectIdByIdState = new Map(entries);
 };
 
+/**
+ * Synchronous lookup of a conversation's display name from the in-memory list
+ * snapshot. Used by the turn-completed notification to name the originating
+ * conversation. Returns the trimmed name, or `undefined` when the conversation
+ * is not loaded yet or has no (non-empty) name — callers fall back to a generic
+ * message.
+ */
+export const getSnapshotConversationName = (conversation_id: string): string | undefined => {
+  const conversation = conversationsState.find((item) => item.id === conversation_id);
+  const name = conversation?.name?.trim();
+  return name ? name : undefined;
+};
+
 const refreshConversations = () => {
   void ipcBridge.database.getUserConversations
     .invoke({ limit: 10000 })

--- a/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
+++ b/packages/desktop/src/renderer/services/i18n/i18n-keys.d.ts
@@ -1783,6 +1783,7 @@ export type I18nKey =
   | 'settings.browserData.title'
   | 'settings.browserNotification.bodyConfirmation'
   | 'settings.browserNotification.bodyTurnCompleted'
+  | 'settings.browserNotification.bodyTurnCompletedNamed'
   | 'settings.browserNotification.denied'
   | 'settings.browserNotification.enable'
   | 'settings.browserNotification.granted'

--- a/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/de-DE/settings.json
@@ -1329,7 +1329,8 @@
     "denied": "Notifications blocked — enable them in your browser's site settings",
     "insecureContext": "Browser notifications require HTTPS or localhost access",
     "bodyConfirmation": "An agent is waiting for your confirmation",
-    "bodyTurnCompleted": "The agent has finished responding"
+    "bodyTurnCompleted": "The agent has finished responding",
+    "bodyTurnCompletedNamed": "\"{{name}}\" has finished responding"
   },
   "repair": {
     "pathLabel": "Launch Path",

--- a/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/en-US/settings.json
@@ -342,7 +342,8 @@
     "denied": "Notifications blocked — enable them in your browser's site settings",
     "insecureContext": "Browser notifications require HTTPS or localhost access",
     "bodyConfirmation": "An agent is waiting for your confirmation",
-    "bodyTurnCompleted": "The agent has finished responding"
+    "bodyTurnCompleted": "The agent has finished responding",
+    "bodyTurnCompletedNamed": "\"{{name}}\" has finished responding"
   },
   "notification": "Notifications",
   "cronNotificationEnabled": "Scheduled Task Completion",

--- a/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/es-ES/settings.json
@@ -1305,7 +1305,8 @@
     "denied": "Notifications blocked — enable them in your browser's site settings",
     "insecureContext": "Browser notifications require HTTPS or localhost access",
     "bodyConfirmation": "An agent is waiting for your confirmation",
-    "bodyTurnCompleted": "The agent has finished responding"
+    "bodyTurnCompleted": "The agent has finished responding",
+    "bodyTurnCompletedNamed": "\"{{name}}\" has finished responding"
   },
   "repair": {
     "pathLabel": "Launch Path",

--- a/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fa-IR/settings.json
@@ -342,7 +342,8 @@
     "denied": "اعلان‌ها مسدود شده‌اند — آن‌ها را در تنظیمات سایت مرورگر فعال کنید",
     "insecureContext": "اعلان‌های مرورگر به HTTPS یا دسترسی localhost نیاز دارند",
     "bodyConfirmation": "یک ایجنت منتظر تأیید شماست",
-    "bodyTurnCompleted": "ایجنت پاسخ را کامل کرده است"
+    "bodyTurnCompleted": "ایجنت پاسخ را کامل کرده است",
+    "bodyTurnCompletedNamed": "«{{name}}» پاسخ را کامل کرد"
   },
   "notification": "اعلان‌ها",
   "cronNotificationEnabled": "اتمام کار زمان‌بندی‌شده",

--- a/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/fr-FR/settings.json
@@ -342,7 +342,8 @@
     "denied": "Notifications bloquées : activez-les dans les paramètres du site de votre navigateur",
     "insecureContext": "Les notifications du navigateur nécessitent un accès HTTPS ou localhost",
     "bodyConfirmation": "Un agent attend votre confirmation",
-    "bodyTurnCompleted": "L'agent a fini de répondre"
+    "bodyTurnCompleted": "L'agent a fini de répondre",
+    "bodyTurnCompletedNamed": "« {{name}} » a fini de répondre"
   },
   "notification": "Notifications",
   "cronNotificationEnabled": "Fin de tâche planifiée",

--- a/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ja-JP/settings.json
@@ -342,7 +342,8 @@
     "denied": "通知がブロックされています — ブラウザのサイト設定から有効にしてください",
     "insecureContext": "ブラウザ通知には HTTPS または localhost からのアクセスが必要です",
     "bodyConfirmation": "エージェントが確認を待っています",
-    "bodyTurnCompleted": "エージェントが応答を完了しました"
+    "bodyTurnCompleted": "エージェントが応答を完了しました",
+    "bodyTurnCompletedNamed": "「{{name}}」の応答が完了しました"
   },
   "notification": "通知",
   "cronNotificationEnabled": "定期タスク完了通知",

--- a/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ko-KR/settings.json
@@ -342,7 +342,8 @@
     "denied": "알림이 차단되었습니다 — 브라우저 사이트 설정에서 허용해 주세요",
     "insecureContext": "브라우저 알림은 HTTPS 또는 localhost 접속이 필요합니다",
     "bodyConfirmation": "에이전트가 확인을 기다리고 있습니다",
-    "bodyTurnCompleted": "에이전트가 응답을 완료했습니다"
+    "bodyTurnCompleted": "에이전트가 응답을 완료했습니다",
+    "bodyTurnCompletedNamed": "\"{{name}}\"의 응답이 완료되었습니다"
   },
   "notification": "알림",
   "cronNotificationEnabled": "예약 작업 완료 알림",

--- a/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/pt-BR/settings.json
@@ -342,7 +342,8 @@
     "denied": "Notificações bloqueadas — ative-as nas configurações de site do seu navegador",
     "insecureContext": "As notificações do navegador exigem acesso via HTTPS ou localhost",
     "bodyConfirmation": "Um agente está aguardando sua confirmação",
-    "bodyTurnCompleted": "O agente terminou de responder"
+    "bodyTurnCompleted": "O agente terminou de responder",
+    "bodyTurnCompletedNamed": "\"{{name}}\" terminou de responder"
   },
   "notification": "Notificações",
   "cronNotificationEnabled": "Conclusão de Tarefa Agendada",

--- a/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/ru-RU/settings.json
@@ -350,7 +350,8 @@
     "denied": "Уведомления заблокированы — разрешите их в настройках сайта браузера",
     "insecureContext": "Браузерные уведомления требуют доступа через HTTPS или localhost",
     "bodyConfirmation": "Агент ожидает вашего подтверждения",
-    "bodyTurnCompleted": "Агент завершил ответ"
+    "bodyTurnCompleted": "Агент завершил ответ",
+    "bodyTurnCompletedNamed": "«{{name}}» завершил ответ"
   },
   "notification": "Уведомления",
   "cronNotificationEnabled": "Уведомление о завершении запланированных задач",

--- a/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/tr-TR/settings.json
@@ -342,7 +342,8 @@
     "denied": "Bildirimler engellendi — tarayıcınızın site ayarlarından etkinleştirin",
     "insecureContext": "Tarayıcı bildirimleri için HTTPS veya localhost erişimi gereklidir",
     "bodyConfirmation": "Bir agent onayınızı bekliyor",
-    "bodyTurnCompleted": "Agent yanıtlamayı tamamladı"
+    "bodyTurnCompleted": "Agent yanıtlamayı tamamladı",
+    "bodyTurnCompletedNamed": "\"{{name}}\" yanıtlamayı tamamladı"
   },
   "notification": "Bildirimler",
   "cronNotificationEnabled": "Zamanlanmış Görev Tamamlanma",

--- a/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/uk-UA/settings.json
@@ -350,7 +350,8 @@
     "denied": "Сповіщення заблоковано — увімкніть їх у налаштуваннях сайту браузера",
     "insecureContext": "Сповіщення браузера вимагають доступу через HTTPS або localhost",
     "bodyConfirmation": "Агент чекає вашого підтвердження",
-    "bodyTurnCompleted": "Агент завершив відповідь"
+    "bodyTurnCompleted": "Агент завершив відповідь",
+    "bodyTurnCompletedNamed": "«{{name}}» завершив відповідь"
   },
   "notification": "Сповіщення",
   "cronNotificationEnabled": "Завершення запланованих завдань",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-CN/settings.json
@@ -342,7 +342,8 @@
     "denied": "通知已被拦截 —— 请在浏览器的网站设置中开启",
     "insecureContext": "浏览器通知需要通过 HTTPS 或 localhost 访问",
     "bodyConfirmation": "有一个 agent 正在等待你的确认",
-    "bodyTurnCompleted": "agent 已完成本轮回复"
+    "bodyTurnCompleted": "已完成本轮回复",
+    "bodyTurnCompletedNamed": "「{{name}}」已完成本轮回复"
   },
   "notification": "通知",
   "cronNotificationEnabled": "定时任务完成通知",

--- a/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
+++ b/packages/desktop/src/renderer/services/i18n/locales/zh-TW/settings.json
@@ -342,7 +342,8 @@
     "denied": "通知已被封鎖 —— 請在瀏覽器的網站設定中開啟",
     "insecureContext": "瀏覽器通知需要透過 HTTPS 或 localhost 存取",
     "bodyConfirmation": "有一個 agent 正在等待你的確認",
-    "bodyTurnCompleted": "agent 已完成本輪回覆"
+    "bodyTurnCompleted": "已完成本輪回覆",
+    "bodyTurnCompletedNamed": "「{{name}}」已完成本輪回覆"
   },
   "notification": "通知",
   "cronNotificationEnabled": "定時任務完成通知",

--- a/tests/unit/renderer/browserNotificationCore.test.ts
+++ b/tests/unit/renderer/browserNotificationCore.test.ts
@@ -7,6 +7,8 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   shouldShowNotification,
   createBrowserNotificationController,
+  truncateConversationName,
+  CONVERSATION_NAME_MAX_LENGTH,
   type NotificationGate,
 } from '@/renderer/hooks/system/notification/browserNotificationCore';
 
@@ -36,21 +38,48 @@ describe('shouldShowNotification', () => {
   });
 });
 
+describe('truncateConversationName', () => {
+  it('returns a short name unchanged (trimmed)', () => {
+    expect(truncateConversationName('  My chat  ')).toBe('My chat');
+  });
+
+  it('keeps a name exactly at the limit', () => {
+    const exact = 'a'.repeat(CONVERSATION_NAME_MAX_LENGTH);
+    expect(truncateConversationName(exact)).toBe(exact);
+  });
+
+  it('truncates from the end and appends an ellipsis when over the limit', () => {
+    const long = 'a'.repeat(CONVERSATION_NAME_MAX_LENGTH + 5);
+    expect(truncateConversationName(long)).toBe(`${'a'.repeat(CONVERSATION_NAME_MAX_LENGTH)}…`);
+  });
+
+  it('honors a custom max length', () => {
+    expect(truncateConversationName('abcdef', 3)).toBe('abc…');
+  });
+});
+
 describe('createBrowserNotificationController.onStreamMessage', () => {
   const makeDeps = (gate: NotificationGate = openGate) => {
     const show = vi.fn();
+    const bodyFor = vi.fn((kind: string) => kind);
     const controller = createBrowserNotificationController({
       shouldShow: () => shouldShowNotification(gate),
       show,
-      bodyFor: (kind) => kind,
+      bodyFor,
     });
-    return { show, controller };
+    return { show, bodyFor, controller };
   };
 
   it('shows a turn-completed notification on a finish stream message', () => {
     const { show, controller } = makeDeps();
     controller.onStreamMessage({ type: 'finish', conversation_id: 'c1', turn_id: 't1' });
     expect(show).toHaveBeenCalledWith({ body: 'turnCompleted', conversationId: 'c1', kind: 'turnCompleted' });
+  });
+
+  it('passes the conversation id to bodyFor so the body can name the conversation', () => {
+    const { bodyFor, controller } = makeDeps();
+    controller.onStreamMessage({ type: 'finish', conversation_id: 'c1', turn_id: 't1' });
+    expect(bodyFor).toHaveBeenCalledWith('turnCompleted', 'c1');
   });
 
   it('shows a confirmation notification on an acp_permission stream message', () => {

--- a/tests/unit/renderer/hooks/getSnapshotConversationName.dom.test.tsx
+++ b/tests/unit/renderer/hooks/getSnapshotConversationName.dom.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/renderer/utils/emitter', () => ({
+  addEventListener: vi.fn(),
+}));
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    database: {
+      getUserConversations: {
+        invoke: vi.fn().mockResolvedValue({
+          items: [
+            { id: 'c1', name: 'Quarterly report review' },
+            { id: 'c2', name: '  padded name  ' },
+            { id: 'c3', name: '   ' },
+            { id: 'c4' },
+          ],
+        }),
+      },
+    },
+    application: {
+      writeRendererLog: { invoke: vi.fn().mockResolvedValue(undefined) },
+    },
+    conversation: {
+      listChanged: { on: vi.fn() },
+      responseStream: { on: vi.fn() },
+      turnCompleted: { on: vi.fn() },
+    },
+  },
+}));
+
+import {
+  getSnapshotConversationName,
+  useConversationListSync,
+} from '@/renderer/pages/conversation/GroupedHistory/hooks/useConversationListSync';
+
+describe('getSnapshotConversationName', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the trimmed name for a loaded conversation, undefined otherwise', async () => {
+    renderHook(() => useConversationListSync());
+
+    // The store loads conversations asynchronously on mount.
+    await waitFor(() => {
+      expect(getSnapshotConversationName('c1')).toBe('Quarterly report review');
+    });
+
+    expect(getSnapshotConversationName('c2')).toBe('padded name');
+    // Whitespace-only name → treated as no name.
+    expect(getSnapshotConversationName('c3')).toBeUndefined();
+    // Missing name field → undefined.
+    expect(getSnapshotConversationName('c4')).toBeUndefined();
+    // Unknown conversation id → undefined.
+    expect(getSnapshotConversationName('nope')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Description

Turn-completed system/browser notifications previously showed a fixed body ("agent has finished responding") with no way to tell which conversation had finished — every notification looked identical in the notification center.

This PR resolves the originating conversation's name from the in-memory list snapshot and embeds it in the notification body, so the user can tell at a glance which conversation completed. When no name is available (e.g. a brand-new conversation without a title yet) it falls back to the generic message.

Behavior details:
- Title stays `AionUi` (brand preserved); the conversation name goes into the body.
- The name is truncated to a tunable max length (`CONVERSATION_NAME_MAX_LENGTH`), keeping the leading characters where a title's meaning is front-loaded, with a trailing ellipsis on overflow.
- Click-to-navigate behavior is **unchanged** — only the displayed text changed.
- The awkward mixed-language "agent" word was dropped from the Chinese fallback text.

Example body: `"<conversation name>" has finished responding` / fallback: `The agent has finished responding`.

## Related Issues

- Closes #

## Type of Change

- [ ] `fix` — Bug fix (non-breaking change which fixes an issue)
- [x] `feat` — New feature (non-breaking change which adds functionality)
- [ ] `perf` — Performance improvement
- [ ] `refactor` — Code restructuring (no behavior change)
- [ ] Breaking change (fix or feature that would break existing functionality)
- [ ] `docs` — Documentation update

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors
- [x] `bunx tsc --noEmit` — no type errors
- [x] `bunx vitest run` — tests pass (full suite: 4948 passed)
- [x] i18n validated (`bun run i18n:types` + `node scripts/check-i18n.js`)
- [x] New/changed user-facing text uses i18n keys (new key `bodyTurnCompletedNamed` added across all 13 locales)

## Runtime Verification

- [x] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

Verified in the dev environment on macOS:
- Turn-completed notification with a conversation title shows the title in the body.
- Fallback notification (conversation without a title yet) shows the generic message.
- Title remains `AionUi`.

Multi-language rendering was not manually exercised; the new `bodyTurnCompletedNamed` key is present in all 13 locales and passes `check-i18n` validation.

## Screenshots

_Omitted to avoid exposing local/session information._

## Additional Context

- Core logic (`browserNotificationCore.ts`): added `CONVERSATION_NAME_MAX_LENGTH` + `truncateConversationName()`; `bodyFor()` now receives `conversation_id`.
- Data access (`useConversationListSync.ts`): added a synchronous, read-only `getSnapshotConversationName()` following the existing snapshot-lookup pattern.
- Unit tests cover truncation (short / at-limit / overflow / custom limit), the controller passing the id into `bodyFor`, and name resolution (trim / whitespace-only / missing / unknown id).