### PR TITLE
chore: bump version to 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,20 @@
 # Changelog
 
-## [2.2.0](https://github.com/iOfficeAI/AionUi/compare/v2.1.61...v2.2.0) (2026-08-28)
+## [2.2.1](https://github.com/iOfficeAI/AionUi/compare/v2.1.61...v2.2.1) (2026-09-01)
 
 ### Desktop
 
 #### Features
 
+- **conversation:** distinguish waiting-for-user state in sidebar and notify (#4198)
+- **notification:** name the conversation in turn-completed notifications (#4195)
 - **auth:** silently refresh WebUI session on 401 (#4175)
 
 #### Bug Fixes
 
 - **webui:** stop bridge websocket reconnect storm on repeated failures (#4156)
 
-### Core ([v0.2.0](https://github.com/iOfficeAI/AionCore/releases/tag/v0.2.0))
+### Core ([v0.2.1](https://github.com/iOfficeAI/AionCore/releases/tag/v0.2.1))
 
 #### ⚠ BREAKING CHANGES
 
@@ -22,6 +24,13 @@
 
 - **auth:** dual-token refresh with singleflight (#926)
 - **skills:** deliver skills through an AionUi-owned view instead of the workspace (#938)
+- **conversation:** route @@ mentions to the session-message skill (#949)
+- **scm:** enumerate a repository's linked worktrees during discovery (#959)
+- **session-message:** add session capabilities fallback to @@ blocks (#952)
+
+#### Bug Fixes
+
+- **session-message:** align recipient block capabilities wording with sender (#955)
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",
@@ -261,7 +261,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aioncoreVersion": "v0.2.0",
+  "aioncoreVersion": "v0.2.1",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
## [2.2.1](https://github.com/iOfficeAI/AionUi/compare/v2.1.61...v2.2.1) (2026-09-01)

> Note: v2.2.0 was packaged but never actually released, so this entry merges v2.2.0's changes together with the new commits since.

### Desktop

#### Features

- **conversation:** distinguish waiting-for-user state in sidebar and notify (#4198)
- **notification:** name the conversation in turn-completed notifications (#4195)
- **auth:** silently refresh WebUI session on 401 (#4175)

#### Bug Fixes

- **webui:** stop bridge websocket reconnect storm on repeated failures (#4156)

### Core ([v0.2.1](https://github.com/iOfficeAI/AionCore/releases/tag/v0.2.1))

#### ⚠ BREAKING CHANGES

- **skills:** deliver skills through an AionUi-owned view instead of the workspace (#938)

#### Features

- **auth:** dual-token refresh with singleflight (#926)
- **skills:** deliver skills through an AionUi-owned view instead of the workspace (#938)
- **conversation:** route @@ mentions to the session-message skill (#949)
- **scm:** enumerate a repository's linked worktrees during discovery (#959)
- **session-message:** add session capabilities fallback to @@ blocks (#952)

#### Bug Fixes

- **session-message:** align recipient block capabilities wording with sender (#955)