### PR TITLE
fix(chat): ignore enter while ime composition is active

### DIFF
--- a/packages/desktop/src/renderer/hooks/chat/useCompositionInput.ts
+++ b/packages/desktop/src/renderer/hooks/chat/useCompositionInput.ts
@@ -21,7 +21,9 @@ export const useCompositionInput = () => {
 
   const createKeyDownHandler = (onEnterPress: () => void, onKeyDownIntercept?: (e: React.KeyboardEvent) => boolean) => {
     return (e: React.KeyboardEvent) => {
-      if (isComposing.current) return;
+      // Safari can dispatch compositionend before the keydown that confirms
+      // the IME candidate, so the ref may already be false at this point.
+      if (isComposing.current || e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
       if (onKeyDownIntercept?.(e)) return;
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();

--- a/tests/unit/renderer/useCompositionInput.dom.test.ts
+++ b/tests/unit/renderer/useCompositionInput.dom.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2026 AionUi (aionui.com)
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useCompositionInput } from '@/renderer/hooks/chat/useCompositionInput';
+
+type KeyDownOptions = {
+  isComposing?: boolean;
+  key?: string;
+  keyCode?: number;
+  shiftKey?: boolean;
+};
+
+const createKeyDownEvent = ({
+  isComposing = false,
+  key = 'Enter',
+  keyCode = key === 'Enter' ? 13 : 0,
+  shiftKey = false,
+}: KeyDownOptions = {}) => {
+  const nativeEvent = new KeyboardEvent('keydown', { key, shiftKey });
+
+  Object.defineProperty(nativeEvent, 'isComposing', { configurable: true, value: isComposing });
+  Object.defineProperty(nativeEvent, 'keyCode', { configurable: true, value: keyCode });
+
+  return {
+    key,
+    nativeEvent,
+    preventDefault: vi.fn(),
+    shiftKey,
+  } as unknown as ReactKeyboardEvent;
+};
+
+describe('useCompositionInput Enter handling', () => {
+  it('does not send when Enter is pressed during tracked composition', () => {
+    const { result } = renderHook(() => useCompositionInput());
+    const onEnterPress = vi.fn();
+    const onKeyDown = result.current.createKeyDownHandler(onEnterPress);
+
+    act(() => {
+      result.current.compositionHandlers.onCompositionStartCapture();
+      onKeyDown(createKeyDownEvent());
+    });
+
+    expect(onEnterPress).not.toHaveBeenCalled();
+  });
+
+  it('does not send when the native keyboard event reports composition', () => {
+    const { result } = renderHook(() => useCompositionInput());
+    const onEnterPress = vi.fn();
+    const onKeyDown = result.current.createKeyDownHandler(onEnterPress);
+
+    act(() => {
+      onKeyDown(createKeyDownEvent({ isComposing: true }));
+    });
+
+    expect(onEnterPress).not.toHaveBeenCalled();
+  });
+
+  it('does not send when compositionend precedes the IME confirmation keydown', () => {
+    const { result } = renderHook(() => useCompositionInput());
+    const onEnterPress = vi.fn();
+    const onKeyDown = result.current.createKeyDownHandler(onEnterPress);
+
+    act(() => {
+      result.current.compositionHandlers.onCompositionStartCapture();
+      result.current.compositionHandlers.onCompositionEndCapture();
+      onKeyDown(createKeyDownEvent({ isComposing: false, keyCode: 229 }));
+    });
+
+    expect(onEnterPress).not.toHaveBeenCalled();
+  });
+
+  it('sends once for Enter after composition has ended', () => {
+    const { result } = renderHook(() => useCompositionInput());
+    const onEnterPress = vi.fn();
+    const onKeyDown = result.current.createKeyDownHandler(onEnterPress);
+
+    act(() => {
+      result.current.compositionHandlers.onCompositionStartCapture();
+      result.current.compositionHandlers.onCompositionEndCapture();
+      onKeyDown(createKeyDownEvent());
+    });
+
+    expect(onEnterPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends for regular Enter', () => {
+    const { result } = renderHook(() => useCompositionInput());
+    const onEnterPress = vi.fn();
+    const onKeyDown = result.current.createKeyDownHandler(onEnterPress);
+
+    act(() => {
+      onKeyDown(createKeyDownEvent());
+    });
+
+    expect(onEnterPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not send for Shift+Enter', () => {
+    const { result } = renderHook(() => useCompositionInput());
+    const onEnterPress = vi.fn();
+    const onKeyDown = result.current.createKeyDownHandler(onEnterPress);
+
+    act(() => {
+      onKeyDown(createKeyDownEvent({ shiftKey: true }));
+    });
+
+    expect(onEnterPress).not.toHaveBeenCalled();
+  });
+
+  it('preserves existing key interception before normal Enter sends', () => {
+    const { result } = renderHook(() => useCompositionInput());
+    const onEnterPress = vi.fn();
+    const onKeyDownIntercept = vi.fn(() => true);
+    const onKeyDown = result.current.createKeyDownHandler(onEnterPress, onKeyDownIntercept);
+
+    act(() => {
+      onKeyDown(createKeyDownEvent());
+    });
+
+    expect(onKeyDownIntercept).toHaveBeenCalledTimes(1);
+    expect(onEnterPress).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Prevent IME confirmation Enter from submitting the chat input while composition is still active or while WebKit reports the IME confirmation key as `keyCode === 229`.

The shared composition handler already tracked `compositionstart` / `compositionend`, but that ref alone can be cleared before the confirmation `keydown` arrives. This keeps the existing tracked state and also checks the native keyboard event's composition state plus the WebKit IME confirmation fallback.

## Behavior

- composing + Enter → does not send
- native `isComposing` + Enter → does not send
- `compositionend` followed by IME confirmation `keydown` (`keyCode === 229`) → does not send
- normal Enter after composition → sends once
- regular Enter → unchanged
- Shift+Enter → unchanged
- existing key interception/menu handling → unchanged

## Verification

- focused `useCompositionInput` tests: 7/7 pass
- full Vitest suite: 4,987 pass / 5 skipped
- `bun run format` — pass
- `bun run lint` — 0 errors
- `bunx tsc --noEmit` — pass
- i18n checks — pass

Fixes #4182.