### PR TITLE
fix(team): preserve empty antigravity model so agy does not receive literal 'default' (DEV-3230)

### DIFF
--- a/packages/desktop/src/common/adapter/teamMapper.ts
+++ b/packages/desktop/src/common/adapter/teamMapper.ts
@@ -163,7 +163,7 @@ export function toBackendAssistant(a: TeamAssistantInput): Record<string, unknow
   return {
     name: a.assistant_name,
     role: a.role === 'leader' ? 'lead' : a.role,
-    model: a.model || 'default',
+    model: a.model ?? 'default',
     assistant_id: a.assistant_id,
   };
 }

--- a/tests/unit/common-adapter/teamMapper.test.ts
+++ b/tests/unit/common-adapter/teamMapper.test.ts
@@ -197,4 +197,34 @@ describe('teamMapper', () => {
       })
     ).toThrow('assistant_id is required');
   });
+
+  it('preserves an empty model string so antigravity can omit the --model flag', () => {
+    expect(
+      toBackendAssistant({
+        role: 'teammate',
+        assistant_backend: 'antigravity',
+        assistant_name: 'Antigravity',
+        status: 'pending',
+        assistant_id: 'assistant-antigravity',
+        model: '',
+      })
+    ).toMatchObject({
+      model: '',
+    });
+  });
+
+  it('falls back to the default placeholder only when model is missing', () => {
+    expect(
+      toBackendAssistant({
+        role: 'teammate',
+        assistant_backend: 'claude',
+        assistant_name: 'Writer',
+        status: 'pending',
+        assistant_id: 'assistant-writer',
+        model: undefined as unknown as string,
+      })
+    ).toMatchObject({
+      model: 'default',
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Antigravity (agy) assistants added as team members fail every turn with  because the team-slot conversation ends up with  literally set to the string "default". That literal is forwarded to the agy CLI as , which agy does not recognize.

## Root cause

 already returns an empty string for antigravity teammates so that aioncore can let agy pick its own default model. However,  coerced any falsy  value back to  before sending it to the backend, undoing the resolver's antigravity handling.

## Fix

Change the fallback in  from  to  so that an empty string is preserved for antigravity while / still falls back to  for other backends that rely on the placeholder.

## Testing

- Added unit tests in  covering:
  - empty string is preserved for antigravity
  - missing model still falls back to 
- Ran 
[1m[46m RUN [49m[22m [36mv4.1.0 [39m[90m/Users/randy/src/aionui[39m

 [32m✓[39m [30m[43m node [49m[39m tests/unit/common-adapter/teamMapper.test.ts [2m([22m[2m23 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m [30m[43m node [49m[39m tests/unit/renderer/teamCreateModelResolver.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 8[2mms[22m[39m

[2m Test Files [22m [1m[32m2 passed[39m[22m[90m (2)[39m
[2m      Tests [22m [1m[32m31 passed[39m[22m[90m (31)[39m
[2m   Start at [22m 02:25:30
[2m   Duration [22m 215ms[2m (transform 113ms, setup 85ms, import 59ms, tests 15ms, environment 0ms)[22m → 31 passed
- Ran 
[1m[46m RUN [49m[22m [36mv4.1.0 [39m[90m/Users/randy/src/aionui[39m

 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/useTeamWarmup.dom.test.tsx [2m([22m[2m14 tests[22m[2m)[22m[33m 353[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/useTeamActivityFeed.dom.test.tsx [2m([22m[2m9 tests[22m[2m)[22m[33m 621[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/ActivityControlBar.dom.test.tsx [2m([22m[2m5 tests[22m[2m)[22m[33m 539[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/TeamTabs.dom.test.tsx [2m([22m[2m4 tests[22m[2m)[22m[32m 92[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/useTeamListStoragePrune.dom.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 102[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/activityCards.dom.test.tsx [2m([22m[2m5 tests[22m[2m)[22m[32m 195[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/useBlockerTaskResolver.dom.test.tsx [2m([22m[2m3 tests[22m[2m)[22m[32m 84[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/TeamAddMemberPopover.dom.test.tsx [2m([22m[2m8 tests[22m[2m)[22m[32m 244[2mms[22m[39m
[90mstdout[2m | tests/unit/renderer/team/TeamChatView.dom.test.tsx[2m > [22m[2mTeamChatView[2m > [22m[2mpasses loaded skills and MCP snapshot to AionRS team chat
[22m[39m[httpBridge] GET /api/settings/client?keys=google.config (no body)
[httpBridge] GET /api/providers (no body)

 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/TeamChatView.dom.test.tsx [2m([22m[2m13 tests[22m[2m)[22m[33m 723[2mms[22m[39m
     [33m[2m✓[22m[39m prefers preset assistant backend over legacy conversation extra backend [33m 316[2mms[22m[39m
     [33m[2m✓[22m[39m passes loaded skills and MCP snapshot to AionRS team chat [33m 318[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/useTeamListCronCleanup.dom.test.tsx [2m([22m[2m1 test[22m[2m)[22m[32m 76[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/TaskCardInteraction.dom.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[32m 102[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/TeammateMessageAvatar.dom.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[32m 43[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/TeamWarmupOverlay.dom.test.tsx [2m([22m[2m4 tests[22m[2m)[22m[32m 102[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/activityLayouts.dom.test.tsx [2m([22m[2m6 tests[22m[2m)[22m[32m 131[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/TeamAgentIdentity.dom.test.tsx [2m([22m[2m4 tests[22m[2m)[22m[32m 86[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/TaskCardBlocked.dom.test.tsx [2m([22m[2m3 tests[22m[2m)[22m[32m 70[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/useTeamActivityControls.dom.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 40[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/TeamChatEmptyState.dom.test.tsx [2m([22m[2m4 tests[22m[2m)[22m[32m 94[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/activityCardTime.dom.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[32m 84[2mms[22m[39m
 [32m✓[39m [30m[43m node [49m[39m tests/unit/renderer/teamCreateModelResolver.test.ts [2m([22m[2m8 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m [30m[43m node [49m[39m tests/unit/renderer/team/removeTeamAssistantWithCronCleanup.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 6[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/useTeamViewMode.dom.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 9[2mms[22m[39m
 [32m✓[39m [30m[43m node [49m[39m tests/unit/renderer/team/teamMemberColors.test.ts [2m([22m[2m10 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m [30m[43m node [49m[39m tests/unit/renderer/teamSendRuntime.test.ts [2m([22m[2m20 tests[22m[2m)[22m[32m 12[2mms[22m[39m
 [32m✓[39m [30m[43m node [49m[39m tests/unit/renderer/team/activityTypes.test.ts [2m([22m[2m7 tests[22m[2m)[22m[32m 4[2mms[22m[39m
 [32m✓[39m [30m[43m node [49m[39m tests/unit/renderer/team/activityTime.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 5[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/teamStorage.dom.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/useIsClamped.dom.test.ts [2m([22m[2m2 tests[22m[2m)[22m[32m 14[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/useTeamSessionCronCleanup.dom.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 39[2mms[22m[39m
 [32m✓[39m [30m[43m node [49m[39m tests/unit/renderer/teamRuntimeUiRemoved.test.ts [2m([22m[2m1 test[22m[2m)[22m[32m 1[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/TeamPageCronJobManager.dom.test.tsx [2m([22m[2m2 tests[22m[2m)[22m[32m 200[2mms[22m[39m
 [32m✓[39m [30m[43m node [49m[39m tests/unit/renderer/team/assistantSelectUtils.test.ts [2m([22m[2m3 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m [30m[43m node [49m[39m tests/unit/renderer/team/simplifyWarmupError.test.ts [2m([22m[2m4 tests[22m[2m)[22m[32m 2[2mms[22m[39m
 [32m✓[39m [30m[45m dom [49m[39m tests/unit/renderer/team/TeamPageWarmup.dom.test.tsx [2m([22m[2m10 tests[22m[2m)[22m[33m 1512[2mms[22m[39m
     [33m[2m✓[22m[39m withholds the trigger while the team is warming (isWarmingUp) [33m 426[2mms[22m[39m
     [33m[2m✓[22m[39m targets the selected teammate through the dedicated context-reset action [33m 310[2mms[22m[39m
     [33m[2m✓[22m[39m reports completed reset with failed restart as localized partial success [33m 304[2mms[22m[39m

[2m Test Files [22m [1m[32m34 passed[39m[22m[90m (34)[39m
[2m      Tests [22m [1m[32m176 passed[39m[22m[90m (176)[39m
[2m   Start at [22m 02:25:31
[2m   Duration [22m 8.78s[2m (transform 4.90s, setup 2.34s, import 36.32s, tests 5.60s, environment 20.16s)[22m → 176 passed
- Ran Found 0 warnings and 0 errors.
Finished in 14ms on 0 files with 128 rules using 10 threads. → 0 warnings/errors

Fixes behavior described in DEV-3230.