### PR TITLE
fix(team): stop persisting literal default as antigravity model

### DIFF
--- a/packages/desktop/src/common/adapter/teamMapper.ts
+++ b/packages/desktop/src/common/adapter/teamMapper.ts
@@ -163,7 +163,11 @@ export function toBackendAssistant(a: TeamAssistantInput): Record<string, unknow
   return {
     name: a.assistant_name,
     role: a.role === 'leader' ? 'lead' : a.role,
-    model: a.model || 'default',
+    // Preserve empty string: antigravity teammates resolve to '' so aioncore
+    // omits --model and agy uses its own default. `||` coerced that to the
+    // literal 'default', which agy rejects as UserLlmProviderModelNotFound.
+    // Undefined still falls back to 'default' for aionrs / claude / other ACP.
+    model: a.model ?? 'default',
     assistant_id: a.assistant_id,
   };
 }

--- a/packages/desktop/src/renderer/pages/team/TeamPage.tsx
+++ b/packages/desktop/src/renderer/pages/team/TeamPage.tsx
@@ -37,6 +37,7 @@ import { TeamPermissionProvider, useTeamPermission } from './hooks/TeamPermissio
 import { useTeamSession } from './hooks/useTeamSession';
 import { useTeamRunView, type TeamRunViewState } from './hooks/useTeamRunView';
 import { getConversationOrNull } from '@/renderer/pages/conversation/utils/conversationCache';
+import { isAntigravityPlaceholderModelId } from './components/teamCreateModelResolver';
 import { useActiveLease } from '@/renderer/pages/conversation/hooks/useActiveLease';
 import { resolveTeamWorkspaceView } from './utils/teamWorkspaceView';
 import { usePreviewContext } from '@/renderer/pages/conversation/Preview';
@@ -399,7 +400,10 @@ const AssistantChatSlot: React.FC<{
   );
 
   const isAionrs = conversation?.type === 'aionrs';
-  const initialModelId = (conversation?.extra as { current_model_id?: string })?.current_model_id;
+  const persistedModelId = (conversation?.extra as { current_model_id?: string })?.current_model_id;
+  const initialModelId = isAntigravityPlaceholderModelId(assistant.assistant_backend, persistedModelId)
+    ? undefined
+    : persistedModelId;
   const isAcpLike = conversation?.type === 'acp' || isAcpLikeBackend(assistant.assistant_backend);
   const cronJobId = resolveCronJobId(conversation?.extra);
   // No model-change handler here on purpose: the team config-option request that
@@ -456,6 +460,7 @@ const AssistantChatSlot: React.FC<{
                 conversation_id={assistant.conversation_id}
                 backend={assistant.assistant_backend}
                 initialModelId={initialModelId}
+                prepareRuntime={teamPermission?.warmupSession}
                 prepareSetRuntime={teamPermission?.warmupSession}
                 configOptionsPort={teamPermission?.configOptionsPort}
                 warmup={warmup}

--- a/packages/desktop/src/renderer/pages/team/components/teamCreateModelResolver.ts
+++ b/packages/desktop/src/renderer/pages/team/components/teamCreateModelResolver.ts
@@ -53,12 +53,29 @@ async function resolveAssistantDetail(assistant_id?: string): Promise<AssistantD
   }
 }
 
+const ANTIGRAVITY_PLACEHOLDER_MODEL_IDS = new Set(['default', 'auto']);
+
+/**
+ * True when a stored model id is a placeholder, not a real agy model.
+ * Team slots must not persist these as `current_model_id` — solo omits them
+ * so agy resolves auto; a literal "default" fails every team turn.
+ */
+export function isAntigravityPlaceholderModelId(backend: string | undefined, modelId: string | undefined): boolean {
+  if (backend !== 'antigravity' || modelId == null) return false;
+  const trimmed = modelId.trim();
+  return trimmed === '' || ANTIGRAVITY_PLACEHOLDER_MODEL_IDS.has(trimmed);
+}
+
 function resolveAssistantModel(detail: AssistantDetail): string | undefined {
+  const backend = assistantRuntimeKey({ agent: detail.engine?.agent });
+
   if (detail.defaults.model.mode === 'fixed' && detail.defaults.model.value) {
+    if (isAntigravityPlaceholderModelId(backend, detail.defaults.model.value)) return undefined;
     return detail.defaults.model.value;
   }
 
   if (detail.defaults.model.mode === 'auto' && detail.preferences.last_model_id) {
+    if (isAntigravityPlaceholderModelId(backend, detail.preferences.last_model_id)) return undefined;
     return detail.preferences.last_model_id;
   }
 

--- a/tests/unit/common-adapter/teamMapper.test.ts
+++ b/tests/unit/common-adapter/teamMapper.test.ts
@@ -197,4 +197,42 @@ describe('teamMapper', () => {
       })
     ).toThrow('assistant_id is required');
   });
+
+  it('preserves an empty model so antigravity teammates do not persist literal default', () => {
+    expect(
+      toBackendAssistant({
+        role: 'teammate',
+        assistant_backend: 'antigravity',
+        assistant_name: 'Agy',
+        status: 'pending',
+        assistant_id: 'assistant-agy',
+        model: '',
+      })
+    ).toMatchObject({ model: '' });
+  });
+
+  it('falls back to default when the team payload omits model', () => {
+    expect(
+      toBackendAssistant({
+        role: 'teammate',
+        assistant_backend: 'claude',
+        assistant_name: 'Claude',
+        status: 'pending',
+        assistant_id: 'assistant-claude',
+      })
+    ).toMatchObject({ model: 'default' });
+  });
+
+  it('keeps an explicit model id', () => {
+    expect(
+      toBackendAssistant({
+        role: 'teammate',
+        assistant_backend: 'codex',
+        assistant_name: 'Writer',
+        status: 'pending',
+        assistant_id: 'assistant-writer',
+        model: 'gpt-5',
+      })
+    ).toMatchObject({ model: 'gpt-5' });
+  });
 });

--- a/tests/unit/renderer/team/TeamPageWarmup.dom.test.tsx
+++ b/tests/unit/renderer/team/TeamPageWarmup.dom.test.tsx
@@ -31,7 +31,16 @@ const {
   });
   return {
     getConversationOrNullMock: vi.fn(),
-    acpSelectorPropsBySlot: new Map<string, { status: string; trigger?: () => Promise<void> }>(),
+    acpSelectorPropsBySlot: new Map<
+      string,
+      {
+        status?: string;
+        trigger?: () => Promise<void>;
+        prepareRuntime?: () => Promise<void>;
+        prepareSetRuntime?: () => Promise<void>;
+        initialModelId?: string;
+      }
+    >(),
     restartPropsBySlot: new Map<string, { availability: string; disabled?: boolean; disabledReason?: string }>(),
     ensureSessionMock: vi.fn(async () => undefined),
     teamEventHandlers: handlers,
@@ -138,8 +147,20 @@ vi.mock('@/renderer/pages/conversation/components/ChatLayout', () => ({
 // Probe: capture the warmup prop each slot's AcpModelSelector receives, keyed by conversation_id.
 vi.mock('@/renderer/components/agent/AcpModelSelector', () => ({
   __esModule: true,
-  default: (props: { conversation_id: string; warmup?: { status: string; trigger?: () => Promise<void> } }) => {
-    if (props.warmup) acpSelectorPropsBySlot.set(props.conversation_id, props.warmup);
+  default: (props: {
+    conversation_id: string;
+    warmup?: { status: string; trigger?: () => Promise<void> };
+    prepareRuntime?: () => Promise<void>;
+    prepareSetRuntime?: () => Promise<void>;
+    initialModelId?: string;
+  }) => {
+    acpSelectorPropsBySlot.set(props.conversation_id, {
+      status: props.warmup?.status,
+      trigger: props.warmup?.trigger,
+      prepareRuntime: props.prepareRuntime,
+      prepareSetRuntime: props.prepareSetRuntime,
+      initialModelId: props.initialModelId,
+    });
     return <div data-testid={`acp-model-selector-${props.conversation_id}`} />;
   },
 }));
@@ -459,6 +480,49 @@ describe('TeamPage teammate warmup wiring', () => {
     expect(screen.getAllByText('team.agentActions.disabled.unsupported').length).toBeGreaterThan(0);
     expect(getComputedStyle(contextResetTitle).pointerEvents).toBe('none');
     expect(modalConfirmMock).not.toHaveBeenCalled();
+  });
+
+  it('warms the team session before fetching teammate model options', async () => {
+    ensureSessionMock.mockResolvedValue(undefined);
+
+    render(
+      <MemoryRouter>
+        <TeamPage team={team()} />
+      </MemoryRouter>
+    );
+
+    await screen.findByTestId('acp-model-selector-member-conv');
+    await waitFor(() => expect(acpSelectorPropsBySlot.get('member-conv')?.prepareRuntime).toBeInstanceOf(Function));
+    expect(acpSelectorPropsBySlot.get('member-conv')?.prepareSetRuntime).toBeInstanceOf(Function);
+
+    ensureSessionMock.mockClear();
+    await act(async () => {
+      await acpSelectorPropsBySlot.get('member-conv')!.prepareRuntime!();
+    });
+    expect(ensureSessionMock).toHaveBeenCalledWith({ team_id: 'team-1' });
+  });
+
+  it('does not seed the teammate picker with a literal antigravity default model id', async () => {
+    ensureSessionMock.mockResolvedValue(undefined);
+    const antigravityTeam = team();
+    antigravityTeam.assistants[1].assistant_backend = 'antigravity';
+    getConversationOrNullMock.mockImplementation(async (id: string) =>
+      conversation({
+        id,
+        name: id,
+        extra: id === 'member-conv' ? { current_model_id: 'default' } : {},
+      })
+    );
+
+    render(
+      <MemoryRouter>
+        <TeamPage team={antigravityTeam} />
+      </MemoryRouter>
+    );
+
+    await screen.findByTestId('acp-model-selector-member-conv');
+    await waitFor(() => expect(acpSelectorPropsBySlot.has('member-conv')).toBe(true));
+    expect(acpSelectorPropsBySlot.get('member-conv')?.initialModelId).toBeUndefined();
   });
 
   it('uses the same teammate action menu on mobile', async () => {

--- a/tests/unit/renderer/teamCreateModelResolver.test.ts
+++ b/tests/unit/renderer/teamCreateModelResolver.test.ts
@@ -18,7 +18,10 @@ vi.mock('@/common', () => ({
   },
 }));
 
-import { resolveDefaultTeamAgentModel } from '@/renderer/pages/team/components/teamCreateModelResolver';
+import {
+  isAntigravityPlaceholderModelId,
+  resolveDefaultTeamAgentModel,
+} from '@/renderer/pages/team/components/teamCreateModelResolver';
 
 describe('resolveDefaultTeamAgentModel', () => {
   beforeEach(() => {
@@ -147,5 +150,68 @@ describe('resolveDefaultTeamAgentModel', () => {
         assistant_backend: 'claude',
       })
     ).resolves.toBe('default');
+  });
+
+  it('treats a remembered antigravity default/auto last_model_id as unset', async () => {
+    getAssistantMock.mockResolvedValue({
+      defaults: {
+        model: { mode: 'auto' },
+      },
+      preferences: {
+        last_model_id: 'default',
+      },
+      engine: {
+        agent_id: 'agy-agent',
+        agent: {
+          id: 'agy-agent',
+          type: 'acp',
+          source: 'builtin',
+          acp_backend: 'antigravity',
+        },
+      },
+    });
+
+    await expect(
+      resolveDefaultTeamAgentModel({
+        assistant_id: 'assistant-antigravity',
+      })
+    ).resolves.toBe('');
+  });
+
+  it('keeps a real remembered antigravity model id', async () => {
+    getAssistantMock.mockResolvedValue({
+      defaults: {
+        model: { mode: 'auto' },
+      },
+      preferences: {
+        last_model_id: 'gemini-3-pro',
+      },
+      engine: {
+        agent_id: 'agy-agent',
+        agent: {
+          id: 'agy-agent',
+          type: 'acp',
+          source: 'builtin',
+          acp_backend: 'antigravity',
+        },
+      },
+    });
+
+    await expect(
+      resolveDefaultTeamAgentModel({
+        assistant_id: 'assistant-antigravity',
+      })
+    ).resolves.toBe('gemini-3-pro');
+  });
+});
+
+describe('isAntigravityPlaceholderModelId', () => {
+  it('detects placeholder ids only for antigravity', () => {
+    expect(isAntigravityPlaceholderModelId('antigravity', 'default')).toBe(true);
+    expect(isAntigravityPlaceholderModelId('antigravity', 'auto')).toBe(true);
+    expect(isAntigravityPlaceholderModelId('antigravity', '')).toBe(true);
+    expect(isAntigravityPlaceholderModelId('antigravity', 'gemini-3-pro')).toBe(false);
+    expect(isAntigravityPlaceholderModelId('claude', 'default')).toBe(false);
+    expect(isAntigravityPlaceholderModelId(undefined, 'default')).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

Antigravity (`agy`) teammates fail every turn with `UserLlmProviderModelNotFound` because the team-slot conversation persists the literal string `default` as `current_model_id` and forwards it as `--model`. Solo chat omits the model so agy resolves auto.

Secondary: the teammate model picker never fetches. `AcpModelSelector.reload()` warms via `prepareRuntime`, but TeamPage only passed `prepareSetRuntime`, so `GET /config-options` hits `TEAM_RUNTIME_NOT_READY` (409) with no retry and the picker spins.

## Fix

- `toBackendAssistant`: `a.model ?? 'default'` so an empty antigravity model stays empty (aioncore omits `--model`). Other backends that omit model still get `'default'`.
- Resolver: treat antigravity `last_model_id` of `default` / `auto` as unset, matching solo.
- TeamPage: pass `prepareRuntime={warmupSession}` so the picker warms then fetches models. Strip a persisted antigravity `default` so existing slots do not pin the fake id.

## Testing

`bun run test` — 4988 passed, 5 skipped.

Focused:
- `tests/unit/common-adapter/teamMapper.test.ts`
- `tests/unit/renderer/teamCreateModelResolver.test.ts`
- `tests/unit/renderer/team/TeamPageWarmup.dom.test.tsx`

Linear: DEV-3230. Do not merge; Lynn merges on green.

Supersedes mapper-only https://github.com/iOfficeAI/AionUi/pull/4216 (missing picker warmup).