### PR TITLE
fix: use real packaged data path for Codex workspaces

### DIFF
--- a/packages/desktop/src/process/utils/utils.ts
+++ b/packages/desktop/src/process/utils/utils.ts
@@ -98,6 +98,12 @@ const ensureCliSafeSymlink = (targetPath: string, symlinkName: string): string =
 export const getDataPath = (): string => {
   const rootPath = getElectronPathOrFallback('userData');
   const dataPath = path.join(rootPath, 'aionui');
+  // Codex validates writable roots lexically and rejects a symlinked root.
+  // Packaged AionUI therefore passes the real Application Support path to the
+  // backend; dev keeps the historical CLI-safe symlink isolation.
+  if (getPlatformServices().paths.isPackaged()) {
+    return dataPath;
+  }
   return ensureCliSafeSymlink(dataPath, getEnvAwareName('.aionui'));
 };
 


### PR DESCRIPTION
## Summary
- use Electron userData directly for packaged AionUI
- keep the existing CLI-safe symlink isolation for development

## Validation
- packaged arm64 AionUI launched from /Applications
- bundled AionCore started and Codex produced a real response
- Velorn MCP gateway tools/list plus reversible checkpoint/marker/undo flow passed
- post-restart conversation persisted

This prevents Codex CLI from rejecting the packaged writable root because the historical ~/.aionui path is a symlink.