### PR TITLE
fix(conversation): keep older-history pagination reliable during running turns

### DIFF
--- a/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/MessageList.tsx
@@ -150,6 +150,14 @@ const highlightStyle: React.CSSProperties = {
 
 const getUnhandledMessageType = (_message: never): string => 'unknown';
 
+// A running turn folds consecutive tool calls into one summary card and drops
+// hidden/plan rows, so a 50-row DB page can render as just a few short cards —
+// too short to overflow the scroller. Without a scrollbar `onScroll` never
+// fires, so `handleMessageListScroll`'s older-page trigger can never run even
+// though more history exists. Cap how many pages we'll pull just to fill the
+// viewport so a pathological conversation can't trigger unbounded fetching.
+const MAX_VIEWPORT_FILL_PAGES = 5;
+
 // Image preview context
 export const ImagePreviewContext = createContext<{ inPreviewGroup: boolean }>({ inPreviewGroup: false });
 
@@ -562,6 +570,24 @@ const MessageList: React.FC<{ className?: string; emptySlot?: React.ReactNode }>
     },
     [handleScroll, loadPreviousMessagePage, pagination.hasMoreBefore, pagination.isLoadingBefore]
   );
+
+  const viewportFillPagesRef = useRef(0);
+
+  // See MAX_VIEWPORT_FILL_PAGES above: keep pulling older pages after mount
+  // (and after each prepend) as long as the rendered content still fits inside
+  // the scroller without a scrollbar, so scroll-triggered pagination has a
+  // scrollbar to trigger on.
+  useEffect(() => {
+    const scroller = scrollerElementRef.current;
+    const content = contentElementRef.current;
+    if (!scroller || !content) return;
+    if (!pagination.hasMoreBefore || pagination.isLoadingBefore) return;
+    if (viewportFillPagesRef.current >= MAX_VIEWPORT_FILL_PAGES) return;
+    if (content.scrollHeight > scroller.clientHeight) return;
+
+    viewportFillPagesRef.current += 1;
+    void loadPreviousMessagePage();
+  }, [pagination.hasMoreBefore, pagination.isLoadingBefore, processedList, loadPreviousMessagePage]);
 
   useEffect(() => {
     if (!targetMessageId || processedList.length === 0) {

--- a/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/hooks.ts
@@ -943,26 +943,39 @@ export const useMessageLstCache = (key: string) => {
   useEffect(() => {
     listRef.current = list;
   }, [list]);
-  const loadMessages = useCallback(async (): Promise<TMessage[]> => {
-    const result = await loadLatestConversationMessages(key, {
-      limit: DEFAULT_MESSAGE_PAGE_LIMIT,
-      contentMode: 'compact',
-    });
-    const messages = result?.items?.map(normalizeDbMessage);
-    if (messages && Array.isArray(messages)) {
-      update((currentList) => mergeLoadedPageWithCurrent(key, messages, currentList));
-      setPagination({
-        oldestCursor: result.oldest_cursor ?? undefined,
-        newestCursor: result.newest_cursor ?? undefined,
-        hasMoreBefore: result.has_more_before,
-        hasMoreAfter: result.has_more_after,
-        isLoadingBefore: false,
-        isLoadingAnchor: false,
+  const loadMessages = useCallback(
+    async (options?: { preservePaginationBefore?: boolean }): Promise<TMessage[]> => {
+      const result = await loadLatestConversationMessages(key, {
+        limit: DEFAULT_MESSAGE_PAGE_LIMIT,
+        contentMode: 'compact',
       });
-      return messages;
-    }
-    return [];
-  }, [key, setPagination, update]);
+      const messages = result?.items?.map(normalizeDbMessage);
+      if (messages && Array.isArray(messages)) {
+        update((currentList) => mergeLoadedPageWithCurrent(key, messages, currentList));
+        setPagination((current) =>
+          options?.preservePaginationBefore
+            ? {
+                ...current,
+                newestCursor: result.newest_cursor ?? undefined,
+                hasMoreAfter: result.has_more_after,
+                isLoadingBefore: false,
+                isLoadingAnchor: false,
+              }
+            : {
+                oldestCursor: result.oldest_cursor ?? undefined,
+                newestCursor: result.newest_cursor ?? undefined,
+                hasMoreBefore: result.has_more_before,
+                hasMoreAfter: result.has_more_after,
+                isLoadingBefore: false,
+                isLoadingAnchor: false,
+              }
+        );
+        return messages;
+      }
+      return [];
+    },
+    [key, setPagination, update]
+  );
 
   useEffect(() => {
     if (!key) return;
@@ -1061,7 +1074,10 @@ export const useMessageLstCache = (key: string) => {
       );
 
       if (hasPendingDelivery) {
-        void loadMessages().catch((error) => {
+        // Preserve any older-page pagination progress the user already loaded by
+        // scrolling up — this reload is a reconciliation of the newest page, not
+        // a fresh mount, so it must not discard `oldestCursor`/`hasMoreBefore`.
+        void loadMessages({ preservePaginationBefore: true }).catch((error) => {
           console.error('[useMessageLstCache] Failed to reconcile pending messages after turn completion:', error);
         });
       }

--- a/packages/desktop/src/renderer/pages/conversation/Messages/useAutoScroll.ts
+++ b/packages/desktop/src/renderer/pages/conversation/Messages/useAutoScroll.ts
@@ -53,7 +53,6 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
 
   const userScrolledRef = useRef(false);
   const lastScrollTopRef = useRef(0);
-  const previousListLengthRef = useRef(messages.length);
   const previousLastMessageRef = useRef<TMessage | undefined>(messages[messages.length - 1]);
   const lastProgrammaticScrollTimeRef = useRef(0);
   const initialScrollDoneRef = useRef(false);
@@ -200,17 +199,19 @@ export function useAutoScroll({ messages, itemCount }: UseAutoScrollOptions): Us
   }, [itemCount, scrollerEl, scrollToBottom]);
 
   useEffect(() => {
-    const currentListLength = messages.length;
-    const previousLength = previousListLengthRef.current;
     const lastMessage = messages[messages.length - 1];
     const previousLastMessage = previousLastMessageRef.current;
-    const isNewMessage = currentListLength > previousLength;
-    const isLastMessageUpdated = currentListLength > 0 && lastMessage !== previousLastMessage;
+    // A prepended history page also grows `messages.length`, so length alone
+    // can't tell "a message arrived" from "older history loaded ahead of the
+    // unchanged tail". Identify the tail by id: a different id means a genuinely
+    // new message landed at the bottom; the same id with a different object means
+    // the existing tail was updated in place (e.g. streaming content).
+    const isNewTailMessage = lastMessage?.id !== previousLastMessage?.id;
+    const isLastMessageUpdated = !isNewTailMessage && lastMessage !== previousLastMessage;
 
-    previousListLengthRef.current = currentListLength;
     previousLastMessageRef.current = lastMessage;
 
-    if (!isNewMessage) {
+    if (!isNewTailMessage) {
       if (isLastMessageUpdated) {
         scheduleAutoFollow();
       }

--- a/tests/unit/renderer/messageList.dom.test.tsx
+++ b/tests/unit/renderer/messageList.dom.test.tsx
@@ -5,17 +5,29 @@
  */
 
 import React, { type PropsWithChildren } from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ipcBridge } from '@/common';
 import type { IMessageAcpToolCall, IMessageText, IMessageToolGroup, TMessage } from '@/common/chat/chatLib';
 import type { MessageFileChangesProps } from '@/renderer/pages/conversation/Messages/MessageFileChanges';
 import {
   MessageListLoadingProvider,
   MessageListProvider,
   MessagePaginationProvider,
+  type MessagePaginationState,
   useUpdateMessageList,
 } from '@/renderer/pages/conversation/Messages/hooks';
 import MessageList from '@/renderer/pages/conversation/Messages/MessageList';
+
+vi.mock('@/common', () => ({
+  ipcBridge: {
+    database: {
+      getConversationMessages: {
+        invoke: vi.fn(),
+      },
+    },
+  },
+}));
 
 const { parseDiffMock, useTeamPermissionMock } = vi.hoisted(() => ({
   parseDiffMock: vi.fn(),
@@ -156,6 +168,10 @@ vi.mock('@/renderer/pages/conversation/Messages/components/SelectionReplyButton'
   default: () => null,
 }));
 
+vi.mock('@/renderer/pages/conversation/Messages/anchorRail', () => ({
+  MessageAnchorRail: () => null,
+}));
+
 vi.mock('@icon-park/react', () => ({
   Down: () => <span>down</span>,
 }));
@@ -233,12 +249,11 @@ function Wrapper({
   children,
   messages = [createTextMessage()],
   loading = false,
-}: PropsWithChildren<{ messages?: TMessage[]; loading?: boolean }>): JSX.Element {
+  pagination = { hasMoreBefore: false, hasMoreAfter: false, isLoadingBefore: false, isLoadingAnchor: false },
+}: PropsWithChildren<{ messages?: TMessage[]; loading?: boolean; pagination?: MessagePaginationState }>): JSX.Element {
   return (
     <MessageListLoadingProvider value={loading}>
-      <MessagePaginationProvider
-        value={{ hasMoreBefore: false, hasMoreAfter: false, isLoadingBefore: false, isLoadingAnchor: false }}
-      >
+      <MessagePaginationProvider value={pagination}>
         <MessageListProvider value={messages}>{children}</MessageListProvider>
       </MessagePaginationProvider>
     </MessageListLoadingProvider>
@@ -262,6 +277,7 @@ describe('MessageList', () => {
       diff: 'diff',
     });
     useTeamPermissionMock.mockReturnValue(null);
+    vi.mocked(ipcBridge.database.getConversationMessages.invoke).mockReset();
   });
 
   it('never renders a plan as a stream row (it belongs to ConversationPlanBar)', () => {
@@ -656,5 +672,53 @@ describe('MessageList', () => {
     expect(screen.getByTestId('tool-summary')).toHaveTextContent(message.id);
     expect(screen.queryByTestId('file-changes')).not.toBeInTheDocument();
     expect(screen.queryByTestId('tool-group')).not.toBeInTheDocument();
+  });
+
+  it('auto-loads more history to fill the viewport when the initial page does not overflow the scroller', async () => {
+    // A running turn folds tool calls into short summary cards, so a page can
+    // render without a scrollbar even though older history remains. Without
+    // this, scroll-triggered pagination never gets a scrollbar to trigger on.
+    const invoke = vi.mocked(ipcBridge.database.getConversationMessages.invoke);
+    invoke.mockResolvedValueOnce({
+      items: [],
+      oldest_cursor: 'cursor-older',
+      newest_cursor: 'cursor-latest',
+      has_more_before: false,
+      has_more_after: false,
+    });
+
+    render(<MessageList />, {
+      wrapper: ({ children }) => (
+        <Wrapper
+          pagination={{
+            hasMoreBefore: true,
+            hasMoreAfter: false,
+            isLoadingBefore: false,
+            isLoadingAnchor: false,
+            oldestCursor: 'cursor-latest',
+          }}
+        >
+          {children}
+        </Wrapper>
+      ),
+    });
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(expect.objectContaining({ before: 'cursor-latest' }));
+    });
+  });
+
+  it('does not auto-load history when there is no older page to fetch', async () => {
+    const invoke = vi.mocked(ipcBridge.database.getConversationMessages.invoke);
+
+    render(<MessageList />, {
+      wrapper: ({ children }) => <Wrapper>{children}</Wrapper>,
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(invoke).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/renderer/messageMerging.dom.test.tsx
+++ b/tests/unit/renderer/messageMerging.dom.test.tsx
@@ -14,8 +14,10 @@ import {
   MessageListProvider,
   MessagePaginationProvider,
   useAddOrUpdateMessage,
+  useLoadPreviousMessagePage,
   useMessageLstCache,
   useMessageList,
+  useMessagePaginationState,
   useReplaceWithAnchorWindow,
 } from '@/renderer/pages/conversation/Messages/hooks';
 
@@ -521,6 +523,108 @@ describe('message merging', () => {
     });
 
     expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('preserves older-page pagination progress across a turnCompleted reconciliation reload', async () => {
+    const invoke = vi.mocked(ipcBridge.database.getConversationMessages.invoke);
+    invoke.mockResolvedValueOnce({
+      items: [],
+      oldest_cursor: 'cursor-latest',
+      newest_cursor: 'cursor-latest',
+      has_more_before: true,
+      has_more_after: false,
+    });
+
+    let emitUserCreated: ((payload: any) => void) | undefined;
+    let emitTurnCompleted: ((payload: any) => void) | undefined;
+    vi.mocked(ipcBridge.conversation.userCreated.on).mockImplementation((cb: any) => {
+      emitUserCreated = cb;
+      return () => {};
+    });
+    vi.mocked(ipcBridge.conversation.turnCompleted.on).mockImplementation((cb: any) => {
+      emitTurnCompleted = cb;
+      return () => {};
+    });
+
+    function useCacheAndPaginationHarness() {
+      useMessageLstCache(CONVERSATION_ID);
+      return {
+        messages: useMessageList(),
+        pagination: useMessagePaginationState(),
+        loadPreviousMessagePage: useLoadPreviousMessagePage(CONVERSATION_ID),
+      };
+    }
+
+    const { result } = renderHook(() => useCacheAndPaginationHarness(), { wrapper: CacheWrapper });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current.pagination.hasMoreBefore).toBe(true);
+
+    // User scrolls up and loads an older page before the turn finishes.
+    invoke.mockResolvedValueOnce({
+      items: [],
+      oldest_cursor: 'cursor-older',
+      newest_cursor: 'cursor-latest',
+      has_more_before: true,
+      has_more_after: false,
+    });
+
+    await act(async () => {
+      await result.current.loadPreviousMessagePage();
+    });
+
+    expect(result.current.pagination.oldestCursor).toBe('cursor-older');
+
+    act(() => {
+      emitUserCreated?.({
+        conversation_id: CONVERSATION_ID,
+        msg_id: 'msg-midturn-5',
+        content: 'sent mid-turn',
+        position: 'right',
+        status: 'pending',
+        hidden: false,
+        created_at: Date.now(),
+      });
+    });
+
+    // The reconcile reload only re-fetches the newest page, so taken alone it
+    // reports no older history. That must not clobber the older-page progress
+    // the user already loaded above.
+    invoke.mockResolvedValueOnce({
+      items: [
+        {
+          id: 'msg-midturn-5',
+          msg_id: 'msg-midturn-5',
+          conversation_id: CONVERSATION_ID,
+          type: 'text',
+          position: 'right',
+          status: 'finish',
+          hidden: false,
+          created_at: Date.now(),
+          content: { content: 'sent mid-turn' },
+        },
+      ],
+      oldest_cursor: 'cursor-latest',
+      newest_cursor: 'cursor-latest',
+      has_more_before: false,
+      has_more_after: false,
+    });
+
+    act(() => {
+      emitTurnCompleted?.({ session_id: CONVERSATION_ID, turn_id: 'turn-1' });
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(
+      (result.current.messages.find((m) => m.msg_id === 'msg-midturn-5') as IMessageText | undefined)?.status
+    ).toBe('finish');
+    expect(result.current.pagination.oldestCursor).toBe('cursor-older');
+    expect(result.current.pagination.hasMoreBefore).toBe(true);
   });
 
   it('ignores turnCompleted for a different conversation even with a pending row', async () => {

--- a/tests/unit/renderer/useAutoScroll.dom.test.tsx
+++ b/tests/unit/renderer/useAutoScroll.dom.test.tsx
@@ -363,6 +363,41 @@ describe('useAutoScroll', () => {
     });
   });
 
+  it('does not force a bottom sync when older history is prepended ahead of an unread right-position message', () => {
+    const scroller = createScroller({ scrollTop: 80, scrollHeight: 1000, clientHeight: 400 });
+    const content = createContent();
+    const rightMessage = createRightMessage('question');
+    const { result, rerender } = renderHook(
+      ({ messages }) =>
+        useAutoScroll({
+          messages,
+          itemCount: messages.length,
+        }),
+      {
+        initialProps: {
+          messages: [rightMessage] as TMessage[],
+        },
+      }
+    );
+
+    attachElements(result, scroller, content);
+    act(() => {
+      vi.runAllTimers();
+    });
+    vi.mocked(scroller.scrollTo).mockClear();
+
+    act(() => {
+      rerender({
+        messages: [createLeftMessage('older context'), rightMessage],
+      });
+    });
+    act(() => {
+      vi.runAllTimers();
+    });
+
+    expect(scroller.scrollTo).not.toHaveBeenCalled();
+  });
+
   it('scrolls a target element into view for explicit message jumps', () => {
     const { result } = renderHook(() =>
       useAutoScroll({


### PR DESCRIPTION
## Description

While a conversation turn is running, older message history can silently become unreachable, and the pagination/auto-scroll state around history loading can get corrupted:

1. **Pagination never triggers when content doesn't overflow the viewport.** A running turn folds consecutive tool calls into a single summary card and drops hidden/plan rows, so a full DB page can render as just a few short cards — too short to produce a scrollbar. Since the older-page loader only runs on `onScroll`, it never fires even though more history exists. `MessageList.tsx` now proactively pulls older pages (capped at `MAX_VIEWPORT_FILL_PAGES`) after mount/prepend as long as content still fits without a scrollbar.
2. **Turn-completion reconciliation reset pagination progress.** After a user scrolls up and loads older pages (`oldestCursor`/`hasMoreBefore`), a pending turn completing would reload the newest page and reset pagination as if it were a fresh mount, discarding that progress. `loadMessages` now accepts a `preservePaginationBefore` option, used by the turn-completion reconciliation path.
3. **`useAutoScroll` misidentified prepended history as a new message.** It compared only `messages.length` to detect "a new message arrived," but a prepended older page also grows the list length. It now compares the tail message by `id` instead.

## Related Issues

- Closes #4232

## Type of Change

- [x] `fix` — Bug fix (non-breaking change which fixes an issue)

## Atomic PR Checklist (Rule 1)

- [x] This PR contains **exactly one** feature or bug fix that cannot be further decomposed
- [x] The PR title follows Conventional Commit format: `<type>(<scope>): <subject>` (English)

## Local Checks (Rule 3)

- [x] `bun run format` — formatting passes
- [x] `bun run lint` — no lint errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx tsc --noEmit` — no type errors (skip if no `.ts`/`.tsx` changed)
- [x] `bunx vitest run` — tests pass (520 files / 4984 tests passed)
- [ ] i18n validated — N/A, no user-facing text changed
- [x] New/changed user-facing text uses i18n keys (no hardcoded strings) — N/A, no user-facing text changed

## Runtime Verification

- [ ] Verified on macOS
- [ ] Verified on Windows
- [ ] Verified on Linux
- [x] I have performed a self-review of my own code

## Additional Context

Regression tests added in `tests/unit/renderer/messageList.dom.test.tsx`, `tests/unit/renderer/messageMerging.dom.test.tsx`, and `tests/unit/renderer/useAutoScroll.dom.test.tsx`.