### PR TITLE
chore: bump version to 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [2.2.2](https://github.com/iOfficeAI/AionUi/compare/v2.2.1...v2.2.2) (2026-09-09)
+
+### Desktop
+
+#### Features
+
+- **explorer:** tab-scoped refresh with repo re-discovery and Collapse All (#4202)
+
+### Core ([v0.2.2](https://github.com/iOfficeAI/AionCore/releases/tag/v0.2.2))
+
+#### Features
+
+- **conversation:** add aioncore conversation create for agent-driven conversation creation (#977)
+
+---
+
 ## [2.2.1](https://github.com/iOfficeAI/AionUi/compare/v2.1.61...v2.2.1) (2026-09-01)
 
 ### Desktop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "AionUi",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "description": "Transform your command-line AI agent into a modern, efficient AI Chat interface.",
   "keywords": [],
   "license": "Apache-2.0",
@@ -261,7 +261,7 @@
   "engines": {
     "node": ">=22 <25"
   },
-  "aioncoreVersion": "v0.2.1",
+  "aioncoreVersion": "v0.2.2",
   "electronRebuild": {
     "electronVersion": "^37.3.1"
   },


### PR DESCRIPTION
## [2.2.2](https://github.com/iOfficeAI/AionUi/compare/v2.2.1...v2.2.2) (2026-09-09)

### Desktop

#### Features

- **explorer:** tab-scoped refresh with repo re-discovery and Collapse All (#4202)

### Core ([v0.2.2](https://github.com/iOfficeAI/AionCore/releases/tag/v0.2.2))

#### Features

- **conversation:** add aioncore conversation create for agent-driven conversation creation (#977)
