### PR TITLE
fix(conversation): always send type and extra in create body (aioncore v0.1.72 compat)

### DIFF
--- a/packages/desktop/src/common/adapter/apiModelMapper.ts
+++ b/packages/desktop/src/common/adapter/apiModelMapper.ts
@@ -54,13 +54,14 @@ export type CreateConversationBodyInput = {
  * agent types carry model info via `extra`.
  */
 export function buildCreateConversationBody(p: CreateConversationBodyInput): Record<string, unknown> {
-  const hasAssistant = p.assistant !== undefined && p.assistant !== null;
+  // aioncore >= v0.1.72 rejects create bodies without top-level `type` and
+  // `extra` ("Invalid JSON request body"), so both must always be present.
   const body: Record<string, unknown> = {
-    type: hasAssistant ? undefined : p.type,
+    type: p.type,
     id: p.id,
     name: p.name,
     assistant: p.assistant,
-    extra: p.extra,
+    extra: p.extra ?? {},
   };
   const model = p.type === 'acp' ? undefined : toApiModelOptional(p.model);
   if (model) body.model = model;

--- a/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
+++ b/packages/desktop/src/renderer/pages/guid/hooks/useGuidSend.ts
@@ -177,6 +177,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
       }
       try {
         const conversation = await ipcBridge.conversation.create.invoke({
+          type: 'aionrs',
           name: input,
           model: current_model,
           assistant: {
@@ -232,6 +233,7 @@ export const useGuidSend = (deps: GuidSendDeps): GuidSendResult => {
 
     try {
       const conversation = await ipcBridge.conversation.create.invoke({
+        type: 'acp',
         name: input,
         assistant: {
           id: assistantConversationId,

--- a/tests/unit/common-adapter/apiModelMapper.test.ts
+++ b/tests/unit/common-adapter/apiModelMapper.test.ts
@@ -154,7 +154,7 @@ describe('apiModelMapper', () => {
       expect('model' in body).toBe(false);
     });
 
-    it('strips legacy type when assistant identity is present', () => {
+    it('passes type through when assistant identity is present', () => {
       const body = buildCreateConversationBody({
         type: 'acp',
         name: 'hello',
@@ -162,7 +162,7 @@ describe('apiModelMapper', () => {
         extra: {},
       });
 
-      expect(body.type).toBeUndefined();
+      expect(body.type).toBe('acp');
     });
 
     it('omits the top-level model for ACP creates that pass an empty placeholder', () => {

--- a/tests/unit/renderer/useGuidSend.dom.test.ts
+++ b/tests/unit/renderer/useGuidSend.dom.test.ts
@@ -94,7 +94,7 @@ describe('useGuidSend', () => {
 
     expect(createConversationInvokeMock).toHaveBeenCalledTimes(1);
     const payload = createConversationInvokeMock.mock.calls[0][0];
-    expect(payload.type).toBeUndefined();
+    expect(payload.type).toBe('acp');
     expect('model' in payload).toBe(false);
     expect(payload.assistant?.conversation_overrides?.permission).toBe('bypassPermissions');
     expect(payload.assistant?.conversation_overrides?.model).toBe('claude-opus');
@@ -200,7 +200,7 @@ describe('useGuidSend', () => {
     });
 
     const payload = createConversationInvokeMock.mock.calls[0][0];
-    expect(payload.type).toBeUndefined();
+    expect(payload.type).toBe('aionrs');
     expect(payload.model).toBe(deps.current_model);
     expect(payload.assistant?.id).toBe('bare:aionrs');
     expect(payload.assistant?.conversation_overrides?.skill_ids).toEqual(['pdf-reader']);
@@ -239,7 +239,7 @@ describe('useGuidSend', () => {
 
     const payload = createConversationInvokeMock.mock.calls[0][0];
     expect(payload.assistant?.id).toBe('bare:claude');
-    expect(payload.type).toBeUndefined();
+    expect(payload.type).toBe('acp');
     expect('model' in payload).toBe(false);
     expect(payload.extra.preset_assistant_id).toBeUndefined();
     expect(payload.extra.backend).toBeUndefined();


### PR DESCRIPTION
## Problem

On aioncore **v0.1.72**, every first submit from the home screen fails with `400 Invalid JSON request body` when a conversation is created with an assistant selected.

## Root cause

The backend now requires the top-level `type` and `extra` fields in `POST /api/conversations`. However:

- `buildCreateConversationBody()` sets `type: undefined` whenever an assistant is present (JSON.stringify then drops the key), and drops `extra` when it is not set
- the `useGuidSend` call sites never pass `type`

Resulting body `{"assistant":{...}}` (no `type`, no `extra`) → 400.

Verified against a live v0.1.72 backend:
- `{"assistant":{"id":X}}` → **400**
- `{"assistant":{"id":X},"type":"aionrs","extra":{}}` → **201**

## Fix

- always pass `type` through in the body builder and default `extra` to `{}`
- set the engine type (`'aionrs' | 'acp'`) at both `useGuidSend` call sites

Verified end-to-end after rebuild: first submit with an assistant creates the conversation successfully.